### PR TITLE
upapasta: TUI redesign — unified theme, compact top bar, char-safe truncation

### DIFF
--- a/crates/upapasta/ROADMAP.md
+++ b/crates/upapasta/ROADMAP.md
@@ -179,6 +179,39 @@ always "what still needs uploading?" and today they must eyeball every row.
 
 ---
 
+## Phase 40d — Upload-options workflow ✅ Done
+
+A review of "how does a user change an option?" exposed three problems, all now
+fixed in the upload-config panel (opened with `u` from Browser or Queue):
+
+- **The arrow keys lied.** The panel hinted `←→ cycle` on Obfuscate/Verify, but
+  only PAR2 responded; you had to press `Enter`. Now `←→` (and `Space`) advance
+  every cycle/number/toggle field, matching the hint. The whole field list is
+  driven by one `ConfirmField` enum, so the render and the key handlers can no
+  longer disagree on order or behaviour.
+- **The panel was too thin.** It only exposed 5 settings. It now covers
+  Compress (format + password), From, Category and Article size as well — all of
+  which `effective_config_with_overrides` already applied — plus a one-line
+  legend explaining what the current obfuscation mode actually hides. The new
+  persistent settings are restored across sessions like the others.
+- **Folder/season mode was impossible.** `pesto`'s `--season` (per-episode NZBs
+  **plus** a combined season NZB) had no equivalent in the TUI. A **Folder mode**
+  field now appears whenever a directory is queued, with three options:
+  - `single NZB` — the whole folder as one release (default, unchanged);
+  - `per-file` — one NZB per file inside;
+  - `season` — per-file NZBs **and** a combined season NZB, built in upapasta via
+    `pesto::nzb::generate` over the segments each file posted.
+  Each produced NZB is recorded in the catalog honestly (real size + path) via a
+  per-NZB `CatalogRecord`, so a folder in per-file/season mode yields several
+  truthful catalog rows instead of one. Folder mode is intentionally **per-batch**
+  (resets to `single` each session) so an old `season` choice can never silently
+  change how a folder uploads later.
+
+> Known follow-up: the combined season NZB is recorded and saved locally but not
+> yet pushed to the indexer (the per-episode NZBs are). Tracked for later.
+
+---
+
 ## Phase 41 — TUI Layout Redesign (Current Priority)
 
 ### 41a — Three-pane Browser with NZB Status Column
@@ -434,6 +467,7 @@ This phase is lower priority. Do not block earlier phases on it.
 | 40c-4     | "What should I upload?" filter (unbacked items)              | ✅ Done |
 | 40c-5     | Persist the queue; remove the fake pause                     | ✅ Done |
 | 40c-6     | Dedicated Queue tab; layout reconciled with reality          | ✅ Done |
+| 40d       | Upload-options workflow: ←→ fix, richer panel, folder/season mode | ✅ Done |
 | 41a       | Three-pane browser with NZB status column        | ✅ Done    |
 | 41b       | Upload config panel redesign                     | ✅ Done    |
 | 41c       | Full-height upload progress screen               | ✅ Done    |

--- a/crates/upapasta/ROADMAP.md
+++ b/crates/upapasta/ROADMAP.md
@@ -18,6 +18,167 @@
 
 ---
 
+## Phase 40c — Usability Reset (CRITICAL — blocks everything else)
+
+> **Why this exists.** The tool currently passes its own feature checklist but
+> still fails the one job a user actually wants: *"browse my files, pick the
+> ones I want to back up, queue several of them, and let pesto upload them one
+> after another — one NZB per release."* Real usage exposed gaps that no
+> "✅ Done" milestone caught. This phase is about making the happy path
+> trustworthy before adding more screens.
+
+### The user's mental model (what we must honor)
+
+1. I open the file manager and see my disk.
+2. I see at a glance **what still needs uploading** (no NZB yet).
+3. I mark several items — files *and* folders.
+4. I press one key. Pesto uploads them **in sequence**.
+5. Each item becomes **its own NZB**, named after the item. A folder/release
+   becomes **one** NZB, not one per inner file, and never all items merged.
+6. When it finishes, the catalog and the NZB vault reflect exactly what happened
+   — including partial failures.
+
+### 40c-1 — One coherent selection model ✅ Done
+
+> Implemented. The upload queue is now the single source of truth. `Space`
+> queues/unqueues the item under the cursor (file *or* folder) and advances;
+> `Enter` is navigation only and never mutates the queue; `u` opens the config
+> panel for whatever is queued. The Browser `[x]` badge is a render mirror of the
+> queue (`FileTree::set_queued`), so the file list and the queue panel can never
+> disagree. The old `toggle_mark`/`take_marked` second selection set was removed.
+
+
+
+**Problem:** there are two competing selection systems in the Browser.
+`Space` marks into a browser-local set; `Enter` *also* toggles the item
+directly into the queue; `u` then moves marked items into the queue. Three
+verbs, two states, one confused user. The keybinding map at the bottom of this
+document (Space = mark, Enter = enter dir / open detail) does **not** match the
+code.
+
+**Target:**
+- `Space` — the *only* way to mark/unmark an item (file or directory) for the
+  queue. Marking is the queue. No hidden second set.
+- `Enter` — navigation only: enter a directory, or open the detail/NZB panel for
+  a file. Never mutates the queue.
+- `u` — review marked items in the upload-config panel, then confirm.
+- Marked state must be visibly identical in the Browser and in the Queue view
+  (same items, same order, one source of truth).
+
+### 40c-2 — Folder = one release = one NZB ✅ Done
+
+> Implemented. Marking a directory queues it as a single entry; `pesto`'s
+> `expand_inputs` already walks it into one NZB named after the folder (folder
+> names keep their dots — they are not extensions). The queue panel, the upload
+> config panel, and the NZB-status detail now show, per entry, the resulting
+> `<name>.nzb` and, for folders, the bundled file count (`📁 Movie (2024) →
+> 1 NZB (3 files)`), so there is never a surprise before confirming. Counts are
+> cached per queue entry (`App::queue_meta`) to keep the render loop off the
+> filesystem.
+
+
+
+**Problem:** marking is file-by-file. A movie folder (`movie.mkv` + `sample` +
+`.nfo`) cannot be queued as a single release. And the old "merge everything into
+one NZB" bug (fixed in `28caebc`, one NZB per queue item) was the *opposite*
+overcorrection — neither extreme is what users want.
+
+**Target — explicit, predictable grouping:**
+- Marking a **file** ⇒ one NZB for that file.
+- Marking a **directory** ⇒ one NZB containing every file under it, named after
+  the directory. This is the normal Usenet "release" unit.
+- The upload-confirm panel must show, per queue entry: the resulting **NZB name**
+  and how many files it bundles, so there is never a surprise.
+- Never silently merge unrelated queue entries into a single NZB.
+
+### 40c-3 — Honest sequential queue + honest catalog ✅ Done
+
+> Implemented. Catalog records are now written **per item as it finishes**
+> (`ItemUploadDone` → `App::item_upload_done`) using the **real** byte size and
+> the **actual** NZB path from `pesto`'s `UploadOutcome` — the fabricated
+> `total / count` average is gone. A failure no longer erases the batch: each
+> success is already committed, failed items stay in the queue marked `✗` for
+> retry (press `u` again), and successful items leave the queue and gain the
+> uploaded `✓` badge. The queue and the progress screen show live per-item
+> state (`○ queued / ▶ uploading / ✓ done / ✗ failed`) from `App::queue_status`,
+> and the Browser NZB column refreshes as each item lands.
+
+
+
+**Problem:** uploads already run sequentially (good), but bookkeeping is done
+*once at the end* using a global success flag:
+- `upload_finished` records the catalog only `if success && !cancelled`, so if
+  item 2 of 3 fails, **none** of the three are recorded — even the ones that
+  uploaded fine.
+- Per-file size is faked: `size_each = total_bytes / item_count`. Every catalog
+  record gets the batch average, not its real size.
+
+**Target:**
+- Record each item in the catalog **as it finishes**, with its **real** byte
+  size and the **actual** NZB path that pesto wrote.
+- A failed item marks only itself as failed and leaves a visible retry affordance
+  in the queue; it does not erase the successes.
+- The queue view shows live per-item state: `queued / uploading / done / failed`,
+  matching the NZB-status column in the Browser.
+
+### 40c-4 — "What should I upload?" at a glance ✅ Done
+
+> Implemented. `n` toggles an **unbacked-only** filter in the Browser, hiding
+> everything already in the catalog so only what still needs uploading remains
+> (the border turns magenta and the title shows `• filter:unbacked`). A
+> directory counts as needing upload when it was not uploaded as a release and
+> any file under it is still uncatalogued (`dir_has_unbacked`, capped walk). The
+> Browser title carries a live summary — `N items · M unbacked · X GB to upload`
+> (or `all backed ✓`) — recomputed on navigation and whenever the catalog
+> changes, so per-item uploads update it immediately.
+
+
+
+**Problem:** the NZB-status column exists, but there is no way to *filter* the
+Browser down to "things I have not backed up yet." The user's first question is
+always "what still needs uploading?" and today they must eyeball every row.
+
+**Target:**
+- A toggle (e.g. `n`) to filter the Browser to items with **no NZB** (not in
+  catalog, no local NZB). Directories show as needing upload if any child does.
+- A summary line: `N items · M unbacked · X GB to upload`.
+
+### 40c-5 — Persist the queue; tell the truth about pause ✅ Done
+
+> Implemented.
+>
+> **Queue persistence:** the queue is saved to
+> `<config_dir>/upapasta-queue.json` on every mutation (queue/unqueue, remove,
+> clear, reorder, and the post-upload prune) and restored at startup
+> (`App::load_queue`). Paths that no longer exist on disk are dropped on load
+> (with a status note) and the pruned list is re-saved, so a carefully built
+> selection survives navigating away or restarting the app.
+>
+> **Pause removed (honestly):** `pesto`'s poster exposes only a cancel flag
+> (`AtomicBool`), no suspend mechanism, so a real mid-file pause is impossible
+> today. Rather than keep a button that lies, the `p` key, the `upload_paused`
+> state, the `PauseUpload`/`ResumeUpload` events, and all "PAUSED" UI were
+> removed. A true pause requires poster-level support and is tracked as a
+> follow-up (see Phase 46).
+
+### 40c-6 — Reconcile this roadmap with reality ✅ Done
+
+> **Decision:** the queue gets its **own dedicated tab**. Selection still happens
+> in the Browser (`Space`), but all queue *management* now lives in one place.
+>
+> **Real tab order (F1–F6):** `Dashboard · Queue · Browser · History ·
+> NZB Vault · Config`. `Tab`/`Shift+Tab` cycle the same order.
+>
+> The new **Queue screen (F2)** is full-height and shows, per entry, the live
+> status (`○ queued / ▶ uploading / ✓ done / ✗ failed`), the resulting NZB name,
+> the bundled file count for folders, and the size — with a total in the title.
+> Queue management keys (`u` upload, `d` remove, `c` clear, `J/K` reorder) moved
+> off the Dashboard to the Queue screen, so the queue is no longer built in one
+> place and managed in another. The Dashboard is now purely the live
+> upload-progress + log view. Edits are blocked while an upload is running.
+
+---
+
 ## Phase 41 — TUI Layout Redesign (Current Priority)
 
 ### 41a — Three-pane Browser with NZB Status Column
@@ -27,7 +188,7 @@ Replace the current two-tab (Browser + History) model with a unified
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  upapasta  v2.x  |  [F1 Browser]  [F2 Queue]  [F3 History]  [F4 …] │
+│  upapasta v2  | [F1 Dash] [F2 Queue] [F3 Browser] [F4 Hist] [F5 …] │
 ├──────────────────────┬────────────────┬────────────────────────────┤
 │  FILESYSTEM          │  NZB STATUS    │  DETAIL / LOG              │
 │  ~/Videos/           │                │                            │
@@ -200,12 +361,15 @@ This phase is lower priority. Do not block earlier phases on it.
 
 ---
 
-## Phase 46 — Multi-Server & Retry
+## Phase 46 — Multi-Server, Retry & Real Pause
 
 - Support posting to multiple servers simultaneously (primary + fill servers).
 - Retry failed articles automatically with exponential backoff.
 - Per-server connection health indicators in the Config screen.
 - Alert when a server connection is degraded during upload.
+- **Real pause/resume:** requires a suspend mechanism in `pesto`'s poster
+  (hold the connection pool without tearing it down). Removed from the TUI in
+  40c-5 until the engine supports it — do not re-add a UI-only pause.
 
 ---
 
@@ -237,19 +401,19 @@ This phase is lower priority. Do not block earlier phases on it.
 
 | Key         | Context          | Action                              |
 |-------------|------------------|-------------------------------------|
-| F1–F5       | Global           | Switch tabs                         |
+| F1–F6       | Global           | Jump to tab (Dash/Queue/Browser/Hist/Vault/Config) |
+| Tab / S-Tab | Global           | Cycle tabs                          |
 | j / k       | Lists            | Move cursor                         |
 | Enter       | File tree        | Enter directory / open detail       |
-| Space       | File tree        | Mark/unmark for queue               |
+| Space       | File tree        | Queue/unqueue item (file or folder) |
 | b / Bksp    | File tree        | Go to parent directory              |
 | h           | File tree        | Toggle hidden files                 |
-| u           | Browser          | Open upload config panel for marked |
-| U           | Browser          | Upload single file under cursor     |
+| n           | Browser          | Toggle unbacked-only filter         |
+| u           | Browser, Queue   | Open upload config panel for queue  |
 | d / Del     | Queue            | Remove item from queue              |
 | c           | Queue            | Clear queue                         |
 | Shift+J/K   | Queue            | Reorder items                       |
-| p           | Upload progress  | Pause / Resume                      |
-| Ctrl+X      | Upload progress  | Cancel upload                       |
+| x           | Queue, Dashboard | Cancel running upload               |
 | /           | Log, History     | Start search                        |
 | Esc         | Any              | Close modal / cancel search         |
 | P           | Browser, Vault   | Search Prowlarr for selected file   |
@@ -264,6 +428,12 @@ This phase is lower priority. Do not block earlier phases on it.
 | Milestone | Description                                      | Status    |
 |-----------|--------------------------------------------------|-----------|
 | 40b       | Core upload flow, progress bars, catalog, history| ✅ Done    |
+| 40c-1     | One coherent selection model (queue = single source of truth) | ✅ Done |
+| 40c-2     | Folder = one release = one NZB (with per-entry preview)        | ✅ Done |
+| 40c-3     | Honest sequential queue + honest catalog (per-item record, real size, retry) | ✅ Done |
+| 40c-4     | "What should I upload?" filter (unbacked items)              | ✅ Done |
+| 40c-5     | Persist the queue; remove the fake pause                     | ✅ Done |
+| 40c-6     | Dedicated Queue tab; layout reconciled with reality          | ✅ Done |
 | 41a       | Three-pane browser with NZB status column        | ✅ Done    |
 | 41b       | Upload config panel redesign                     | ✅ Done    |
 | 41c       | Full-height upload progress screen               | ✅ Done    |
@@ -274,4 +444,4 @@ This phase is lower priority. Do not block earlier phases on it.
 | 43d       | Automated Prowlarr backup workflow               | 🔲 Planned |
 | 44        | Catalog enhancements (tags, export, dedup)       | 🔲 Planned |
 | 45        | TMDb metadata enrichment                         | 🔲 Later   |
-| 46        | Multi-server posting + retry                     | 🔲 Later   |
+| 46        | Multi-server posting + retry + real pause        | 🔲 Later   |

--- a/crates/upapasta/src/app.rs
+++ b/crates/upapasta/src/app.rs
@@ -532,6 +532,65 @@ pub struct SessionOverrides {
     pub nzb_password: Option<String>,
     pub nzb_category: Option<String>,
     pub compress_password: Option<String>,
+    /// Compression archive format: `none`, `zip`, `7z` or `rar`.
+    pub compress_format: Option<String>,
+    /// How a queued directory becomes NZB(s). `None` = the default (`single`).
+    pub folder_mode: Option<FolderMode>,
+}
+
+/// How a queued directory is turned into NZB(s) at upload time.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum FolderMode {
+    /// One NZB for the whole folder (a single release). The default.
+    #[default]
+    Single,
+    /// One NZB per file inside the folder (no combined release NZB).
+    PerFile,
+    /// One NZB per file *and* a combined "season" NZB over all of them.
+    Season,
+}
+
+impl FolderMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            FolderMode::Single => "single NZB",
+            FolderMode::PerFile => "per-file",
+            FolderMode::Season => "season (per-file + combined)",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            FolderMode::Single => FolderMode::PerFile,
+            FolderMode::PerFile => FolderMode::Season,
+            FolderMode::Season => FolderMode::Single,
+        }
+    }
+}
+
+/// One editable setting in the upload-config panel. The order here is the order
+/// shown on screen and navigated with j/k; both the render and the key handlers
+/// derive from this single list, so there are no fragile parallel indices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmField {
+    Obfuscate,
+    Par2,
+    FolderMode,
+    Compress,
+    CompressPassword,
+    Verify,
+    NzbPassword,
+    Groups,
+    From,
+    Category,
+    ArticleSize,
+}
+
+/// A rendered snapshot of one field for the panel.
+pub struct ConfirmFieldView {
+    pub label: &'static str,
+    pub value: String,
+    pub hint: &'static str,
 }
 
 /// State for the Config screen.
@@ -951,6 +1010,7 @@ impl App {
         size_bytes: u64,
         nzb_path: Option<PathBuf>,
         duration_s: f64,
+        record_catalog: bool,
     ) {
         let status = if success {
             FileStatus::Done
@@ -967,16 +1027,27 @@ impl App {
             }
         }
 
-        if !success {
-            return;
-        }
-
-        if let Some(ref cat) = self.catalog {
+        // Per-file / season folder modes record each produced NZB separately via
+        // `CatalogRecord`, so the item-level event must not double-record.
+        if success && record_catalog {
             let original_name = std::path::Path::new(path)
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or(path)
                 .to_string();
+            self.record_catalog_entry(original_name, size_bytes, nzb_path, duration_s);
+        }
+    }
+
+    /// Record one produced NZB in the catalog and refresh the Browser status.
+    pub fn record_catalog_entry(
+        &mut self,
+        original_name: String,
+        size_bytes: u64,
+        nzb_path: Option<PathBuf>,
+        duration_s: f64,
+    ) {
+        if let Some(ref cat) = self.catalog {
             let group = self
                 .pesto_config
                 .as_ref()
@@ -1516,67 +1587,137 @@ impl App {
         if let Some(ref pw) = ov.compress_password {
             cfg.compress_password = Some(pw.clone());
         }
+        if let Some(ref fmt) = ov.compress_format {
+            cfg.compress_format = if fmt == "none" {
+                None
+            } else {
+                Some(fmt.clone())
+            };
+        }
         Some(cfg)
+    }
+
+    /// The effective folder mode for this batch (override or the default).
+    pub fn effective_folder_mode(&self) -> FolderMode {
+        self.config_state.overrides.folder_mode.unwrap_or_default()
     }
 
     // ── Upload config panel field editing ─────────────────────────────────────
 
-    /// Number of editable fields in the upload config panel.
-    /// 0=Obfuscate  1=PAR2%  2=Verify  3=Password  4=Groups
-    pub const CONFIRM_FIELDS: usize = 5;
+    /// The fields shown in the panel, in order. `Folder mode` only appears when
+    /// a directory is queued (it is a no-op for plain files).
+    pub fn confirm_order(&self) -> Vec<ConfirmField> {
+        use ConfirmField::*;
+        let has_dir = self
+            .upload_queue
+            .items
+            .iter()
+            .any(|p| self.queue_info(p).is_dir);
+        let mut v = vec![Obfuscate, Par2];
+        if has_dir {
+            v.push(FolderMode);
+        }
+        v.extend([
+            Compress,
+            CompressPassword,
+            Verify,
+            NzbPassword,
+            Groups,
+            From,
+            Category,
+            ArticleSize,
+        ]);
+        v
+    }
+
+    /// The field currently under the cursor.
+    fn current_confirm_field(&self) -> Option<ConfirmField> {
+        self.confirm_order().get(self.confirm_field).copied()
+    }
 
     pub fn confirm_field_next(&mut self) {
-        self.confirm_field = (self.confirm_field + 1) % Self::CONFIRM_FIELDS;
+        let len = self.confirm_order().len().max(1);
+        self.confirm_field = (self.confirm_field + 1) % len;
     }
 
     pub fn confirm_field_prev(&mut self) {
+        let len = self.confirm_order().len().max(1);
         self.confirm_field = if self.confirm_field == 0 {
-            Self::CONFIRM_FIELDS - 1
+            len - 1
         } else {
             self.confirm_field - 1
         };
     }
 
-    /// Cycle / toggle enum and bool fields. For text fields (3, 4), enter edit mode.
+    fn obf_effective(&self) -> ObfuscateMode {
+        self.config_state.overrides.obfuscate.unwrap_or(
+            self.pesto_config
+                .as_ref()
+                .map(|c| c.obfuscate)
+                .unwrap_or(ObfuscateMode::None),
+        )
+    }
+
+    fn par2_effective(&self) -> u8 {
+        self.config_state
+            .overrides
+            .par2
+            .unwrap_or(self.pesto_config.as_ref().map(|c| c.par2).unwrap_or(10))
+    }
+
+    fn compress_effective(&self) -> String {
+        self.config_state
+            .overrides
+            .compress_format
+            .clone()
+            .or_else(|| {
+                self.pesto_config
+                    .as_ref()
+                    .and_then(|c| c.compress_format.clone())
+            })
+            .unwrap_or_else(|| "none".to_string())
+    }
+
+    /// Cycle / toggle enum and bool fields; for text/number fields, enter edit mode.
     pub fn confirm_field_activate(&mut self) {
-        match self.confirm_field {
-            0 => {
-                // Obfuscate: cycle None → Subject → Full → None
-                let current = self.config_state.overrides.obfuscate.unwrap_or(
+        let Some(field) = self.current_confirm_field() else {
+            return;
+        };
+        match field {
+            ConfirmField::Obfuscate => self.confirm_cycle_obfuscate(true),
+            ConfirmField::FolderMode => {
+                let cur = self.effective_folder_mode();
+                self.config_state.overrides.folder_mode = Some(cur.next());
+            }
+            ConfirmField::Compress => self.confirm_cycle_compress(true),
+            ConfirmField::Verify => self.confirm_toggle_verify(),
+            // Number / text fields → enter edit mode prefilled with the current value.
+            ConfirmField::Par2 => self.confirm_start_edit(self.par2_effective().to_string()),
+            ConfirmField::ArticleSize => {
+                let kb = self.config_state.overrides.article_size_kb.unwrap_or(
                     self.pesto_config
                         .as_ref()
-                        .map(|c| c.obfuscate)
-                        .unwrap_or(ObfuscateMode::None),
+                        .map(|c| c.article_size / 1024)
+                        .unwrap_or(768),
                 );
-                self.config_state.overrides.obfuscate = Some(match current {
-                    ObfuscateMode::None => ObfuscateMode::Subject,
-                    ObfuscateMode::Subject => ObfuscateMode::Full,
-                    ObfuscateMode::Full => ObfuscateMode::None,
-                });
+                self.confirm_start_edit(kb.to_string());
             }
-            1 => {
-                // PAR2 %: enter text-edit mode
-                let current = self
+            ConfirmField::CompressPassword => {
+                let cur = self
                     .config_state
                     .overrides
-                    .par2
-                    .unwrap_or(self.pesto_config.as_ref().map(|c| c.par2).unwrap_or(10));
-                self.confirm_edit_buf = current.to_string();
-                self.confirm_editing = true;
+                    .compress_password
+                    .clone()
+                    .or_else(|| {
+                        self.pesto_config
+                            .as_ref()
+                            .and_then(|c| c.compress_password.clone())
+                    })
+                    .unwrap_or_default();
+                self.confirm_start_edit(cur);
             }
-            2 => {
-                // Verify: toggle
-                let current = self.config_state.overrides.verify.unwrap_or(
-                    self.pesto_config
-                        .as_ref()
-                        .map(|c| c.verify)
-                        .unwrap_or(false),
-                );
-                self.config_state.overrides.verify = Some(!current);
-            }
-            3 => {
-                // NZB Password: enter text-edit mode
-                let current = self
+            ConfirmField::NzbPassword => {
+                let cur = self
                     .config_state
                     .overrides
                     .nzb_password
@@ -1587,69 +1728,257 @@ impl App {
                             .and_then(|c| c.nzb_password.clone())
                     })
                     .unwrap_or_default();
-                self.confirm_edit_buf = current;
-                self.confirm_editing = true;
+                self.confirm_start_edit(cur);
             }
-            4 => {
-                // Groups: enter text-edit mode
-                let current = self
+            ConfirmField::Groups => {
+                let cur = self
                     .config_state
                     .overrides
                     .groups
                     .clone()
                     .or_else(|| self.pesto_config.as_ref().map(|c| c.groups.join(", ")))
                     .unwrap_or_default();
-                self.confirm_edit_buf = current;
-                self.confirm_editing = true;
+                self.confirm_start_edit(cur);
+            }
+            ConfirmField::From => {
+                let cur = self
+                    .config_state
+                    .overrides
+                    .from
+                    .clone()
+                    .or_else(|| self.pesto_config.as_ref().map(|c| c.from.clone()))
+                    .unwrap_or_default();
+                self.confirm_start_edit(cur);
+            }
+            ConfirmField::Category => {
+                let cur = self
+                    .config_state
+                    .overrides
+                    .nzb_category
+                    .clone()
+                    .or_else(|| {
+                        self.pesto_config
+                            .as_ref()
+                            .and_then(|c| c.nzb_category.clone())
+                    })
+                    .unwrap_or_default();
+                self.confirm_start_edit(cur);
+            }
+        }
+    }
+
+    fn confirm_start_edit(&mut self, prefill: String) {
+        self.confirm_edit_buf = prefill;
+        self.confirm_editing = true;
+    }
+
+    fn confirm_cycle_obfuscate(&mut self, _forward: bool) {
+        let next = match self.obf_effective() {
+            ObfuscateMode::None => ObfuscateMode::Subject,
+            ObfuscateMode::Subject => ObfuscateMode::Full,
+            ObfuscateMode::Full => ObfuscateMode::None,
+        };
+        self.config_state.overrides.obfuscate = Some(next);
+    }
+
+    fn confirm_cycle_compress(&mut self, _forward: bool) {
+        let next = match self.compress_effective().as_str() {
+            "none" => "zip",
+            "zip" => "7z",
+            "7z" => "rar",
+            _ => "none",
+        };
+        self.config_state.overrides.compress_format = Some(next.to_string());
+    }
+
+    fn confirm_toggle_verify(&mut self) {
+        let cur = self.config_state.overrides.verify.unwrap_or(
+            self.pesto_config
+                .as_ref()
+                .map(|c| c.verify)
+                .unwrap_or(false),
+        );
+        self.config_state.overrides.verify = Some(!cur);
+    }
+
+    /// `→` / `l` / Space: advance cycle/number/toggle fields in place.
+    pub fn confirm_field_increment(&mut self) {
+        match self.current_confirm_field() {
+            Some(ConfirmField::Obfuscate) => self.confirm_cycle_obfuscate(true),
+            Some(ConfirmField::Compress) => self.confirm_cycle_compress(true),
+            Some(ConfirmField::Verify) => self.confirm_toggle_verify(),
+            Some(ConfirmField::FolderMode) => {
+                let cur = self.effective_folder_mode();
+                self.config_state.overrides.folder_mode = Some(cur.next());
+            }
+            Some(ConfirmField::Par2) => {
+                let cur = self.par2_effective();
+                self.config_state.overrides.par2 = Some(if cur >= 50 { 0 } else { cur + 5 });
             }
             _ => {}
         }
     }
 
-    pub fn confirm_field_increment(&mut self) {
-        if self.confirm_field == 1 {
-            let current = self
-                .config_state
-                .overrides
-                .par2
-                .unwrap_or(self.pesto_config.as_ref().map(|c| c.par2).unwrap_or(10));
-            self.config_state.overrides.par2 = Some(if current >= 50 { 0 } else { current + 5 });
-        }
-    }
-
+    /// `←` / `h`: step cycle/number/toggle fields backwards.
     pub fn confirm_field_decrement(&mut self) {
-        if self.confirm_field == 1 {
-            let current = self
-                .config_state
-                .overrides
-                .par2
-                .unwrap_or(self.pesto_config.as_ref().map(|c| c.par2).unwrap_or(10));
-            self.config_state.overrides.par2 = Some(if current == 0 {
-                50
-            } else {
-                current.saturating_sub(5)
-            });
+        match self.current_confirm_field() {
+            // Cycles are short; stepping backwards is the same as cycling forward.
+            Some(ConfirmField::Obfuscate) => self.confirm_cycle_obfuscate(false),
+            Some(ConfirmField::Compress) => self.confirm_cycle_compress(false),
+            Some(ConfirmField::Verify) => self.confirm_toggle_verify(),
+            Some(ConfirmField::FolderMode) => {
+                let cur = self.effective_folder_mode();
+                self.config_state.overrides.folder_mode = Some(cur.next());
+            }
+            Some(ConfirmField::Par2) => {
+                let cur = self.par2_effective();
+                self.config_state.overrides.par2 =
+                    Some(if cur == 0 { 50 } else { cur.saturating_sub(5) });
+            }
+            _ => {}
         }
     }
 
     /// Commit the text edit buffer into the relevant session override.
     pub fn confirm_confirm_edit(&mut self) {
         let buf = self.confirm_edit_buf.trim().to_string();
-        match self.confirm_field {
-            1 => {
+        let set_opt = |b: String| if b.is_empty() { None } else { Some(b) };
+        match self.current_confirm_field() {
+            Some(ConfirmField::Par2) => {
                 self.config_state.overrides.par2 = buf.parse::<u8>().ok().map(|v| v.min(50));
             }
-            3 => {
-                self.config_state.overrides.nzb_password =
-                    if buf.is_empty() { None } else { Some(buf) };
+            Some(ConfirmField::ArticleSize) => {
+                self.config_state.overrides.article_size_kb =
+                    buf.parse::<usize>().ok().filter(|kb| *kb > 0);
             }
-            4 => {
-                self.config_state.overrides.groups = if buf.is_empty() { None } else { Some(buf) };
+            Some(ConfirmField::CompressPassword) => {
+                self.config_state.overrides.compress_password = set_opt(buf);
+            }
+            Some(ConfirmField::NzbPassword) => {
+                self.config_state.overrides.nzb_password = set_opt(buf);
+            }
+            Some(ConfirmField::Groups) => {
+                self.config_state.overrides.groups = set_opt(buf);
+            }
+            Some(ConfirmField::From) => {
+                self.config_state.overrides.from = set_opt(buf);
+            }
+            Some(ConfirmField::Category) => {
+                self.config_state.overrides.nzb_category = set_opt(buf);
             }
             _ => {}
         }
         self.confirm_editing = false;
         self.confirm_edit_buf.clear();
+    }
+
+    /// Rendered snapshot of all panel fields, in display order.
+    pub fn confirm_field_views(&self) -> Vec<ConfirmFieldView> {
+        let ov = &self.config_state.overrides;
+        let cfg = self.pesto_config.as_ref();
+        let mask = |raw: &str| -> String {
+            if raw.is_empty() {
+                "—".to_string()
+            } else if self.confirm_show_password {
+                raw.to_string()
+            } else {
+                "•".repeat(raw.len().min(20))
+            }
+        };
+        self.confirm_order()
+            .into_iter()
+            .map(|field| {
+                let (label, value, hint): (&'static str, String, &'static str) = match field {
+                    ConfirmField::Obfuscate => (
+                        "Obfuscate",
+                        match self.obf_effective() {
+                            ObfuscateMode::None => "none",
+                            ObfuscateMode::Subject => "subject",
+                            ObfuscateMode::Full => "full",
+                        }
+                        .to_string(),
+                        "←→ cycle",
+                    ),
+                    ConfirmField::Par2 => (
+                        "PAR2 %",
+                        format!("{}%", self.par2_effective()),
+                        "←→ or Enter",
+                    ),
+                    ConfirmField::FolderMode => (
+                        "Folder",
+                        self.effective_folder_mode().label().to_string(),
+                        "←→ cycle",
+                    ),
+                    ConfirmField::Compress => ("Compress", self.compress_effective(), "←→ cycle"),
+                    ConfirmField::CompressPassword => {
+                        let raw = ov
+                            .compress_password
+                            .clone()
+                            .or_else(|| cfg.and_then(|c| c.compress_password.clone()))
+                            .unwrap_or_default();
+                        ("Zip pass", mask(&raw), "Enter edit  Tab show")
+                    }
+                    ConfirmField::Verify => (
+                        "Verify",
+                        if ov.verify.unwrap_or(cfg.map(|c| c.verify).unwrap_or(false)) {
+                            "on"
+                        } else {
+                            "off"
+                        }
+                        .to_string(),
+                        "←→ toggle",
+                    ),
+                    ConfirmField::NzbPassword => {
+                        let raw = ov
+                            .nzb_password
+                            .clone()
+                            .or_else(|| cfg.and_then(|c| c.nzb_password.clone()))
+                            .unwrap_or_default();
+                        ("NZB pass", mask(&raw), "Enter edit  Tab show")
+                    }
+                    ConfirmField::Groups => (
+                        "Groups",
+                        ov.groups
+                            .clone()
+                            .or_else(|| cfg.map(|c| c.groups.join(", ")))
+                            .unwrap_or_else(|| "—".to_string()),
+                        "Enter edit",
+                    ),
+                    ConfirmField::From => (
+                        "From",
+                        ov.from
+                            .clone()
+                            .or_else(|| cfg.map(|c| c.from.clone()))
+                            .unwrap_or_else(|| "—".to_string()),
+                        "Enter edit",
+                    ),
+                    ConfirmField::Category => (
+                        "Category",
+                        ov.nzb_category
+                            .clone()
+                            .or_else(|| cfg.and_then(|c| c.nzb_category.clone()))
+                            .unwrap_or_else(|| "—".to_string()),
+                        "Enter edit",
+                    ),
+                    ConfirmField::ArticleSize => {
+                        let kb = ov
+                            .article_size_kb
+                            .unwrap_or(cfg.map(|c| c.article_size / 1024).unwrap_or(768));
+                        ("Article", format!("{kb} KB"), "Enter edit")
+                    }
+                };
+                ConfirmFieldView { label, value, hint }
+            })
+            .collect()
+    }
+
+    /// One-line explanation of the current obfuscation mode, for the panel.
+    pub fn obfuscate_legend(&self) -> &'static str {
+        match self.obf_effective() {
+            ObfuscateMode::None => "none: public subject + real filenames",
+            ObfuscateMode::Subject => "subject: random subject, real poster + filenames",
+            ObfuscateMode::Full => "full: random subject + poster + filenames",
+        }
     }
 
     pub fn confirm_cancel_edit(&mut self) {
@@ -1759,6 +2088,21 @@ impl App {
             if o.compress_password.is_none() {
                 o.compress_password = prefs.compress_password;
             }
+            if o.compress_format.is_none() {
+                o.compress_format = prefs.compress_format;
+            }
+            if o.from.is_none() {
+                o.from = prefs.from;
+            }
+            if o.nzb_category.is_none() {
+                o.nzb_category = prefs.nzb_category;
+            }
+            if o.article_size_kb.is_none() {
+                o.article_size_kb = prefs.article_size_kb;
+            }
+            // folder_mode is intentionally NOT restored: it is a per-batch choice
+            // (defaults to a single release NZB each session) so an old "season"
+            // selection can never silently change how a folder uploads later.
         }
     }
 }

--- a/crates/upapasta/src/app.rs
+++ b/crates/upapasta/src/app.rs
@@ -92,6 +92,46 @@ pub struct UploadSettingsSummary {
     pub verify: String,
 }
 
+// ── Canonical display vocabulary ──────────────────────────────────────────────
+//
+// One source of truth for how settings are *shown*, so the Dashboard summary,
+// the upload-config panel and the Config overrides all read the same. These map
+// internal values to display labels only — the stored values (enums, bools and
+// the compress-format token used by the cycle handlers) are untouched.
+
+/// Display label for an obfuscation mode: `None` / `Subject` / `Full`.
+pub fn obf_label(mode: ObfuscateMode) -> &'static str {
+    match mode {
+        ObfuscateMode::None => "None",
+        ObfuscateMode::Subject => "Subject",
+        ObfuscateMode::Full => "Full",
+    }
+}
+
+/// Display label for an on/off setting.
+pub fn on_off(enabled: bool) -> &'static str {
+    if enabled {
+        "On"
+    } else {
+        "Off"
+    }
+}
+
+/// Display label for a compression-format token (`none`/`zip`/`7z`/`rar`).
+/// The token stays the logic value used by the cycle handlers; this only
+/// controls how it is rendered (`none` → `Off`).
+pub fn compress_label(token: &str) -> String {
+    match token {
+        "none" | "" => "Off".to_string(),
+        "zip" => "Zip".to_string(),
+        "rar" => "Rar".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// The marker shown for an unset / empty value, used everywhere.
+pub const UNSET: &str = "—";
+
 impl UploadProgress {
     const MAX_HISTORY: usize = 60; // ~1 minute at 1 sample/sec
 
@@ -1213,27 +1253,20 @@ impl App {
             None
         };
         if let Some(cfg) = cfg_ref {
-            let obfuscate = match cfg.obfuscate {
-                ObfuscateMode::None => "None (real filenames)",
-                ObfuscateMode::Subject => "Subject only",
-                ObfuscateMode::Full => "Full (subject + yEnc name)",
-            }
-            .to_string();
+            let obfuscate = obf_label(cfg.obfuscate).to_string();
 
-            let compression = if let Some(fmt) = &cfg.compress_format {
-                if cfg.compress_password.is_some() {
-                    format!("{} + password", fmt)
-                } else {
-                    fmt.clone()
+            let compression = match &cfg.compress_format {
+                Some(fmt) if cfg.compress_password.is_some() => {
+                    format!("{} + password", compress_label(fmt))
                 }
-            } else {
-                "Disabled".to_string()
+                Some(fmt) => compress_label(fmt),
+                None => "Off".to_string(),
             };
 
             let par2 = format!("{}%", cfg.par2);
 
             let groups = if cfg.groups.is_empty() {
-                "Not set".to_string()
+                UNSET.to_string()
             } else {
                 cfg.groups.join(", ")
             };
@@ -1246,12 +1279,7 @@ impl App {
 
             let article = format!("{} KB / {} chars", cfg.article_size / 1024, cfg.line_length);
 
-            let verify = if cfg.verify {
-                "Enabled (STAT)"
-            } else {
-                "Disabled"
-            }
-            .to_string();
+            let verify = on_off(cfg.verify).to_string();
 
             UploadSettingsSummary {
                 obfuscate,
@@ -1266,12 +1294,12 @@ impl App {
             // Dry-run defaults (what we currently use in build_dry_run_config)
             UploadSettingsSummary {
                 obfuscate: "None (dry-run)".to_string(),
-                compression: "Disabled (dry-run)".to_string(),
+                compression: "Off (dry-run)".to_string(),
                 par2: "5% (dry-run)".to_string(),
                 groups: "alt.binaries.test (dry-run)".to_string(),
                 from: "upapasta@local (dry-run)".to_string(),
                 article_size: "750 KB / 128 chars (dry-run)".to_string(),
-                verify: "Disabled (dry-run)".to_string(),
+                verify: "Off (dry-run)".to_string(),
             }
         }
     }
@@ -1878,7 +1906,7 @@ impl App {
         let cfg = self.pesto_config.as_ref();
         let mask = |raw: &str| -> String {
             if raw.is_empty() {
-                "—".to_string()
+                UNSET.to_string()
             } else if self.confirm_show_password {
                 raw.to_string()
             } else {
@@ -1891,12 +1919,7 @@ impl App {
                 let (label, value, hint): (&'static str, String, &'static str) = match field {
                     ConfirmField::Obfuscate => (
                         "Obfuscate",
-                        match self.obf_effective() {
-                            ObfuscateMode::None => "none",
-                            ObfuscateMode::Subject => "subject",
-                            ObfuscateMode::Full => "full",
-                        }
-                        .to_string(),
+                        obf_label(self.obf_effective()).to_string(),
                         "←→ cycle",
                     ),
                     ConfirmField::Par2 => (
@@ -1909,7 +1932,11 @@ impl App {
                         self.effective_folder_mode().label().to_string(),
                         "←→ cycle",
                     ),
-                    ConfirmField::Compress => ("Compress", self.compress_effective(), "←→ cycle"),
+                    ConfirmField::Compress => (
+                        "Compress",
+                        compress_label(&self.compress_effective()),
+                        "←→ cycle",
+                    ),
                     ConfirmField::CompressPassword => {
                         let raw = ov
                             .compress_password
@@ -1920,12 +1947,8 @@ impl App {
                     }
                     ConfirmField::Verify => (
                         "Verify",
-                        if ov.verify.unwrap_or(cfg.map(|c| c.verify).unwrap_or(false)) {
-                            "on"
-                        } else {
-                            "off"
-                        }
-                        .to_string(),
+                        on_off(ov.verify.unwrap_or(cfg.map(|c| c.verify).unwrap_or(false)))
+                            .to_string(),
                         "←→ toggle",
                     ),
                     ConfirmField::NzbPassword => {
@@ -1941,7 +1964,7 @@ impl App {
                         ov.groups
                             .clone()
                             .or_else(|| cfg.map(|c| c.groups.join(", ")))
-                            .unwrap_or_else(|| "—".to_string()),
+                            .unwrap_or_else(|| UNSET.to_string()),
                         "Enter edit",
                     ),
                     ConfirmField::From => (
@@ -1949,7 +1972,7 @@ impl App {
                         ov.from
                             .clone()
                             .or_else(|| cfg.map(|c| c.from.clone()))
-                            .unwrap_or_else(|| "—".to_string()),
+                            .unwrap_or_else(|| UNSET.to_string()),
                         "Enter edit",
                     ),
                     ConfirmField::Category => (
@@ -1957,7 +1980,7 @@ impl App {
                         ov.nzb_category
                             .clone()
                             .or_else(|| cfg.and_then(|c| c.nzb_category.clone()))
-                            .unwrap_or_else(|| "—".to_string()),
+                            .unwrap_or_else(|| UNSET.to_string()),
                         "Enter edit",
                     ),
                     ConfirmField::ArticleSize => {
@@ -1975,9 +1998,9 @@ impl App {
     /// One-line explanation of the current obfuscation mode, for the panel.
     pub fn obfuscate_legend(&self) -> &'static str {
         match self.obf_effective() {
-            ObfuscateMode::None => "none: public subject + real filenames",
-            ObfuscateMode::Subject => "subject: random subject, real poster + filenames",
-            ObfuscateMode::Full => "full: random subject + poster + filenames",
+            ObfuscateMode::None => "None: public subject + real filenames",
+            ObfuscateMode::Subject => "Subject: random subject, real poster + filenames",
+            ObfuscateMode::Full => "Full: random subject + poster + filenames",
         }
     }
 

--- a/crates/upapasta/src/app.rs
+++ b/crates/upapasta/src/app.rs
@@ -14,6 +14,9 @@ use tokio_util::sync::CancellationToken;
 pub enum AppState {
     #[default]
     Dashboard,
+    /// Dedicated upload-queue screen: review, reorder, remove and launch the
+    /// queue built in the Browser. The single home for queue management.
+    Queue,
     Browser,
     History,
     NzbVault,
@@ -187,16 +190,110 @@ impl UploadProgress {
     }
 }
 
+/// Describes how a queued path will become an NZB. A directory bundles every
+/// file under it into a single NZB named after the folder (the standard Usenet
+/// "release" unit); a plain file becomes one NZB named after the file. This is
+/// what makes the queue predictable: one entry → one NZB, never one-per-inner
+/// file and never several entries merged together.
+#[derive(Debug, Clone)]
+pub struct QueueEntryInfo {
+    /// Display name of the resulting NZB (without the `.nzb` suffix).
+    pub nzb_name: String,
+    /// Whether the queued path is a directory (a release bundle).
+    pub is_dir: bool,
+    /// Number of files the NZB will contain (1 for a plain file).
+    pub file_count: usize,
+    /// Total bytes the entry will upload (file length, or the sum under a dir).
+    pub size_bytes: u64,
+}
+
+/// Compute the NZB grouping info for a queued path. For a directory this walks
+/// the tree once to count files and sum their sizes so the user can see, before
+/// confirming, that a folder becomes a single NZB.
+pub fn queue_entry_info(path: &str) -> QueueEntryInfo {
+    let p = std::path::Path::new(path);
+    let base = p
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(path)
+        .to_string();
+    if p.is_dir() {
+        let (file_count, size_bytes) = dir_stats(p);
+        QueueEntryInfo {
+            // A folder name is kept verbatim: dots in a release name are not a
+            // file extension and must not be stripped.
+            nzb_name: base,
+            is_dir: true,
+            file_count,
+            size_bytes,
+        }
+    } else {
+        // Strip a single extension for a plain file's NZB stem (movie.mkv → movie).
+        let stem = p
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| base.clone());
+        QueueEntryInfo {
+            nzb_name: stem,
+            is_dir: false,
+            file_count: 1,
+            size_bytes: std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
+        }
+    }
+}
+
+/// Recursively count regular files under `dir` and sum their sizes, stopping at
+/// a sane cap so a pathological tree cannot stall the UI. Symlinks are skipped
+/// to match `pesto::walk` (which does the same during the real upload).
+fn dir_stats(dir: &std::path::Path) -> (usize, u64) {
+    const CAP: usize = 100_000;
+    let mut stack = vec![dir.to_path_buf()];
+    let mut count = 0usize;
+    let mut bytes = 0u64;
+    while let Some(d) = stack.pop() {
+        let rd = match std::fs::read_dir(&d) {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+        for entry in rd.flatten() {
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if ft.is_symlink() {
+                continue;
+            } else if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                count += 1;
+                bytes += entry.metadata().map(|m| m.len()).unwrap_or(0);
+                if count >= CAP {
+                    return (count, bytes);
+                }
+            }
+        }
+    }
+    (count, bytes)
+}
+
 pub struct App {
     pub state: AppState,
     pub file_tree: FileTree,
     pub upload_queue: UploadQueue,
+    /// Cached NZB grouping info per queued path, keyed by the absolute path
+    /// string stored in `upload_queue.items`. Kept in sync on every queue
+    /// mutation so the UI never re-walks directories on the render hot path.
+    pub queue_meta: std::collections::HashMap<String, QueueEntryInfo>,
+    /// Live per-item upload state, keyed by the queue path. Drives the ✓/✗/▶
+    /// icons in the queue view and survives a partial batch so a failed item
+    /// can be retried without losing the record of the ones that succeeded.
+    pub queue_status: std::collections::HashMap<String, FileStatus>,
     /// Incremented on every Tick event — drives spinner animations in the UI.
     pub tick_count: u64,
     pub log_panel: LogPanel,
     pub status_bar: StatusBar,
     pub upload_in_progress: bool,
-    pub upload_paused: bool,
     pub progress: UploadProgress,
     pub current_cancel_token: Option<CancellationToken>,
 
@@ -486,11 +583,12 @@ impl App {
             state: AppState::Browser,
             file_tree: FileTree::new(),
             upload_queue: UploadQueue::new(),
+            queue_meta: std::collections::HashMap::new(),
+            queue_status: std::collections::HashMap::new(),
             tick_count: 0,
             log_panel: LogPanel::new(80),
             status_bar: StatusBar::new(status_msg),
             upload_in_progress: false,
-            upload_paused: false,
             progress: UploadProgress::default(),
             current_cancel_token: None,
             pesto_config,
@@ -543,15 +641,88 @@ impl App {
         app
     }
 
-    pub fn add_to_queue(&mut self, path: String) {
-        self.upload_queue.add(path.clone());
-        self.status_bar.set("Added to upload queue");
-        self.log_panel.push(format!("Queued: {}", path));
+    /// Toggle the item under the Browser cursor in the upload queue, then
+    /// advance the cursor. This is the single selection action (`Space`): the
+    /// queue is the one source of truth, so the Browser `[x]` badge and the
+    /// queue panel always agree. Files and directories are both allowed; a
+    /// directory is queued as one release → one NZB.
+    pub fn toggle_queue_at_cursor(&mut self) {
+        let path = match self.file_tree.get_selected().cloned() {
+            Some(p) => p,
+            None => return,
+        };
+        let key = path.to_string_lossy().to_string();
+        let now_queued = self.upload_queue.toggle(key.clone());
+        if now_queued {
+            let info = queue_entry_info(&key);
+            if info.is_dir {
+                self.status_bar.set(format!(
+                    "Queued folder “{}” → 1 NZB ({} files) — {} in queue",
+                    info.nzb_name,
+                    info.file_count,
+                    self.upload_queue.items.len()
+                ));
+            } else {
+                self.status_bar.set(format!(
+                    "Queued “{}” — {} in queue",
+                    info.nzb_name,
+                    self.upload_queue.items.len()
+                ));
+            }
+            self.queue_meta.insert(key, info);
+        } else {
+            self.queue_meta.remove(&key);
+            self.status_bar.set(format!(
+                "Unqueued — {} item(s) in queue",
+                self.upload_queue.items.len()
+            ));
+        }
+        self.sync_queue_badges();
+        self.save_queue();
+        self.file_tree.select_next();
+    }
+
+    /// Rebuild the Browser badge mirror from the queue. Must be called after any
+    /// mutation of `upload_queue.items`.
+    pub fn sync_queue_badges(&mut self) {
+        let set: std::collections::HashSet<PathBuf> =
+            self.upload_queue.items.iter().map(PathBuf::from).collect();
+        self.file_tree.set_queued(set);
+    }
+
+    /// Grouping info for a queued path, from the cache when available.
+    pub fn queue_info(&self, path: &str) -> QueueEntryInfo {
+        self.queue_meta
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| queue_entry_info(path))
+    }
+
+    /// Remove the selected queue item, keeping caches and badges in sync.
+    pub fn remove_queue_selected(&mut self) -> Option<String> {
+        let removed = self.upload_queue.remove_selected();
+        if let Some(ref p) = removed {
+            self.queue_meta.remove(p);
+            self.sync_queue_badges();
+            self.save_queue();
+        }
+        removed
+    }
+
+    /// Clear the whole queue, returning how many items were removed.
+    pub fn clear_queue(&mut self) -> usize {
+        let count = self.upload_queue.items.len();
+        self.upload_queue.clear();
+        self.queue_meta.clear();
+        self.sync_queue_badges();
+        self.save_queue();
+        count
     }
 
     pub fn next_tab(&mut self) {
         self.state = match self.state {
-            AppState::Dashboard => AppState::Browser,
+            AppState::Dashboard => AppState::Queue,
+            AppState::Queue => AppState::Browser,
             AppState::Browser => AppState::History,
             AppState::History => AppState::NzbVault,
             AppState::NzbVault => AppState::Config,
@@ -566,7 +737,8 @@ impl App {
     pub fn prev_tab(&mut self) {
         self.state = match self.state {
             AppState::Dashboard => AppState::Config,
-            AppState::Browser => AppState::Dashboard,
+            AppState::Queue => AppState::Dashboard,
+            AppState::Browser => AppState::Queue,
             AppState::History => AppState::Browser,
             AppState::NzbVault => AppState::History,
             AppState::Config => AppState::NzbVault,
@@ -675,19 +847,17 @@ impl App {
         self.upload_queue.active = self.upload_queue.items.len();
         self.upload_started_at = Some(Instant::now());
 
-        // Mark uploading files in the browser for live [▶] badge
-        let uploading_names: std::collections::HashSet<String> = self
+        // Reset per-item state to Pending. The live [▶] badge and Active state
+        // are then driven one item at a time by ItemUploadStarted, because
+        // uploads run sequentially (one NZB at a time).
+        self.queue_status = self
             .upload_queue
             .items
             .iter()
-            .filter_map(|p| {
-                std::path::Path::new(p)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|s| s.to_string())
-            })
+            .map(|p| (p.clone(), FileStatus::Pending))
             .collect();
-        self.file_tree.set_uploading(uploading_names);
+        self.file_tree
+            .set_uploading(std::collections::HashSet::new());
 
         let token = CancellationToken::new();
         self.current_cancel_token = Some(token.clone());
@@ -715,7 +885,7 @@ impl App {
         };
 
         self.status_bar.set(format!(
-            "🚀 Upload started ({} files) — streaming real pesto progress (x to cancel, p to pause)",
+            "🚀 Upload started ({} files) — streaming real pesto progress (x to cancel)",
             self.upload_queue.items.len()
         ));
         let mode = if self.pesto_config.is_some() {
@@ -742,42 +912,142 @@ impl App {
             .push("------------------------------------------".to_string());
     }
 
+    /// Live upload state for a queued path (Pending when unknown).
+    pub fn item_status(&self, path: &str) -> FileStatus {
+        self.queue_status
+            .get(path)
+            .copied()
+            .unwrap_or(FileStatus::Pending)
+    }
+
+    /// A single queue item began uploading. Mark it Active and light up its
+    /// live [▶] badge in the Browser (only this item, since uploads are
+    /// sequential).
+    pub fn item_upload_started(&mut self, path: &str) {
+        self.queue_status
+            .insert(path.to_string(), FileStatus::Active);
+        if let Some(fp) = self.progress.files.iter_mut().find(|f| f.name == path) {
+            fp.status = FileStatus::Active;
+        }
+        let basename = std::path::Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string());
+        let mut set = std::collections::HashSet::new();
+        if let Some(b) = basename {
+            set.insert(b);
+        }
+        self.file_tree.set_uploading(set);
+    }
+
+    /// A single queue item finished. Record it in the catalog immediately with
+    /// the real size and the real NZB path pesto wrote, so a later failure in
+    /// the same batch can never erase this success. Failed items are kept in
+    /// the queue (marked ✗) for retry.
+    pub fn item_upload_done(
+        &mut self,
+        path: &str,
+        success: bool,
+        size_bytes: u64,
+        nzb_path: Option<PathBuf>,
+        duration_s: f64,
+    ) {
+        let status = if success {
+            FileStatus::Done
+        } else {
+            FileStatus::Failed
+        };
+        self.queue_status.insert(path.to_string(), status);
+        if let Some(fp) = self.progress.files.iter_mut().find(|f| f.name == path) {
+            fp.status = status;
+            if success && fp.total_segments == 0 {
+                // No per-file segment stream matched; show a full gauge anyway.
+                fp.total_segments = 1;
+                fp.done_segments = 1;
+            }
+        }
+
+        if !success {
+            return;
+        }
+
+        if let Some(ref cat) = self.catalog {
+            let original_name = std::path::Path::new(path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(path)
+                .to_string();
+            let group = self
+                .pesto_config
+                .as_ref()
+                .and_then(|c| c.groups.first().cloned());
+            let server = self.pesto_config.as_ref().map(|c| c.host.clone());
+
+            let mut rec = NewUpload::from_name(original_name);
+            rec.size_bytes = (size_bytes > 0).then_some(size_bytes as i64);
+            rec.upload_duration_s = Some(duration_s);
+            rec.usenet_group = group;
+            rec.nntp_server = server;
+            rec.nzb_path = nzb_path.map(|p| p.to_string_lossy().into_owned());
+            if let Err(e) = cat.record(&rec) {
+                self.log_panel.push(format!("catalog record error: {}", e));
+            }
+        }
+        // Reflect the new catalog entry in the Browser's NZB status column.
+        self.refresh_nzb_status();
+    }
+
+    /// Refresh only the per-file NZB status map used by the Browser (cheaper
+    /// than a full history refresh; safe to call after each item).
+    pub fn refresh_nzb_status(&mut self) {
+        if let Some(ref cat) = self.catalog {
+            if let Ok(map) = cat.status_map() {
+                self.file_tree.set_nzb_status(map);
+            }
+        }
+    }
+
     pub fn upload_finished(&mut self, success: bool, cancelled: bool) {
-        let duration_s = self
-            .upload_started_at
-            .take()
-            .map(|t| t.elapsed().as_secs_f64());
+        // Catalog records are written per-item in `item_upload_done`, with the
+        // real size and NZB path; nothing is recorded here. This finalizes the
+        // batch UI and prunes the queue.
+        self.upload_started_at.take();
 
         self.upload_in_progress = false;
-        self.upload_paused = false;
         self.upload_queue.active = 0;
         self.progress.is_cancelled = cancelled;
 
-        // Record each uploaded file in the catalog
-        if success && !cancelled {
-            if let Some(ref cat) = self.catalog {
-                let size_each = if self.upload_queue.items.is_empty() {
-                    None
-                } else {
-                    self.progress
-                        .total_bytes
-                        .checked_div(self.upload_queue.items.len() as u64)
-                        .map(|b| b as i64)
-                };
-                let group = self
-                    .pesto_config
-                    .as_ref()
-                    .and_then(|c| c.groups.first().cloned());
-                let server = self.pesto_config.as_ref().map(|c| c.host.clone());
-                for name in &self.upload_queue.items {
-                    let mut rec = NewUpload::from_name(name.clone());
-                    rec.size_bytes = size_each;
-                    rec.upload_duration_s = duration_s;
-                    rec.usenet_group = group.clone();
-                    rec.nntp_server = server.clone();
-                    let _ = cat.record(&rec);
+        // On a non-cancelled batch, successfully uploaded items leave the queue
+        // (they now live in History with a ✓ badge); failed items stay queued
+        // so the user can fix the problem and press `u` to retry just them.
+        let mut failed = 0usize;
+        if !cancelled {
+            let done: Vec<String> = self
+                .upload_queue
+                .items
+                .iter()
+                .filter(|p| self.item_status(p) == FileStatus::Done)
+                .cloned()
+                .collect();
+            failed = self
+                .upload_queue
+                .items
+                .iter()
+                .filter(|p| self.item_status(p) == FileStatus::Failed)
+                .count();
+            for p in &done {
+                if let Some(pos) = self.upload_queue.items.iter().position(|q| q == p) {
+                    self.upload_queue.items.remove(pos);
                 }
+                self.queue_meta.remove(p);
+                self.queue_status.remove(p);
             }
+            let len = self.upload_queue.items.len();
+            if self.upload_queue.selected >= len {
+                self.upload_queue.selected = len.saturating_sub(1);
+            }
+            self.sync_queue_badges();
+            self.save_queue();
         }
 
         self.progress.files.clear();
@@ -791,13 +1061,12 @@ impl App {
             self.status_bar.set("Upload finished successfully");
             self.log_panel.push("=== Upload finished ===".to_string());
         } else {
-            // Keep the UploadError message in the status bar if it was set;
-            // only fall back to this generic message if nothing else set it.
             self.log_panel
-                .push("=== Upload failed — check logs above ===".to_string());
-            if !self.status_bar.message.contains("error") {
-                self.status_bar.set("Upload failed — see Dashboard logs");
-            }
+                .push("=== Upload finished with failures — check logs above ===".to_string());
+            self.status_bar.set(format!(
+                "{} item(s) failed — still queued, press u to retry",
+                failed
+            ));
         }
 
         // Refresh the history list if it's currently visible
@@ -859,22 +1128,6 @@ impl App {
         self.status_bar.set("Cancelling upload...");
         self.log_panel
             .push("=== Upload cancellation requested ===".to_string());
-    }
-
-    pub fn toggle_pause(&mut self) {
-        if !self.upload_in_progress {
-            return;
-        }
-
-        self.upload_paused = !self.upload_paused;
-
-        if self.upload_paused {
-            self.status_bar.set("Upload paused (p to resume)");
-            self.log_panel.push("=== Upload paused ===".to_string());
-        } else {
-            self.status_bar.set("Upload resumed");
-            self.log_panel.push("=== Upload resumed ===".to_string());
-        }
     }
 
     /// Returns a user-friendly summary of the settings that will be used
@@ -1424,6 +1677,59 @@ impl App {
         }
     }
 
+    /// Persist the current upload queue (the list of paths) so a carefully
+    /// built selection survives navigating away or restarting the app.
+    pub fn save_queue(&self) {
+        if let Some(path) = queue_path() {
+            if let Ok(json) = serde_json::to_string_pretty(&self.upload_queue.items) {
+                let _ = std::fs::write(path, json);
+            }
+        }
+    }
+
+    /// Restore a previously saved queue, dropping any path that no longer
+    /// exists on disk, and rebuild the grouping cache and Browser badges.
+    pub fn load_queue(&mut self) {
+        let Some(path) = queue_path() else { return };
+        let Ok(data) = std::fs::read_to_string(&path) else {
+            return;
+        };
+        let Ok(items) = serde_json::from_str::<Vec<String>>(&data) else {
+            return;
+        };
+        let mut dropped = 0usize;
+        self.upload_queue.items = items
+            .into_iter()
+            .filter(|p| {
+                let exists = std::path::Path::new(p).exists();
+                if !exists {
+                    dropped += 1;
+                }
+                exists
+            })
+            .collect();
+        self.upload_queue.selected = 0;
+        self.queue_meta = self
+            .upload_queue
+            .items
+            .iter()
+            .map(|p| (p.clone(), queue_entry_info(p)))
+            .collect();
+        self.sync_queue_badges();
+        let n = self.upload_queue.items.len();
+        if n > 0 {
+            let mut msg = format!("Restored {n} queued item(s)");
+            if dropped > 0 {
+                msg.push_str(&format!(" ({dropped} missing path(s) dropped)"));
+            }
+            self.status_bar.set(msg);
+        }
+        // Persist the pruned list so missing paths do not linger.
+        if dropped > 0 {
+            self.save_queue();
+        }
+    }
+
     /// Load previously saved session overrides and merge them into config_state.
     /// Values already set (e.g. from the pesto config) are not overwritten.
     pub fn load_upload_prefs(&mut self) {
@@ -1521,6 +1827,11 @@ fn collect_nzbs_recursive(
 /// Path to the upload preferences file.
 fn upload_prefs_path() -> Option<PathBuf> {
     pesto::config::config_dir().map(|d| d.join("upapasta-prefs.json"))
+}
+
+/// Path to the persisted upload queue.
+fn queue_path() -> Option<PathBuf> {
+    pesto::config::config_dir().map(|d| d.join("upapasta-queue.json"))
 }
 
 /// Expand a leading `~` to the user's home directory.

--- a/crates/upapasta/src/events.rs
+++ b/crates/upapasta/src/events.rs
@@ -95,9 +95,22 @@ pub enum AppEvent {
     // A single queue item finished, carrying the real data pesto produced so
     // the catalog can be written per-item (real size, real NZB path) instead of
     // a fabricated average at the end of the batch.
+    //
+    // `record_catalog` is false when the item produced several NZBs (per-file /
+    // season folder modes): each NZB is then recorded via its own
+    // `CatalogRecord`, so the item-level event only updates the queue status.
     ItemUploadDone {
         path: String,
         success: bool,
+        size_bytes: u64,
+        nzb_path: Option<std::path::PathBuf>,
+        duration_s: f64,
+        record_catalog: bool,
+    },
+    // Record one produced NZB in the catalog (used by per-file / season folder
+    // modes where a single queue entry yields multiple NZBs).
+    CatalogRecord {
+        original_name: String,
         size_bytes: u64,
         nzb_path: Option<std::path::PathBuf>,
         duration_s: f64,

--- a/crates/upapasta/src/events.rs
+++ b/crates/upapasta/src/events.rs
@@ -88,11 +88,26 @@ pub enum AppEvent {
     UploadError(String),
     // Periodic UI tick
     Tick,
+    // A single queue item started uploading (sequential, one NZB at a time).
+    ItemUploadStarted {
+        path: String,
+    },
+    // A single queue item finished, carrying the real data pesto produced so
+    // the catalog can be written per-item (real size, real NZB path) instead of
+    // a fabricated average at the end of the batch.
+    ItemUploadDone {
+        path: String,
+        success: bool,
+        size_bytes: u64,
+        nzb_path: Option<std::path::PathBuf>,
+        duration_s: f64,
+    },
     // Internal: upload task finished
-    UploadFinished { success: bool, cancelled: bool },
+    UploadFinished {
+        success: bool,
+        cancelled: bool,
+    },
     // Upload control
-    PauseUpload,
-    ResumeUpload,
     Quit,
     // Prowlarr connection check result
     ProwlarrStatus(crate::prowlarr::ConnectionStatus),

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -175,11 +175,11 @@ async fn run_app<B: ratatui::backend::Backend>(
                         KeyCode::Up | KeyCode::Char('k') => app.confirm_field_prev(),
                         // Enter or e: cycle enum/bool, or enter edit mode for text fields
                         KeyCode::Enter | KeyCode::Char('e') => app.confirm_field_activate(),
-                        // Right/l/Space: increment cycle fields
+                        // Right/l/Space: advance cycle/number/toggle fields
                         KeyCode::Right | KeyCode::Char('l') | KeyCode::Char(' ') => {
                             app.confirm_field_increment();
                         }
-                        // Left/h: decrement (PAR2 only)
+                        // Left/h: step cycle/number/toggle fields backwards
                         KeyCode::Left | KeyCode::Char('h') => app.confirm_field_decrement(),
                         _ => {}
                     },
@@ -512,8 +512,24 @@ async fn run_app<B: ratatui::backend::Backend>(
                     size_bytes,
                     nzb_path,
                     duration_s,
+                    record_catalog,
                 } => {
-                    app.item_upload_done(&path, success, size_bytes, nzb_path, duration_s);
+                    app.item_upload_done(
+                        &path,
+                        success,
+                        size_bytes,
+                        nzb_path,
+                        duration_s,
+                        record_catalog,
+                    );
+                }
+                AppEvent::CatalogRecord {
+                    original_name,
+                    size_bytes,
+                    nzb_path,
+                    duration_s,
+                } => {
+                    app.record_catalog_entry(original_name, size_bytes, nzb_path, duration_s);
                 }
                 AppEvent::UploadFinished { success, cancelled } => {
                     app.upload_finished(success, cancelled);
@@ -728,6 +744,10 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
         build_dry_run_config()
     };
 
+    // How directories in the queue become NZB(s): one release NZB (default),
+    // one NZB per file, or per-file + a combined season NZB.
+    let folder_mode = app.effective_folder_mode();
+
     let cancel_token = app.current_cancel_token.clone().unwrap_or_default();
 
     // Direct uploads into nzb_dir/uploaded/ so the vault can distinguish them
@@ -741,17 +761,19 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
         let _ = std::fs::create_dir_all(d);
     }
 
-    // Each queue item is uploaded individually so each file gets its own NZB.
+    // Each queue item is uploaded in sequence. A directory becomes one release
+    // NZB (Single), one NZB per file (PerFile), or per-file NZBs plus a combined
+    // season NZB (Season). Files always upload as a single NZB.
     tokio::spawn(async move {
         let total = entry_paths.len();
         let mut any_cancelled = false;
         let mut all_ok = true;
-        for (i, path) in entry_paths.iter().enumerate() {
+        'outer: for (i, path) in entry_paths.iter().enumerate() {
+            let key = path.to_string_lossy().into_owned();
             let label = path
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_else(|| format!("file-{}", i + 1));
-            let key = path.to_string_lossy().into_owned();
             if total > 1 {
                 let _ = tx.send(AppEvent::Progress(format!(
                     "=== Upload {}/{}: {} ===",
@@ -762,46 +784,174 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
             }
             let _ = tx.send(AppEvent::ItemUploadStarted { path: key.clone() });
             let item_start = Instant::now();
-            let result = run_real_upload(
-                config.clone(),
-                vec![path.clone()],
-                label,
-                nzb_out_dir.clone(),
-                tx.clone(),
-                cancel_token.clone(),
-            )
-            .await;
-            let duration_s = item_start.elapsed().as_secs_f64();
-            match result {
-                Err(ref e) => {
-                    let _ = tx.send(AppEvent::UploadError(e.to_string()));
+
+            let expand = path.is_dir() && folder_mode != app::FolderMode::Single;
+
+            if !expand {
+                // One NZB for this entry (a file, or a folder as a single release).
+                let result = run_real_upload(
+                    config.clone(),
+                    vec![path.clone()],
+                    label,
+                    nzb_out_dir.clone(),
+                    tx.clone(),
+                    cancel_token.clone(),
+                )
+                .await;
+                let duration_s = item_start.elapsed().as_secs_f64();
+                match result {
+                    Err(ref e) => {
+                        let _ = tx.send(AppEvent::UploadError(e.to_string()));
+                        let _ = tx.send(AppEvent::ItemUploadDone {
+                            path: key,
+                            success: false,
+                            size_bytes: 0,
+                            nzb_path: None,
+                            duration_s,
+                            record_catalog: false,
+                        });
+                        all_ok = false;
+                    }
+                    Ok(ref o) if o.cancelled => {
+                        any_cancelled = true;
+                        break;
+                    }
+                    Ok(o) => {
+                        let success = !o.had_failures;
+                        if !success {
+                            all_ok = false;
+                        }
+                        let _ = tx.send(AppEvent::ItemUploadDone {
+                            path: key,
+                            success,
+                            size_bytes: o.total_bytes,
+                            nzb_path: o.nzb_path,
+                            duration_s,
+                            record_catalog: true,
+                        });
+                    }
+                }
+                continue;
+            }
+
+            // PerFile / Season: expand the folder into its files and upload each
+            // as its own NZB, recording each in the catalog as it lands.
+            let files = match pesto::walk::expand_inputs(std::slice::from_ref(path)) {
+                Ok(f) => f,
+                Err(e) => {
+                    let _ = tx.send(AppEvent::UploadError(format!("expand {label}: {e}")));
                     let _ = tx.send(AppEvent::ItemUploadDone {
                         path: key,
                         success: false,
                         size_bytes: 0,
                         nzb_path: None,
-                        duration_s,
+                        duration_s: item_start.elapsed().as_secs_f64(),
+                        record_catalog: false,
                     });
                     all_ok = false;
+                    continue;
                 }
-                Ok(ref o) if o.cancelled => {
-                    any_cancelled = true;
-                    break;
-                }
-                Ok(o) => {
-                    let success = !o.had_failures;
-                    if !success {
-                        all_ok = false;
+            };
+
+            let mut all_segments = Vec::new();
+            let mut total_size = 0u64;
+            let mut folder_ok = true;
+            for inf in &files {
+                let ep_name = inf
+                    .path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| inf.name.clone());
+                let ep_start = Instant::now();
+                let result = run_real_upload(
+                    config.clone(),
+                    vec![inf.path.clone()],
+                    ep_name.clone(),
+                    nzb_out_dir.clone(),
+                    tx.clone(),
+                    cancel_token.clone(),
+                )
+                .await;
+                let ep_dur = ep_start.elapsed().as_secs_f64();
+                match result {
+                    Err(ref e) => {
+                        let _ = tx.send(AppEvent::UploadError(e.to_string()));
+                        folder_ok = false;
                     }
-                    let _ = tx.send(AppEvent::ItemUploadDone {
-                        path: key,
-                        success,
-                        size_bytes: o.total_bytes,
-                        nzb_path: o.nzb_path,
-                        duration_s,
-                    });
+                    Ok(ref o) if o.cancelled => {
+                        any_cancelled = true;
+                        break 'outer;
+                    }
+                    Ok(o) => {
+                        if o.had_failures {
+                            folder_ok = false;
+                        }
+                        total_size += o.total_bytes;
+                        let _ = tx.send(AppEvent::CatalogRecord {
+                            original_name: ep_name,
+                            size_bytes: o.total_bytes,
+                            nzb_path: o.nzb_path,
+                            duration_s: ep_dur,
+                        });
+                        all_segments.extend(o.segments);
+                    }
                 }
             }
+
+            // Season: consolidate every posted segment into one combined NZB.
+            let mut season_nzb = None;
+            if folder_mode == app::FolderMode::Season && !all_segments.is_empty() {
+                if let Some(ref dir) = nzb_out_dir {
+                    let out = dir.join(format!("{label}.nzb"));
+                    let meta = pesto::nzb::NzbMeta {
+                        name: Some(label.clone()),
+                        password: config
+                            .nzb_password
+                            .clone()
+                            .or_else(|| config.compress_password.clone()),
+                        category: config.nzb_category.clone(),
+                    };
+                    let xml = pesto::nzb::generate(
+                        &config.from,
+                        &config.groups,
+                        &all_segments,
+                        &meta,
+                        config.obfuscate == ObfuscateMode::Full,
+                    );
+                    match std::fs::write(&out, xml) {
+                        Ok(()) => {
+                            let _ = tx.send(AppEvent::Progress(format!(
+                                "wrote season nzb: {}",
+                                out.display()
+                            )));
+                            let _ = tx.send(AppEvent::CatalogRecord {
+                                original_name: label.clone(),
+                                size_bytes: total_size,
+                                nzb_path: Some(out.clone()),
+                                duration_s: item_start.elapsed().as_secs_f64(),
+                            });
+                            season_nzb = Some(out);
+                        }
+                        Err(e) => {
+                            let _ =
+                                tx.send(AppEvent::UploadError(format!("season nzb write: {e}")));
+                            folder_ok = false;
+                        }
+                    }
+                }
+            }
+
+            if !folder_ok {
+                all_ok = false;
+            }
+            let _ = tx.send(AppEvent::ItemUploadDone {
+                path: key,
+                success: folder_ok,
+                size_bytes: total_size,
+                nzb_path: season_nzb,
+                duration_s: item_start.elapsed().as_secs_f64(),
+                record_catalog: false,
+            });
         }
         let _ = tx.send(AppEvent::UploadFinished {
             success: all_ok && !any_cancelled,

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     io, path::PathBuf, sync::atomic::AtomicBool, sync::atomic::Ordering, sync::Arc, time::Duration,
+    time::Instant,
 };
 
 use crossterm::{
@@ -39,6 +40,7 @@ async fn main() -> io::Result<()> {
         .await
         .expect("App::new panicked");
     app.load_upload_prefs();
+    app.load_queue();
 
     // Event channel (the backbone of the new architecture)
     let (tx, mut rx) = mpsc::unbounded_channel::<AppEvent>();
@@ -123,22 +125,25 @@ async fn run_app<B: ratatui::backend::Backend>(
                             app.refresh_history();
                         }
                     }
-                    // F1–F5: direct tab jump
+                    // F1–F6: direct tab jump
                     KeyCode::F(1) => {
                         app.state = app::AppState::Dashboard;
                     }
                     KeyCode::F(2) => {
-                        app.state = app::AppState::Browser;
+                        app.state = app::AppState::Queue;
                     }
                     KeyCode::F(3) => {
+                        app.state = app::AppState::Browser;
+                    }
+                    KeyCode::F(4) => {
                         app.state = app::AppState::History;
                         app.refresh_history();
                     }
-                    KeyCode::F(4) => {
+                    KeyCode::F(5) => {
                         app.state = app::AppState::NzbVault;
                         app.load_vault();
                     }
-                    KeyCode::F(5) => {
+                    KeyCode::F(6) => {
                         app.state = app::AppState::Config;
                     }
                     // ── Upload config panel (text-edit mode takes priority) ──
@@ -206,27 +211,22 @@ async fn run_app<B: ratatui::backend::Backend>(
                         KeyCode::Up | KeyCode::Char('k') => app.file_tree.select_previous(),
                         KeyCode::Down | KeyCode::Char('j') => app.file_tree.select_next(),
                         KeyCode::Char(' ') => {
-                            // Space: mark/unmark current item and advance cursor
-                            app.file_tree.toggle_mark();
-                            let n = app.file_tree.marked_count();
-                            app.status_bar
-                                .set(format!("{} item(s) marked — press u to queue & upload", n));
+                            // Space is the single selection action: queue/unqueue
+                            // the item under the cursor (file or folder), then
+                            // advance. The queue is the one source of truth.
+                            app.toggle_queue_at_cursor();
                         }
                         KeyCode::Enter => {
+                            // Enter is navigation only and never touches the
+                            // queue: enter a directory, or (on a file) just keep
+                            // the detail panel focused on it. Use Space to queue.
                             if let Some(selected) = app.file_tree.get_selected().cloned() {
                                 if selected.is_dir() {
                                     app.file_tree.current_dir = selected;
                                     app.file_tree.refresh();
                                     app.file_tree.selected = 0;
                                 } else {
-                                    let path_str = selected.to_string_lossy().to_string();
-                                    if app.upload_queue.items.contains(&path_str) {
-                                        app.upload_queue.items.retain(|p| p != &path_str);
-                                        app.status_bar.set("Removed from queue");
-                                        app.log_panel.push(format!("Removed: {}", path_str));
-                                    } else {
-                                        app.add_to_queue(path_str);
-                                    }
+                                    app.status_bar.set("Press Space to queue/unqueue this file");
                                 }
                             }
                         }
@@ -234,11 +234,8 @@ async fn run_app<B: ratatui::backend::Backend>(
                             app.file_tree.go_to_parent();
                         }
                         KeyCode::Char('u') => {
-                            // Queue all marked items first
-                            let marked = app.file_tree.take_marked();
-                            for p in marked {
-                                app.add_to_queue(p.to_string_lossy().to_string());
-                            }
+                            // The queue already reflects everything marked with
+                            // Space, so just open the config panel.
                             if app.upload_queue.items.is_empty() {
                                 app.status_bar
                                     .set("Queue is empty — mark files with Space first");
@@ -246,21 +243,68 @@ async fn run_app<B: ratatui::backend::Backend>(
                                 app.show_upload_confirm = true;
                             }
                         }
+                        KeyCode::Char('n') => {
+                            // Toggle "show only items without an NZB yet".
+                            app.file_tree.toggle_filter_unbacked();
+                            let (_, unbacked, _) = app.file_tree.summary();
+                            if app.file_tree.filter_unbacked {
+                                app.status_bar.set(format!(
+                                    "Showing {} item(s) that still need uploading (n to show all)",
+                                    unbacked
+                                ));
+                            } else {
+                                app.status_bar.set("Showing all items");
+                            }
+                        }
                         KeyCode::Char('P') => {
                             trigger_prowlarr_search(app, tx.clone());
                         }
                         _ => {}
                     },
-                    KeyCode::Char('u')
-                        if app.state == app::AppState::Dashboard && !app.log_panel.searching =>
-                    {
-                        if app.upload_queue.items.is_empty() {
-                            app.status_bar
-                                .set("Queue is empty — go to Browser and mark files with Space");
-                        } else {
-                            app.show_upload_confirm = true;
+                    // ── Queue screen keys (the home for queue management) ───
+                    _ if app.state == app::AppState::Queue => match key.code {
+                        KeyCode::Up | KeyCode::Char('k') => app.upload_queue.select_previous(),
+                        KeyCode::Down | KeyCode::Char('j') => app.upload_queue.select_next(),
+                        KeyCode::Char('u') => {
+                            if app.upload_queue.items.is_empty() {
+                                app.status_bar.set(
+                                    "Queue is empty — go to Browser (F3) and mark files with Space",
+                                );
+                            } else if app.upload_in_progress {
+                                app.status_bar.set("Upload already running");
+                            } else {
+                                app.show_upload_confirm = true;
+                            }
                         }
-                    }
+                        KeyCode::Char('d') | KeyCode::Delete => {
+                            if app.upload_in_progress {
+                                app.status_bar.set("Cannot edit the queue during upload");
+                            } else if let Some(removed) = app.remove_queue_selected() {
+                                app.status_bar.set(format!("Removed: {}", removed));
+                            }
+                        }
+                        KeyCode::Char('c') => {
+                            if app.upload_in_progress {
+                                app.status_bar.set("Cannot edit the queue during upload");
+                            } else {
+                                let count = app.clear_queue();
+                                app.status_bar
+                                    .set(format!("Cleared {} items from queue", count));
+                            }
+                        }
+                        KeyCode::Char('J') if !app.upload_in_progress => {
+                            app.upload_queue.move_selected_down();
+                            app.save_queue();
+                        }
+                        KeyCode::Char('K') if !app.upload_in_progress => {
+                            app.upload_queue.move_selected_up();
+                            app.save_queue();
+                        }
+                        KeyCode::Char('x') if app.upload_in_progress => {
+                            app.cancel_upload();
+                        }
+                        _ => {}
+                    },
                     // ── Log panel search (Dashboard) ───────────────────────
                     _ if app.state == app::AppState::Dashboard && app.log_panel.searching => {
                         match key.code {
@@ -298,60 +342,11 @@ async fn run_app<B: ratatui::backend::Backend>(
                     {
                         app.log_panel.toggle_auto_scroll();
                     }
-                    // Queue management on Dashboard
-                    KeyCode::Char('d') | KeyCode::Delete
-                        if app.state == app::AppState::Dashboard =>
-                    {
-                        if let Some(removed) = app.upload_queue.remove_selected() {
-                            app.status_bar.set(format!("Removed: {}", removed));
-                            app.log_panel
-                                .push(format!("Removed from queue: {}", removed));
-                            if app.upload_queue.items.is_empty() {
-                                app.upload_in_progress = false;
-                            }
-                        }
-                    }
-                    KeyCode::Char('c') if app.state == app::AppState::Dashboard => {
-                        let count = app.upload_queue.items.len();
-                        app.upload_queue.clear();
-                        app.status_bar
-                            .set(format!("Cleared {} items from queue", count));
-                        app.log_panel.push("Upload queue cleared".to_string());
-                        app.upload_in_progress = false;
-                    }
-                    // Cancel current upload
+                    // Cancel current upload (Dashboard shows the live progress)
                     KeyCode::Char('x')
                         if app.state == app::AppState::Dashboard && app.upload_in_progress =>
                     {
                         app.cancel_upload();
-                    }
-                    // Pause / Resume
-                    KeyCode::Char('p')
-                        if app.state == app::AppState::Dashboard && app.upload_in_progress =>
-                    {
-                        app.toggle_pause();
-                        // Send event so the upload task can react (for now UI-only pause)
-                        let _ = tx.send(AppEvent::PauseUpload); // will be improved
-                    }
-                    // Navigate and reorder queue on Dashboard (Shift+J/K = move item)
-                    KeyCode::Char('J')
-                        if app.state == app::AppState::Dashboard && !app.upload_in_progress =>
-                    {
-                        app.upload_queue.move_selected_down();
-                        app.status_bar.set("Moved item down");
-                    }
-                    KeyCode::Char('K')
-                        if app.state == app::AppState::Dashboard && !app.upload_in_progress =>
-                    {
-                        app.upload_queue.move_selected_up();
-                        app.status_bar.set("Moved item up");
-                    }
-                    // Navigate queue selection (no reorder) during upload
-                    KeyCode::Char('J') if app.state == app::AppState::Dashboard => {
-                        app.upload_queue.select_next();
-                    }
-                    KeyCode::Char('K') if app.state == app::AppState::Dashboard => {
-                        app.upload_queue.select_previous();
                     }
                     // ── History screen keys ────────────────────────────────
                     // NZB viewer overlay takes priority when open
@@ -505,13 +500,21 @@ async fn run_app<B: ratatui::backend::Backend>(
                     app.log_panel.push_error(format!("ERROR: {}", msg));
                     app.status_bar.set("Upload error — see logs for details");
                 }
-                AppEvent::ProgressUpdate(update) if !app.upload_paused => {
+                AppEvent::ProgressUpdate(update) => {
                     app.handle_progress_update(update);
                 }
-                AppEvent::PauseUpload => {
-                    // Currently pause is UI-driven; in future we can throttle the worker here
+                AppEvent::ItemUploadStarted { path } => {
+                    app.item_upload_started(&path);
                 }
-                AppEvent::ResumeUpload => {}
+                AppEvent::ItemUploadDone {
+                    path,
+                    success,
+                    size_bytes,
+                    nzb_path,
+                    duration_s,
+                } => {
+                    app.item_upload_done(&path, success, size_bytes, nzb_path, duration_s);
+                }
                 AppEvent::UploadFinished { success, cancelled } => {
                     app.upload_finished(success, cancelled);
                 }
@@ -748,6 +751,7 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_else(|| format!("file-{}", i + 1));
+            let key = path.to_string_lossy().into_owned();
             if total > 1 {
                 let _ = tx.send(AppEvent::Progress(format!(
                     "=== Upload {}/{}: {} ===",
@@ -756,6 +760,8 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
                     label
                 )));
             }
+            let _ = tx.send(AppEvent::ItemUploadStarted { path: key.clone() });
+            let item_start = Instant::now();
             let result = run_real_upload(
                 config.clone(),
                 vec![path.clone()],
@@ -765,19 +771,36 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
                 cancel_token.clone(),
             )
             .await;
+            let duration_s = item_start.elapsed().as_secs_f64();
             match result {
                 Err(ref e) => {
                     let _ = tx.send(AppEvent::UploadError(e.to_string()));
+                    let _ = tx.send(AppEvent::ItemUploadDone {
+                        path: key,
+                        success: false,
+                        size_bytes: 0,
+                        nzb_path: None,
+                        duration_s,
+                    });
                     all_ok = false;
                 }
                 Ok(ref o) if o.cancelled => {
                     any_cancelled = true;
                     break;
                 }
-                Ok(ref o) if o.had_failures => {
-                    all_ok = false;
+                Ok(o) => {
+                    let success = !o.had_failures;
+                    if !success {
+                        all_ok = false;
+                    }
+                    let _ = tx.send(AppEvent::ItemUploadDone {
+                        path: key,
+                        success,
+                        size_bytes: o.total_bytes,
+                        nzb_path: o.nzb_path,
+                        duration_s,
+                    });
                 }
-                Ok(_) => {}
             }
         }
         let _ = tx.send(AppEvent::UploadFinished {
@@ -879,14 +902,12 @@ async fn run_real_upload(
     let paths = entry_paths.clone();
     let lbl = label.clone();
     // Resolve the full NZB output path (dir + stem.nzb) when a subdir is given.
+    // A directory keeps its full name (release names contain dots that are not
+    // extensions); a plain file has a single extension stripped.
     let nzb_override = nzb_out_dir.map(|dir| {
         let stem = entry_paths
             .first()
-            .and_then(|p| p.file_name())
-            .map(|n| {
-                let s = std::path::Path::new(n);
-                s.file_stem().unwrap_or(n).to_string_lossy().into_owned()
-            })
+            .map(|p| app::queue_entry_info(&p.to_string_lossy()).nzb_name)
             .unwrap_or_else(|| label.clone());
         dir.join(format!("{stem}.nzb"))
     });

--- a/crates/upapasta/src/ui/components/file_tree.rs
+++ b/crates/upapasta/src/ui/components/file_tree.rs
@@ -290,8 +290,20 @@ impl FileTree {
             .enumerate()
             .map(|(i, path)| {
                 let badge = self.badge_for(path);
-                let icon = if path.is_dir() { "📁" } else { "📄" };
-                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                let is_dir = path.is_dir();
+                let raw_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                // Directories carry a single-width marker + trailing slash so
+                // they read at a glance without relying on (double-width) emoji.
+                let marker = if is_dir {
+                    crate::ui::theme::DIR_MARK
+                } else {
+                    crate::ui::theme::FILE_MARK
+                };
+                let name = if is_dir {
+                    format!("{raw_name}/")
+                } else {
+                    raw_name.to_string()
+                };
                 let is_selected = i == self.selected;
 
                 let (check, check_style, name_style) = match &badge {
@@ -336,15 +348,26 @@ impl FileTree {
                             Style::default()
                                 .fg(Color::Yellow)
                                 .add_modifier(Modifier::BOLD)
+                        } else if is_dir {
+                            Style::default().fg(Color::Blue)
                         } else {
                             Style::default()
                         },
                     ),
                 };
 
+                // Marker takes the directory accent unless the row is selected
+                // (then the highlight bg owns the styling).
+                let marker_style = if is_dir && !is_selected {
+                    Style::default().fg(Color::Blue)
+                } else {
+                    name_style
+                };
+
                 ListItem::new(Line::from(vec![
                     Span::styled(check, check_style),
-                    Span::styled(format!("{} {}", icon, name), name_style),
+                    Span::styled(marker, marker_style),
+                    Span::styled(name, name_style),
                 ]))
             })
             .collect();
@@ -395,12 +418,7 @@ impl FileTree {
                     .title(title)
                     .border_style(border_style),
             )
-            .highlight_style(
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            );
+            .highlight_style(crate::ui::theme::highlight());
 
         let mut state = ListState::default();
         state.select(Some(self.selected));

--- a/crates/upapasta/src/ui/components/file_tree.rs
+++ b/crates/upapasta/src/ui/components/file_tree.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ratatui::{
     layout::Rect,
@@ -14,9 +14,10 @@ use crate::catalog::NzbStatusEntry;
 /// How a file appears in the browser based on its catalog/queue state.
 #[derive(Debug, Clone)]
 pub enum NzbBadge {
-    /// Not in catalog, not marked.
+    /// Not in catalog, not queued.
     None,
-    /// Marked for queuing (Space key).
+    /// Queued for upload (Space key). The queue is the single source of truth;
+    /// this badge is a render mirror of `App::upload_queue`.
     Marked,
     /// Currently being uploaded.
     Uploading,
@@ -26,12 +27,24 @@ pub enum NzbBadge {
 
 #[derive(Debug)]
 pub struct FileTree {
+    /// Items currently visible (after the optional "unbacked only" filter).
     pub items: Vec<PathBuf>,
+    /// Every entry in `current_dir` (before filtering); the source for `items`
+    /// and for the directory summary line.
+    all_items: Vec<PathBuf>,
     pub current_dir: PathBuf,
     pub selected: usize,
     pub show_hidden: bool,
-    /// Absolute paths that have been marked for queuing (Space key).
-    pub marked: HashSet<PathBuf>,
+    /// When true, the browser hides items that already have an NZB (in the
+    /// catalog), so only what still needs uploading is shown.
+    pub filter_unbacked: bool,
+    /// Directory summary, recomputed on refresh / catalog change.
+    /// `(total items, unbacked items, total bytes still to upload)`.
+    summary: (usize, usize, u64),
+    /// Absolute paths currently in the upload queue. This is a render mirror of
+    /// `App::upload_queue`, refreshed via [`set_queued`]; it is never mutated
+    /// directly so the queue stays the single source of truth.
+    pub queued: HashSet<PathBuf>,
     /// NZB status from the catalog, keyed by original_name (filename or full path).
     pub nzb_status: HashMap<String, NzbStatusEntry>,
     /// Names of files currently being uploaded (basename).
@@ -46,10 +59,13 @@ impl FileTree {
     pub fn new() -> Self {
         let mut tree = Self {
             items: vec![],
+            all_items: vec![],
             current_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")),
             selected: 0,
             show_hidden: false,
-            marked: HashSet::new(),
+            filter_unbacked: false,
+            summary: (0, 0, 0),
+            queued: HashSet::new(),
             nzb_status: HashMap::new(),
             uploading: HashSet::new(),
             scroll_offset: 0,
@@ -59,14 +75,24 @@ impl FileTree {
         tree
     }
 
-    /// Replace the NZB status map (called after catalog refresh).
+    /// Replace the NZB status map (called after catalog refresh). The summary
+    /// and the unbacked filter depend on it, so recompute both.
     pub fn set_nzb_status(&mut self, status: HashMap<String, NzbStatusEntry>) {
         self.nzb_status = status;
+        self.recompute_summary();
+        self.apply_filter();
     }
 
     /// Mark names that are currently being uploaded.
     pub fn set_uploading(&mut self, names: HashSet<String>) {
         self.uploading = names;
+    }
+
+    /// Replace the set of queued paths (called whenever the upload queue
+    /// changes). Keeps the `[x]` badge in the Browser in lock-step with the
+    /// queue panel — one selection model, two views.
+    pub fn set_queued(&mut self, paths: HashSet<PathBuf>) {
+        self.queued = paths;
     }
 
     pub fn select_next(&mut self) {
@@ -122,11 +148,13 @@ impl FileTree {
             .unwrap_or_default();
         let full = path.to_string_lossy();
 
-        if self.marked.contains(path) {
-            return NzbBadge::Marked;
-        }
+        // Uploading takes precedence: an item stays in the queue while it is
+        // being posted, so the live ▶ badge must win over the queued [x].
         if self.uploading.contains(name) {
             return NzbBadge::Uploading;
+        }
+        if self.queued.contains(path) {
+            return NzbBadge::Marked;
         }
         if let Some(entry) = self
             .nzb_status
@@ -136,29 +164,6 @@ impl FileTree {
             return NzbBadge::Uploaded(entry.clone());
         }
         NzbBadge::None
-    }
-
-    /// Toggle the mark on the currently selected item and advance cursor.
-    pub fn toggle_mark(&mut self) {
-        if let Some(path) = self.items.get(self.selected).cloned() {
-            if self.marked.contains(&path) {
-                self.marked.remove(&path);
-            } else {
-                self.marked.insert(path);
-            }
-        }
-        self.select_next();
-    }
-
-    /// Return all marked paths (files and directories). Clears the mark set.
-    pub fn take_marked(&mut self) -> Vec<PathBuf> {
-        let mut paths: Vec<PathBuf> = self.marked.drain().collect();
-        paths.sort();
-        paths
-    }
-
-    pub fn marked_count(&self) -> usize {
-        self.marked.len()
     }
 
     pub fn refresh(&mut self) {
@@ -188,12 +193,77 @@ impl FileTree {
                 }
             });
 
-            self.items = items;
-            if self.selected >= self.items.len() {
-                self.selected = 0;
-                self.scroll_offset = 0;
+            self.all_items = items;
+            self.recompute_summary();
+            self.apply_filter();
+        }
+    }
+
+    /// Rebuild `items` from `all_items`, honoring the unbacked filter, and clamp
+    /// the cursor/scroll to the new length.
+    fn apply_filter(&mut self) {
+        self.items = if self.filter_unbacked {
+            self.all_items
+                .iter()
+                .filter(|p| !self.is_backed(p))
+                .cloned()
+                .collect()
+        } else {
+            self.all_items.clone()
+        };
+        if self.selected >= self.items.len() {
+            self.selected = 0;
+            self.scroll_offset = 0;
+        }
+    }
+
+    /// Toggle the "show only items without an NZB" filter.
+    pub fn toggle_filter_unbacked(&mut self) {
+        self.filter_unbacked = !self.filter_unbacked;
+        self.selected = 0;
+        self.scroll_offset = 0;
+        self.apply_filter();
+    }
+
+    /// Recompute the `(total, unbacked, bytes-to-upload)` summary for the
+    /// current directory listing.
+    fn recompute_summary(&mut self) {
+        let total = self.all_items.len();
+        let mut unbacked = 0usize;
+        let mut bytes = 0u64;
+        for p in &self.all_items {
+            if !self.is_backed(p) {
+                unbacked += 1;
+                bytes += item_size(p);
             }
         }
+        self.summary = (total, unbacked, bytes);
+    }
+
+    /// `(total items, unbacked items, bytes still to upload)` for the status line.
+    pub fn summary(&self) -> (usize, usize, u64) {
+        self.summary
+    }
+
+    /// Whether a path is already backed up (has an NZB in the catalog).
+    ///
+    /// A file is backed when it is in the catalog by full path or base name.
+    /// A directory is backed when it was uploaded as a release (its folder name
+    /// is in the catalog) *or* every file under it is individually backed —
+    /// i.e. it is unbacked if any child still needs uploading.
+    fn is_backed(&self, path: &Path) -> bool {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        let full = path.to_string_lossy();
+        if self.nzb_status.contains_key(full.as_ref()) || self.nzb_status.contains_key(name) {
+            return true;
+        }
+        if path.is_dir() {
+            return !dir_has_unbacked(path, &self.nzb_status);
+        }
+        false
     }
 
     pub fn go_to_parent(&mut self) {
@@ -279,22 +349,40 @@ impl FileTree {
             })
             .collect();
 
-        let n_marked = self.marked.len();
-        let marked_hint = if n_marked > 0 {
-            format!(" — {} marked", n_marked)
+        let n_queued = self.queued.len();
+        let queued_hint = if n_queued > 0 {
+            format!(" — {} queued", n_queued)
         } else {
             String::new()
         };
 
+        let (total, unbacked, bytes) = self.summary;
+        let summary = if unbacked > 0 {
+            format!(" — {} unbacked · {} to upload", unbacked, fmt_bytes(bytes))
+        } else if total > 0 {
+            " — all backed ✓".to_string()
+        } else {
+            String::new()
+        };
+        let filter_tag = if self.filter_unbacked {
+            " • filter:unbacked"
+        } else {
+            ""
+        };
+
         let title = format!(
-            " Browser — {} ({} items{}{}) ",
+            " Browser — {} ({} items{}{}{}{}) ",
             self.current_dir.display(),
-            self.items.len(),
+            total,
             if self.show_hidden { " • hidden" } else { "" },
-            marked_hint,
+            filter_tag,
+            queued_hint,
+            summary,
         );
 
-        let border_style = if focused {
+        let border_style = if self.filter_unbacked {
+            Style::default().fg(Color::Magenta)
+        } else if focused {
             Style::default().fg(Color::Cyan)
         } else {
             Style::default().fg(Color::DarkGray)
@@ -330,5 +418,104 @@ fn badge_symbol(entry: &NzbStatusEntry) -> (&'static str, Color) {
         (true, false) => ("[~] ", Color::Yellow),
         (false, true) => ("[P] ", Color::Magenta),
         (true, true) => ("[*] ", Color::Cyan),
+    }
+}
+
+/// Compact human-readable byte size (e.g. `3.2 GB`) for the summary line.
+fn fmt_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[unit])
+    } else {
+        format!("{:.1} {}", size, UNITS[unit])
+    }
+}
+
+/// Whether `dir` contains at least one file (recursively) that is not in the
+/// catalog by its base name. Walks with a cap and stops at the first hit, so a
+/// huge tree cannot stall the UI. Symlinks are skipped (as `pesto::walk` does).
+fn dir_has_unbacked(dir: &Path, nzb_status: &HashMap<String, NzbStatusEntry>) -> bool {
+    const CAP: usize = 50_000;
+    let mut stack = vec![dir.to_path_buf()];
+    let mut visited = 0usize;
+    while let Some(d) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let Ok(ft) = entry.file_type() else { continue };
+            if ft.is_symlink() {
+                continue;
+            } else if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                visited += 1;
+                let name = entry.file_name();
+                let in_catalog = name
+                    .to_str()
+                    .map(|n| nzb_status.contains_key(n))
+                    .unwrap_or(false);
+                if !in_catalog {
+                    return true;
+                }
+                if visited >= CAP {
+                    return false;
+                }
+            }
+        }
+    }
+    // No files at all (empty dir) counts as nothing to upload.
+    false
+}
+
+/// Best-effort byte size of an item: file length, or the recursive sum of a
+/// directory's files (capped for very large trees).
+fn item_size(path: &Path) -> u64 {
+    if path.is_file() {
+        return std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    }
+    const CAP: usize = 50_000;
+    let mut stack = vec![path.to_path_buf()];
+    let mut total = 0u64;
+    let mut visited = 0usize;
+    while let Some(d) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let Ok(ft) = entry.file_type() else { continue };
+            if ft.is_symlink() {
+                continue;
+            } else if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                total += entry.metadata().map(|m| m.len()).unwrap_or(0);
+                visited += 1;
+                if visited >= CAP {
+                    return total;
+                }
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fmt_bytes;
+
+    #[test]
+    fn fmt_bytes_scales_units() {
+        assert_eq!(fmt_bytes(0), "0 B");
+        assert_eq!(fmt_bytes(512), "512 B");
+        assert_eq!(fmt_bytes(1024), "1.0 KB");
+        assert_eq!(fmt_bytes(1536), "1.5 KB");
+        assert_eq!(fmt_bytes(3 * 1024 * 1024 * 1024), "3.0 GB");
     }
 }

--- a/crates/upapasta/src/ui/components/status_bar.rs
+++ b/crates/upapasta/src/ui/components/status_bar.rs
@@ -1,10 +1,6 @@
-use ratatui::{
-    layout::Rect,
-    style::{Color, Style},
-    widgets::{Block, Borders, Paragraph},
-    Frame,
-};
-
+/// Holds the transient status message shown in the bottom bar. Rendering lives
+/// in `ui::draw_status_bar`, which combines this message with context-sensitive
+/// key hints.
 #[derive(Debug, Default)]
 pub struct StatusBar {
     pub message: String,
@@ -17,15 +13,5 @@ impl StatusBar {
 
     pub fn set(&mut self, msg: impl Into<String>) {
         self.message = msg.into();
-    }
-
-    pub fn render(&self, f: &mut Frame, area: Rect) {
-        let help = format!("{}  |  Tab: switch  •  q: quit", self.message);
-
-        let status = Paragraph::new(help)
-            .style(Style::default().fg(Color::DarkGray))
-            .block(Block::default().borders(Borders::TOP).title(" Status "));
-
-        f.render_widget(status, area);
     }
 }

--- a/crates/upapasta/src/ui/components/upload_queue.rs
+++ b/crates/upapasta/src/ui/components/upload_queue.rs
@@ -18,12 +18,20 @@ impl UploadQueue {
         Self::default()
     }
 
-    pub fn add(&mut self, path: String) {
-        if !self.items.contains(&path) {
-            self.items.push(path);
-            if self.selected >= self.items.len() {
-                self.selected = self.items.len().saturating_sub(1);
+    /// Add the path if absent, remove it if present. Returns `true` when the
+    /// item is now queued, `false` when it was removed. This is the single
+    /// mutation used by the Browser's `Space` key, keeping the queue the one
+    /// source of truth for what will be uploaded.
+    pub fn toggle(&mut self, path: String) -> bool {
+        if let Some(pos) = self.items.iter().position(|p| p == &path) {
+            self.items.remove(pos);
+            if self.selected >= self.items.len() && !self.items.is_empty() {
+                self.selected = self.items.len() - 1;
             }
+            false
+        } else {
+            self.items.push(path);
+            true
         }
     }
 

--- a/crates/upapasta/src/ui/mod.rs
+++ b/crates/upapasta/src/ui/mod.rs
@@ -593,12 +593,9 @@ fn draw_queue(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_upload_config_panel(f: &mut Frame, app: &App, area: Rect) {
-    use pesto::config::ObfuscateMode;
-
     let s = app.effective_upload_settings();
     let queue = &app.upload_queue.items;
     let cfg = app.pesto_config.as_ref();
-    let ov = &app.config_state.overrides;
 
     let border_style = Style::default()
         .fg(Color::Yellow)
@@ -707,80 +704,21 @@ fn draw_upload_config_panel(f: &mut Frame, app: &App, area: Rect) {
     );
 
     // ── Editable fields ─────────────────────────────────────────────────────
-    let obf_str = match ov
-        .obfuscate
-        .unwrap_or(cfg.map(|c| c.obfuscate).unwrap_or(ObfuscateMode::None))
-    {
-        ObfuscateMode::None => "none",
-        ObfuscateMode::Subject => "subject",
-        ObfuscateMode::Full => "full",
-    };
-    let par2_str = format!("{}%", ov.par2.unwrap_or(cfg.map(|c| c.par2).unwrap_or(10)));
-    let verify_str = if ov.verify.unwrap_or(cfg.map(|c| c.verify).unwrap_or(false)) {
-        "on"
-    } else {
-        "off"
-    };
-
-    let pw_raw = ov
-        .nzb_password
-        .as_deref()
-        .or_else(|| cfg.and_then(|c| c.nzb_password.as_deref()))
-        .unwrap_or("");
-    let pw_display = if pw_raw.is_empty() {
-        "—".to_string()
-    } else if app.confirm_show_password {
-        pw_raw.to_string()
-    } else {
-        "•".repeat(pw_raw.len().min(20))
-    };
-
-    let groups_str = ov
-        .groups
-        .clone()
-        .or_else(|| cfg.map(|c| c.groups.join(", ")))
-        .unwrap_or_else(|| "—".to_string());
-
-    struct Field {
-        label: &'static str,
-        value: String,
-        hint: &'static str,
-    }
-    let fields = [
-        Field {
-            label: " Obfuscate",
-            value: obf_str.to_string(),
-            hint: "←→ cycle",
-        },
-        Field {
-            label: " PAR2 %  ",
-            value: par2_str,
-            hint: "←→ or Enter",
-        },
-        Field {
-            label: " Verify  ",
-            value: verify_str.to_string(),
-            hint: "←→ toggle",
-        },
-        Field {
-            label: " Password",
-            value: pw_display,
-            hint: "Enter edit  Tab show",
-        },
-        Field {
-            label: " Groups  ",
-            value: groups_str,
-            hint: "Enter edit",
-        },
-    ];
+    // Field labels, values and hints all come from one source in `app`, so the
+    // panel and the key handlers can never disagree on order or behaviour.
+    let fields = app.confirm_field_views();
 
     let field_area = vchunks[2];
     let header = Line::from(Span::styled(
         " Settings  (j/k navigate · Enter/e edit · ←→ cycle)",
         Style::default().fg(Color::DarkGray),
     ));
+    let legend = Line::from(Span::styled(
+        format!(" {}", app.obfuscate_legend()),
+        Style::default().fg(Color::DarkGray),
+    ));
 
-    let mut field_lines: Vec<Line> = vec![header, Line::from("")];
+    let mut field_lines: Vec<Line> = vec![header, legend, Line::from("")];
 
     for (i, field) in fields.iter().enumerate() {
         let is_sel = app.confirm_field == i;

--- a/crates/upapasta/src/ui/mod.rs
+++ b/crates/upapasta/src/ui/mod.rs
@@ -1,14 +1,13 @@
 use crate::app::{App, AppState};
 use pesto::config::ObfuscateMode;
 pub mod components;
+pub mod theme;
 
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{
-        Block, Borders, Clear, Gauge, List, ListItem, ListState, Paragraph, Sparkline, Tabs,
-    },
+    widgets::{Block, Borders, Clear, Gauge, List, ListItem, ListState, Paragraph, Sparkline},
     Frame,
 };
 
@@ -27,21 +26,20 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         return;
     }
 
-    // Compact mode: skip header when height is tight
+    // Compact mode: drop the separator rule under the tab strip when height is tight
     let compact = area.height < 20;
 
     let constraints: Vec<Constraint> = if compact {
         vec![
-            Constraint::Length(3), // Tabs only
+            Constraint::Length(1), // Tab strip (no rule)
             Constraint::Min(5),    // Main content
             Constraint::Length(1), // Status (slim)
         ]
     } else {
         vec![
-            Constraint::Length(3), // Header
-            Constraint::Length(3), // Tabs
+            Constraint::Length(2), // Tab strip + separator rule
             Constraint::Min(10),   // Main content
-            Constraint::Length(3), // Status bar
+            Constraint::Length(1), // Status bar (single line)
         ]
     };
 
@@ -50,18 +48,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         .constraints(constraints)
         .split(area);
 
-    if compact {
-        draw_tabs(f, app, chunks[0]);
-        draw_main(f, app, chunks[1]);
-        let slim = Paragraph::new(app.status_bar.message.clone())
-            .style(Style::default().fg(Color::DarkGray));
-        f.render_widget(slim, chunks[2]);
-    } else {
-        draw_header(f, chunks[0]);
-        draw_tabs(f, app, chunks[1]);
-        draw_main(f, app, chunks[2]);
-        draw_status_bar(f, app, chunks[3]);
-    }
+    draw_top_bar(f, app, chunks[0], !compact);
+    draw_main(f, app, chunks[1]);
+    draw_status_bar(f, app, chunks[2]);
 
     // Prowlarr search overlay floats above everything
     if app.prowlarr.search.is_some() {
@@ -69,60 +58,63 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     }
 }
 
-fn draw_header(f: &mut Frame, area: Rect) {
-    let title = Line::from(vec![
+/// Single-line top bar: brand on the left, tab strip in the middle, version on
+/// the right. When `rule` is true a thin separator is drawn on the row below,
+/// giving structure without stacking bordered boxes.
+fn draw_top_bar(f: &mut Frame, app: &App, area: Rect, rule: bool) {
+    const TABS: [(&str, AppState); 6] = [
+        ("Dashboard", AppState::Dashboard),
+        ("Queue", AppState::Queue),
+        ("Browser", AppState::Browser),
+        ("History", AppState::History),
+        ("Vault", AppState::NzbVault),
+        ("Config", AppState::Config),
+    ];
+
+    let mut spans: Vec<Span> = vec![
         Span::styled(
-            "UPA",
+            " UPAPASTA",
             Style::default()
-                .fg(Color::Green)
+                .fg(theme::ACCENT)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::raw("PASTA "),
-        Span::styled("v2", Style::default().fg(Color::Yellow)),
-        Span::raw(" — Rust Edition"),
-    ]);
-
-    let header = Paragraph::new(title)
-        .style(Style::default().fg(Color::White))
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Blue))
-                .title(" Welcome to UpaPasta "),
-        );
-
-    f.render_widget(header, area);
-}
-
-fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
-    let titles = vec![
-        " Dashboard ",
-        " Queue ",
-        " Browser ",
-        " History ",
-        " NZB Vault ",
-        " Config ",
+        Span::styled("  ", theme::label()),
     ];
-    let selected = match app.state {
-        AppState::Dashboard => 0,
-        AppState::Queue => 1,
-        AppState::Browser => 2,
-        AppState::History => 3,
-        AppState::NzbVault => 4,
-        AppState::Config => 5,
+
+    for (label, state) in TABS {
+        if app.state == state {
+            spans.push(Span::styled(
+                format!(" {label} "),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(theme::FOCUS)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        } else {
+            spans.push(Span::styled(format!(" {label} "), theme::label()));
+        }
+        spans.push(Span::raw(" "));
+    }
+
+    let strip_area = if rule {
+        let parts = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Length(1)])
+            .split(area);
+        // Separator rule under the strip.
+        let rule_line = "─".repeat(parts[1].width as usize);
+        f.render_widget(Paragraph::new(rule_line).style(theme::label()), parts[1]);
+        parts[0]
+    } else {
+        area
     };
 
-    let tabs = Tabs::new(titles)
-        .select(selected)
-        .style(Style::default().fg(Color::DarkGray))
-        .highlight_style(
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        )
-        .block(Block::default().borders(Borders::ALL).title(" Navigation "));
-
-    f.render_widget(tabs, area);
+    // Right-aligned version tag, drawn first so the tab strip can overlay the left.
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled("v2 ", theme::label()))).alignment(Alignment::Right),
+        strip_area,
+    );
+    f.render_widget(Paragraph::new(Line::from(spans)), strip_area);
 }
 
 fn draw_main(f: &mut Frame, app: &mut App, area: Rect) {
@@ -420,12 +412,14 @@ fn draw_nzb_detail_panel(f: &mut Frame, app: &App, area: Rect) {
         _ => Color::DarkGray,
     };
 
-    let para = ratatui::widgets::Paragraph::new(lines).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(title)
-            .border_style(Style::default().fg(border_color)),
-    );
+    let para = ratatui::widgets::Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(Style::default().fg(border_color)),
+        )
+        .wrap(ratatui::widgets::Wrap { trim: false });
     f.render_widget(para, area);
 }
 
@@ -444,26 +438,20 @@ fn draw_browser_queue(f: &mut Frame, app: &App, area: Rect) {
             } else {
                 Style::default().fg(Color::White)
             };
-            let (status_glyph, status_color) = match app.item_status(item) {
-                crate::app::FileStatus::Active => ("▶ ", Color::Cyan),
-                crate::app::FileStatus::Done => ("✓ ", Color::Green),
-                crate::app::FileStatus::Failed => ("✗ ", Color::Red),
-                crate::app::FileStatus::Pending => {
-                    if app.upload_in_progress {
-                        ("· ", Color::DarkGray)
-                    } else {
-                        ("○ ", Color::DarkGray)
-                    }
-                }
-            };
-            let (icon, suffix) = if info.is_dir {
-                ("📁 ", format!("  ({} files → 1 NZB)", info.file_count))
+            let (glyph, status_color) =
+                theme::status_glyph(app.item_status(item), app.upload_in_progress);
+            let (marker, marker_style, suffix) = if info.is_dir {
+                (
+                    theme::DIR_MARK,
+                    Style::default().fg(theme::DIR),
+                    format!("  ({} files → 1 NZB)", info.file_count),
+                )
             } else {
-                ("📄 ", String::new())
+                (theme::FILE_MARK, Style::default(), String::new())
             };
             ratatui::widgets::ListItem::new(Line::from(vec![
-                Span::styled(status_glyph, Style::default().fg(status_color)),
-                Span::styled(icon, Style::default()),
+                Span::styled(format!("{glyph} "), Style::default().fg(status_color)),
+                Span::styled(marker, marker_style),
                 Span::styled(info.nzb_name, style),
                 Span::styled(suffix, Style::default().fg(Color::DarkGray)),
             ]))
@@ -530,19 +518,12 @@ fn draw_queue(f: &mut Frame, app: &mut App, area: Rect) {
                 FileStatus::Failed => failed += 1,
                 _ => {}
             }
-            let (glyph, color) = match status {
-                FileStatus::Active => ("▶", Color::Cyan),
-                FileStatus::Done => ("✓", Color::Green),
-                FileStatus::Failed => ("✗", Color::Red),
-                FileStatus::Pending => {
-                    if app.upload_in_progress {
-                        ("·", Color::DarkGray)
-                    } else {
-                        ("○", Color::DarkGray)
-                    }
-                }
+            let (glyph, color) = theme::status_glyph(status, app.upload_in_progress);
+            let (marker, marker_style) = if info.is_dir {
+                (theme::DIR_MARK, Style::default().fg(theme::DIR))
+            } else {
+                (theme::FILE_MARK, Style::default())
             };
-            let icon = if info.is_dir { "📁" } else { "📄" };
             let detail = if info.is_dir {
                 format!("  {} files → 1 NZB", info.file_count)
             } else {
@@ -557,7 +538,7 @@ fn draw_queue(f: &mut Frame, app: &mut App, area: Rect) {
             };
             ListItem::new(Line::from(vec![
                 Span::styled(format!("{} ", glyph), Style::default().fg(color)),
-                Span::raw(format!("{} ", icon)),
+                Span::styled(marker, marker_style),
                 Span::styled(info.nzb_name, name_style),
                 Span::styled(detail, Style::default().fg(Color::DarkGray)),
                 Span::styled(
@@ -579,155 +560,127 @@ fn draw_queue(f: &mut Frame, app: &mut App, area: Rect) {
             Block::default()
                 .borders(Borders::ALL)
                 .title(title)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(Style::default().fg(theme::OK)),
         )
-        .highlight_style(
-            Style::default()
-                .fg(Color::Black)
-                .bg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        );
+        .highlight_style(theme::highlight());
     let mut state = ListState::default();
     state.select(Some(app.upload_queue.selected));
     f.render_stateful_widget(list, area, &mut state);
 }
 
 fn draw_upload_config_panel(f: &mut Frame, app: &App, area: Rect) {
-    let s = app.effective_upload_settings();
     let queue = &app.upload_queue.items;
     let cfg = app.pesto_config.as_ref();
 
-    let border_style = Style::default()
-        .fg(Color::Yellow)
-        .add_modifier(Modifier::BOLD);
-
     let outer = Block::default()
         .borders(Borders::ALL)
-        .border_style(border_style)
+        .border_style(Style::default().fg(theme::FOCUS))
         .title(Span::styled(
-            " Upload Config  [y: start  Esc: cancel] ",
+            " Upload Config ",
             Style::default()
-                .fg(Color::Yellow)
+                .fg(theme::FOCUS)
                 .add_modifier(Modifier::BOLD),
         ));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 
-    // Vertical sections inside the panel
-    let file_count = queue.len().min(6) as u16;
+    // One row of horizontal padding inside the border for breathing room.
+    let inner_area = inner_area.inner(ratatui::layout::Margin {
+        horizontal: 1,
+        vertical: 0,
+    });
+
+    // Vertical sections: each opens with a muted section header line instead of
+    // an edge-to-edge rule, so the panel reads as grouped fields, not a form.
+    let file_rows = queue.len().min(6) as u16;
     let vchunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(file_count + 2), // files block
-            Constraint::Length(4),              // read-only info
-            Constraint::Min(7),                 // editable fields
-            Constraint::Length(1),              // bottom hint
+            Constraint::Length(file_rows + 2), // FILES header + rows + spacer
+            Constraint::Length(4),             // DESTINATION header + 2 + spacer
+            Constraint::Min(7),                // SETTINGS
+            Constraint::Length(1),             // bottom hint
         ])
         .split(inner_area);
 
-    // ── Files list ──────────────────────────────────────────────────────────
-    let file_items: Vec<Line> = queue
-        .iter()
-        .take(6)
-        .map(|p| {
-            let info = app.queue_info(p);
-            let suffix = if info.is_dir {
-                format!(" → {}.nzb ({} files)", info.nzb_name, info.file_count)
-            } else {
-                format!(" → {}.nzb", info.nzb_name)
-            };
-            let icon = if info.is_dir { "📁 " } else { "📄 " };
-            let name = std::path::Path::new(p)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or(p);
-            let prefix_len = icon.chars().count() + suffix.chars().count();
-            let max = (vchunks[0].width as usize).saturating_sub(prefix_len + 2);
-            let short = if name.len() > max && max > 3 {
-                format!("{}…", &name[..max - 1])
-            } else {
-                name.to_string()
-            };
-            Line::from(vec![
-                Span::styled(icon, Style::default().fg(Color::DarkGray)),
-                Span::raw(short),
-                Span::styled(suffix, Style::default().fg(Color::DarkGray)),
-            ])
-        })
-        .collect();
-
-    let extra = queue.len().saturating_sub(6);
-    let file_title = if extra > 0 {
-        format!(" Files ({}, +{} more) ", queue.len(), extra)
-    } else {
-        format!(" Files ({}) ", queue.len())
+    let section = |text: String| {
+        Line::from(Span::styled(
+            text,
+            Style::default()
+                .fg(theme::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ))
     };
-    let mut all_file_lines = file_items;
-    if extra > 0 {
-        all_file_lines.push(Line::from(Span::styled(
-            format!(" … and {} more", extra),
-            Style::default().fg(Color::DarkGray),
-        )));
-    }
-    f.render_widget(
-        ratatui::widgets::Paragraph::new(all_file_lines).block(
-            Block::default()
-                .borders(Borders::BOTTOM)
-                .title(file_title)
-                .border_style(Style::default().fg(Color::DarkGray)),
-        ),
-        vchunks[0],
-    );
 
-    // ── Read-only info (server, compress) ──────────────────────────────────
+    // ── FILES ─────────────────────────────────────────────────────────────────
+    let extra = queue.len().saturating_sub(6);
+    let mut file_lines: Vec<Line> = vec![section(if extra > 0 {
+        format!("FILES ({}, +{} more)", queue.len(), extra)
+    } else {
+        format!("FILES ({})", queue.len())
+    })];
+    for p in queue.iter().take(6) {
+        let info = app.queue_info(p);
+        let suffix = if info.is_dir {
+            format!(" → {}.nzb ({} files)", info.nzb_name, info.file_count)
+        } else {
+            format!(" → {}.nzb", info.nzb_name)
+        };
+        let (marker, marker_style) = if info.is_dir {
+            (theme::DIR_MARK, Style::default().fg(theme::DIR))
+        } else {
+            (theme::FILE_MARK, Style::default())
+        };
+        let name = std::path::Path::new(p)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(p);
+        let prefix_len = marker.chars().count() + suffix.chars().count();
+        let max = (vchunks[0].width as usize).saturating_sub(prefix_len + 2);
+        let short = truncate_str(name, max);
+        file_lines.push(Line::from(vec![
+            Span::styled(marker, marker_style),
+            Span::raw(short),
+            Span::styled(suffix, theme::label()),
+        ]));
+    }
+    f.render_widget(ratatui::widgets::Paragraph::new(file_lines), vchunks[0]);
+
+    // ── DESTINATION (read-only) ────────────────────────────────────────────────
     let server_str = cfg
         .map(|c| format!("{}:{}", c.host, c.port))
         .unwrap_or_else(|| "dry-run".to_string());
-
     let info_lines = vec![
+        section("DESTINATION".to_string()),
         Line::from(vec![
-            Span::styled(" Server   ", Style::default().fg(Color::DarkGray)),
+            Span::styled("  Server    ", theme::label()),
             Span::raw(server_str),
         ]),
-        Line::from(vec![
-            Span::styled(" Compress ", Style::default().fg(Color::DarkGray)),
-            Span::raw(s.compression.clone()),
-        ]),
     ];
-    f.render_widget(
-        ratatui::widgets::Paragraph::new(info_lines).block(
-            Block::default()
-                .borders(Borders::BOTTOM)
-                .border_style(Style::default().fg(Color::DarkGray)),
-        ),
-        vchunks[1],
-    );
+    f.render_widget(ratatui::widgets::Paragraph::new(info_lines), vchunks[1]);
 
-    // ── Editable fields ─────────────────────────────────────────────────────
+    // ── SETTINGS (editable) ─────────────────────────────────────────────────────
     // Field labels, values and hints all come from one source in `app`, so the
     // panel and the key handlers can never disagree on order or behaviour.
     let fields = app.confirm_field_views();
-
-    let field_area = vchunks[2];
-    let header = Line::from(Span::styled(
-        " Settings  (j/k navigate · Enter/e edit · ←→ cycle)",
-        Style::default().fg(Color::DarkGray),
-    ));
-    let legend = Line::from(Span::styled(
-        format!(" {}", app.obfuscate_legend()),
-        Style::default().fg(Color::DarkGray),
-    ));
-
-    let mut field_lines: Vec<Line> = vec![header, legend, Line::from("")];
+    let mut field_lines: Vec<Line> = vec![
+        section("SETTINGS".to_string()),
+        Line::from(Span::styled(
+            format!("  {}", app.obfuscate_legend()),
+            theme::label(),
+        )),
+        Line::from(""),
+    ];
 
     for (i, field) in fields.iter().enumerate() {
         let is_sel = app.confirm_field == i;
         let is_editing = is_sel && app.confirm_editing;
 
-        let cursor = if is_sel {
-            Span::styled("▶", Style::default().fg(Color::Yellow))
+        // A left bar marks the selected field instead of a stray arrow glyph.
+        let bar = if is_sel {
+            Span::styled("▌ ", Style::default().fg(theme::FOCUS))
         } else {
-            Span::raw(" ")
+            Span::raw("  ")
         };
 
         let label_style = if is_sel {
@@ -735,7 +688,7 @@ fn draw_upload_config_panel(f: &mut Frame, app: &App, area: Rect) {
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::DarkGray)
+            theme::label()
         };
 
         let value_display = if is_editing {
@@ -745,31 +698,26 @@ fn draw_upload_config_panel(f: &mut Frame, app: &App, area: Rect) {
         };
 
         let value_style = if is_editing {
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD)
+            Style::default().fg(theme::OK).add_modifier(Modifier::BOLD)
         } else if is_sel {
-            Style::default().fg(Color::Yellow)
+            Style::default().fg(theme::FOCUS)
         } else {
             Style::default().fg(Color::White)
         };
 
-        let hint_style = Style::default().fg(Color::DarkGray);
-
         field_lines.push(Line::from(vec![
-            cursor,
+            bar,
             Span::styled(format!("{:<10}", field.label), label_style),
-            Span::styled(" ", Style::default()),
             Span::styled(value_display, value_style),
             if is_sel && !is_editing {
-                Span::styled(format!("  {}", field.hint), hint_style)
+                Span::styled(format!("   {}", field.hint), theme::label())
             } else {
                 Span::raw("")
             },
         ]));
     }
 
-    f.render_widget(ratatui::widgets::Paragraph::new(field_lines), field_area);
+    f.render_widget(ratatui::widgets::Paragraph::new(field_lines), vchunks[2]);
 
     // ── Bottom hint line ────────────────────────────────────────────────────
     let hint = Line::from(vec![
@@ -1059,8 +1007,6 @@ fn draw_speed_sparkline(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_per_file_progress(f: &mut Frame, app: &App, area: Rect) {
-    use crate::app::FileStatus;
-
     let files = &app.progress.files;
     let n = files.len();
 
@@ -1098,12 +1044,8 @@ fn draw_per_file_progress(f: &mut Frame, app: &App, area: Rect) {
             0
         };
 
-        let (status_icon, icon_color) = match fp.status {
-            FileStatus::Done => ("✓", Color::Green),
-            FileStatus::Failed => ("✗", Color::Red),
-            FileStatus::Active => ("▶", Color::Cyan),
-            FileStatus::Pending => (" ", Color::DarkGray),
-        };
+        // Upload is in progress on this screen, so pending shows the running dot.
+        let (status_icon, icon_color) = theme::status_glyph(fp.status, true);
 
         let name_row = rows[i * 2];
         let gauge_row = rows[i * 2 + 1];
@@ -1115,11 +1057,7 @@ fn draw_per_file_progress(f: &mut Frame, app: &App, area: Rect) {
             .and_then(|n| n.to_str())
             .unwrap_or(&fp.name);
         let max_name = (name_row.width as usize).saturating_sub(4);
-        let short_name = if display_name.len() > max_name && max_name > 3 {
-            format!("{}…", &display_name[..max_name - 1])
-        } else {
-            display_name.to_string()
-        };
+        let short_name = truncate_str(display_name, max_name);
         let name_line = Line::from(vec![
             Span::styled(
                 format!(" {} ", status_icon),
@@ -1129,13 +1067,8 @@ fn draw_per_file_progress(f: &mut Frame, app: &App, area: Rect) {
         ]);
         f.render_widget(Paragraph::new(name_line), name_row);
 
-        // Gauge
-        let gauge_color = match fp.status {
-            FileStatus::Done => Color::Green,
-            FileStatus::Failed => Color::Red,
-            FileStatus::Active => Color::Cyan,
-            FileStatus::Pending => Color::DarkGray,
-        };
+        // Gauge — same color as the status glyph.
+        let gauge_color = icon_color;
         let label = if fp.total_segments > 0 {
             format!("{pct}%  {}/{}", fp.done_segments, fp.total_segments)
         } else {
@@ -1178,74 +1111,51 @@ fn draw_upload_settings_summary(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(para, area);
 }
 
+/// Single-line status bar: the live message in white, then context-sensitive
+/// key hints in muted grey. No border — it sits flush at the bottom.
 fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
-    if app.show_upload_confirm {
-        let help = if app.confirm_editing {
-            "Enter: confirm  •  Esc: cancel edit  •  Tab: toggle password visibility"
+    // Hints shown after the message, tailored to the current screen/mode.
+    let hints: String = if app.show_upload_confirm {
+        if app.confirm_editing {
+            "Enter confirm · Esc cancel edit · Tab show password".into()
         } else {
-            "j/k: navigate  •  Enter/←→: edit field  •  y: start upload  •  Esc: cancel"
+            "j/k move · Enter/←→ edit · y start · Esc cancel".into()
+        }
+    } else if app.upload_in_progress {
+        "x cancel · Tab switch · q quit".into()
+    } else if app.state == AppState::Queue && !app.upload_queue.items.is_empty() {
+        "u upload · d remove · c clear · J/K reorder · Tab switch".into()
+    } else if app.state == AppState::Browser {
+        let filter = if app.file_tree.filter_unbacked {
+            "n all"
+        } else {
+            "n unbacked"
         };
-        let status = Paragraph::new(help)
-            .style(Style::default().fg(Color::Yellow))
-            .block(
-                Block::default()
-                    .borders(Borders::TOP)
-                    .title(" Upload Config "),
-            );
-        f.render_widget(status, area);
-        return;
-    }
-
-    if app.upload_in_progress {
-        let help = format!(
-            "{}  •  x: cancel  •  Tab: switch  •  q: quit",
-            app.status_bar.message
-        );
-        let status = Paragraph::new(help)
-            .style(Style::default().fg(Color::DarkGray))
-            .block(Block::default().borders(Borders::TOP).title(" Status "));
-        f.render_widget(status, area);
-        return;
-    }
-
-    if app.state == AppState::Queue && !app.upload_queue.items.is_empty() {
-        let hint = format!(
-            "{}  •  u: upload  •  d: remove  •  c: clear  •  J/K: reorder  •  Tab: switch",
-            app.status_bar.message
-        );
-        let status = Paragraph::new(hint)
-            .style(Style::default().fg(Color::DarkGray))
-            .block(Block::default().borders(Borders::TOP).title(" Status "));
-        f.render_widget(status, area);
-        return;
-    }
-
-    if app.state == AppState::Browser {
         let n = app.upload_queue.items.len();
-        let filter_hint = if app.file_tree.filter_unbacked {
-            "n: show all"
+        if n > 0 {
+            format!("Space queue · u upload ({n}) · {filter} · Tab switch")
         } else {
-            "n: unbacked only"
-        };
-        let hint = if n > 0 {
-            format!(
-                "{}  •  Space: queue/unqueue  •  u: upload ({} queued)  •  {}  •  Tab: switch",
-                app.status_bar.message, n, filter_hint
-            )
-        } else {
-            format!(
-                "{}  •  Space: queue file/folder  •  {}  •  Enter: open  •  Tab: switch",
-                app.status_bar.message, filter_hint
-            )
-        };
-        let status = Paragraph::new(hint)
-            .style(Style::default().fg(Color::DarkGray))
-            .block(Block::default().borders(Borders::TOP).title(" Status "));
-        f.render_widget(status, area);
-        return;
-    }
+            format!("Space queue · Enter open · {filter} · Tab switch")
+        }
+    } else if app.state == AppState::Config {
+        "j/k move · Enter/e edit · r reset · R reset all · C check Prowlarr · Tab switch".into()
+    } else {
+        "Tab switch · q quit".into()
+    };
 
-    app.status_bar.render(f, area);
+    // The upload-config hints read better in the focus color; everything else
+    // is muted so the eye lands on the message first.
+    let hint_style = if app.show_upload_confirm {
+        Style::default().fg(theme::FOCUS)
+    } else {
+        theme::label()
+    };
+
+    let line = Line::from(vec![
+        Span::styled(format!(" {}  ", app.status_bar.message), Style::default()),
+        Span::styled(hints, hint_style),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
 }
 
 // ── History screen ─────────────────────────────────────────────────────────
@@ -1332,11 +1242,7 @@ fn draw_history_list(f: &mut Frame, app: &mut App, area: Rect) {
                 .map(|b| format_bytes(b as u64))
                 .unwrap_or_else(|| "—".to_string());
             let cat_color = category_color(&r.category);
-            let short_name = if r.original_name.len() > 34 {
-                format!("{}…", &r.original_name[..33])
-            } else {
-                r.original_name.clone()
-            };
+            let short_name = truncate_str(&r.original_name, 34);
             let line = Line::from(vec![
                 Span::styled(format!("{} ", date), Style::default().fg(Color::DarkGray)),
                 Span::styled(
@@ -1362,11 +1268,7 @@ fn draw_history_list(f: &mut Frame, app: &mut App, area: Rect) {
                 .borders(Borders::ALL)
                 .title(" Uploads (j/k to navigate) "),
         )
-        .highlight_style(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        )
+        .highlight_style(theme::highlight())
         .highlight_symbol("▶ ");
 
     f.render_stateful_widget(list, area, &mut state);
@@ -1481,6 +1383,20 @@ fn draw_history_stats(f: &mut Frame, app: &App, area: Rect) {
 }
 
 // ── helpers ────────────────────────────────────────────────────────────────
+
+/// Truncate `s` to at most `max` *characters* (not bytes), appending an ellipsis
+/// when shortened. Char-safe so names with accents or other multibyte UTF-8
+/// (e.g. "Programação") never panic on a non-char-boundary slice.
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else if max == 0 {
+        String::new()
+    } else {
+        let kept: String = s.chars().take(max - 1).collect();
+        format!("{kept}…")
+    }
+}
 
 fn format_bytes(b: u64) -> String {
     if b >= 1_073_741_824 {
@@ -1761,7 +1677,9 @@ fn draw_config(f: &mut Frame, app: &App, area: Rect) {
 
             let line = Line::from(vec![
                 override_indicator,
-                Span::styled(format!("{:<14}", field.label), label_style),
+                // Wide enough for the longest label ("Compress password") so the
+                // value column never butts up against the label.
+                Span::styled(format!("{:<18}", field.label), label_style),
                 Span::styled(value_display, value_style),
                 if is_sel {
                     Span::styled(format!("   ← {}", field.hint), hint_style)
@@ -1791,13 +1709,12 @@ fn draw_config(f: &mut Frame, app: &App, area: Rect) {
         .count()
     };
 
+    // Keystroke hints live in the status bar; the title stays short so it never
+    // overflows the panel.
     let title = if override_count > 0 {
-        format!(
-            " Overrides ({} active)  [j/k navigate · Enter/e edit · r reset field · R reset all] ",
-            override_count
-        )
+        format!(" Overrides ({override_count} active) ")
     } else {
-        " Overrides  [j/k navigate · Enter/e edit · r reset field] ".to_string()
+        " Overrides ".to_string()
     };
 
     let list = List::new(items)
@@ -2011,11 +1928,7 @@ fn draw_nzb_vault(f: &mut Frame, app: &App, area: Rect) {
                 let size_str = format_bytes(e.file_size);
                 // Reserve space for: " ✓ ↑ " (5) + "  123.4 KB" (11) = 16 cols
                 let name_width = chunks[0].width.saturating_sub(18) as usize;
-                let name = if e.name.len() > name_width {
-                    format!("{}…", &e.name[..name_width.saturating_sub(1)])
-                } else {
-                    e.name.clone()
-                };
+                let name = truncate_str(&e.name, name_width);
                 ListItem::new(Line::from(vec![
                     Span::styled(format!(" {} ", catalog_marker), catalog_style),
                     Span::styled(format!("{} ", origin_sym), origin_style),
@@ -2036,11 +1949,7 @@ fn draw_nzb_vault(f: &mut Frame, app: &App, area: Rect) {
                 .title(list_title)
                 .border_style(Style::default().fg(Color::Blue)),
         )
-        .highlight_style(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        );
+        .highlight_style(theme::highlight());
 
     let mut list_state = ListState::default();
     list_state.select(if app.vault.entries.is_empty() {
@@ -2217,11 +2126,7 @@ fn draw_vault_viewer_overlay(f: &mut Frame, app: &App, area: Rect) {
     meta_lines.push(header);
 
     for nf in &c.files {
-        let name = if nf.name.len() > 40 {
-            format!("{}…", &nf.name[..39])
-        } else {
-            nf.name.clone()
-        };
+        let name = truncate_str(&nf.name, 40);
         meta_lines.push(Line::from(Span::raw(format!(
             " {:<40}  {:>9}  {:>6}",
             name,
@@ -2302,11 +2207,7 @@ fn draw_prowlarr_search_overlay(f: &mut Frame, app: &App, area: Rect) {
                 };
                 // Truncate title to fit
                 let max_title = h_chunks[0].width.saturating_sub(20) as usize;
-                let title_disp = if r.title.len() > max_title {
-                    format!("{}…", &r.title[..max_title.saturating_sub(1)])
-                } else {
-                    r.title.clone()
-                };
+                let title_disp = truncate_str(&r.title, max_title);
                 ListItem::new(Line::from(vec![
                     Span::raw(format!(" {:<width$}", title_disp, width = max_title)),
                     Span::styled(
@@ -2325,11 +2226,7 @@ fn draw_prowlarr_search_overlay(f: &mut Frame, app: &App, area: Rect) {
                 .title(title)
                 .border_style(Style::default().fg(Color::Cyan)),
         )
-        .highlight_style(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        );
+        .highlight_style(theme::highlight());
 
     let mut list_state = ListState::default();
     list_state.select(if search.results.is_empty() {
@@ -2438,4 +2335,30 @@ fn draw_prowlarr_search_overlay(f: &mut Frame, app: &App, area: Rect) {
         .block(block)
         .wrap(ratatui::widgets::Wrap { trim: false });
     f.render_widget(detail, h_chunks[1]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_str;
+
+    #[test]
+    fn truncate_keeps_short_strings() {
+        assert_eq!(truncate_str("abc", 5), "abc");
+        assert_eq!(truncate_str("abcde", 5), "abcde");
+    }
+
+    #[test]
+    fn truncate_adds_ellipsis_when_too_long() {
+        assert_eq!(truncate_str("abcdef", 4), "abc\u{2026}");
+    }
+
+    #[test]
+    fn truncate_is_char_safe_with_multibyte() {
+        // Must not panic on a multibyte boundary (regression: vault crash on
+        // "Programa\u{e7}\u{e3}o"-style names).
+        let s = "Programa\u{e7}\u{e3}o_e_IA";
+        let out = truncate_str(s, 10);
+        assert!(out.chars().count() <= 10);
+        assert!(out.ends_with('\u{2026}'));
+    }
 }

--- a/crates/upapasta/src/ui/mod.rs
+++ b/crates/upapasta/src/ui/mod.rs
@@ -1,5 +1,4 @@
 use crate::app::{App, AppState};
-use pesto::config::ObfuscateMode;
 pub mod components;
 pub mod theme;
 
@@ -1425,12 +1424,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
     let ov = &app.config_state.overrides;
 
     let masked = |s: &str| "*".repeat(s.len().min(12));
-
-    let obf_str = |m: ObfuscateMode| match m {
-        ObfuscateMode::None => "none",
-        ObfuscateMode::Subject => "subject",
-        ObfuscateMode::Full => "full",
-    };
+    use crate::app::{obf_label, on_off, UNSET};
 
     vec![
         ConfigField {
@@ -1439,7 +1433,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
                 .from
                 .clone()
                 .or_else(|| cfg.map(|c| c.from.clone()))
-                .unwrap_or_else(|| "—".into()),
+                .unwrap_or_else(|| UNSET.into()),
             hint: "Sender address in posted articles",
             has_override: ov.from.is_some(),
         },
@@ -1449,7 +1443,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
                 .groups
                 .clone()
                 .or_else(|| cfg.map(|c| c.groups.join(", ")))
-                .unwrap_or_else(|| "—".into()),
+                .unwrap_or_else(|| UNSET.into()),
             hint: "Comma-separated newsgroup list",
             has_override: ov.groups.is_some(),
         },
@@ -1457,11 +1451,11 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
             label: "Obfuscate",
             value: ov
                 .obfuscate
-                .map(obf_str)
-                .or_else(|| cfg.map(|c| obf_str(c.obfuscate)))
-                .unwrap_or("none")
+                .map(obf_label)
+                .or_else(|| cfg.map(|c| obf_label(c.obfuscate)))
+                .unwrap_or("None")
                 .to_string(),
-            hint: "Enter/e cycles: none → subject → full",
+            hint: "Enter/e cycles: None → Subject → Full",
             has_override: ov.obfuscate.is_some(),
         },
         ConfigField {
@@ -1488,9 +1482,9 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
             label: "Verify",
             value: ov
                 .verify
-                .map(|v| if v { "true" } else { "false" })
-                .or_else(|| cfg.map(|c| if c.verify { "true" } else { "false" }))
-                .unwrap_or("false")
+                .map(on_off)
+                .or_else(|| cfg.map(|c| on_off(c.verify)))
+                .unwrap_or("Off")
                 .to_string(),
             hint: "Enter/e toggles: STAT-check each article after posting",
             has_override: ov.verify.is_some(),
@@ -1502,7 +1496,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
                 .as_deref()
                 .map(masked)
                 .or_else(|| cfg.and_then(|c| c.nzb_password.as_deref()).map(masked))
-                .unwrap_or_else(|| "—".into()),
+                .unwrap_or_else(|| UNSET.into()),
             hint: "Extraction password in the NZB <meta>",
             has_override: ov.nzb_password.is_some(),
         },
@@ -1512,7 +1506,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
                 .nzb_category
                 .clone()
                 .or_else(|| cfg.and_then(|c| c.nzb_category.clone()))
-                .unwrap_or_else(|| "—".into()),
+                .unwrap_or_else(|| UNSET.into()),
             hint: "Category tag in the NZB (e.g. Movies > HD)",
             has_override: ov.nzb_category.is_some(),
         },
@@ -1523,7 +1517,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
                 .as_deref()
                 .map(masked)
                 .or_else(|| cfg.and_then(|c| c.compress_password.as_deref()).map(masked))
-                .unwrap_or_else(|| "—".into()),
+                .unwrap_or_else(|| UNSET.into()),
             hint: "Password for RAR/ZIP compression",
             has_override: ov.compress_password.is_some(),
         },
@@ -1540,7 +1534,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
                 .url_override
                 .clone()
                 .or_else(|| cfg?.indexer_url.clone())
-                .unwrap_or_else(|| "—".into()),
+                .unwrap_or_else(|| UNSET.into()),
             hint: "Base URL, e.g. http://localhost:9696",
             has_override: app.prowlarr.url_override.is_some(),
         },
@@ -1552,7 +1546,7 @@ fn build_config_fields(app: &App) -> Vec<ConfigField> {
                 .as_deref()
                 .map(masked)
                 .or_else(|| cfg?.indexer_api_key.as_deref().map(masked))
-                .unwrap_or_else(|| "—".into()),
+                .unwrap_or_else(|| UNSET.into()),
             hint: "API key from Prowlarr Settings > General",
             has_override: app.prowlarr.api_key_override.is_some(),
         },

--- a/crates/upapasta/src/ui/mod.rs
+++ b/crates/upapasta/src/ui/mod.rs
@@ -97,6 +97,7 @@ fn draw_header(f: &mut Frame, area: Rect) {
 fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
     let titles = vec![
         " Dashboard ",
+        " Queue ",
         " Browser ",
         " History ",
         " NZB Vault ",
@@ -104,10 +105,11 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
     ];
     let selected = match app.state {
         AppState::Dashboard => 0,
-        AppState::Browser => 1,
-        AppState::History => 2,
-        AppState::NzbVault => 3,
-        AppState::Config => 4,
+        AppState::Queue => 1,
+        AppState::Browser => 2,
+        AppState::History => 3,
+        AppState::NzbVault => 4,
+        AppState::Config => 5,
     };
 
     let tabs = Tabs::new(titles)
@@ -130,6 +132,9 @@ fn draw_main(f: &mut Frame, app: &mut App, area: Rect) {
         }
         AppState::Dashboard => {
             draw_dashboard(f, app, area);
+        }
+        AppState::Queue => {
+            draw_queue(f, app, area);
         }
         AppState::History => {
             draw_history(f, app, area);
@@ -280,28 +285,50 @@ fn draw_nzb_detail_panel(f: &mut Frame, app: &App, area: Rect) {
 
         (Some(NzbBadge::Marked), Some(path)) => {
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
-            let lines = vec![
+            let info = app.queue_info(&path.to_string_lossy());
+            let mut lines = vec![
                 Line::from(vec![
-                    Span::styled(" File    ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        if info.is_dir {
+                            " Folder  "
+                        } else {
+                            " File    "
+                        },
+                        Style::default().fg(Color::DarkGray),
+                    ),
                     Span::raw(name.to_string()),
                 ]),
                 Line::from(""),
                 Line::from(Span::styled(
-                    " Marked for upload",
+                    " ✓ Queued for upload",
                     Style::default()
                         .fg(Color::Green)
                         .add_modifier(Modifier::BOLD),
                 )),
-                Line::from(""),
-                Line::from(Span::styled(
-                    " Press u to open the upload panel",
-                    Style::default().fg(Color::DarkGray),
-                )),
-                Line::from(Span::styled(
-                    " Press Space to unmark",
-                    Style::default().fg(Color::DarkGray),
-                )),
             ];
+            if info.is_dir {
+                lines.push(Line::from(vec![
+                    Span::styled(" NZB     ", Style::default().fg(Color::DarkGray)),
+                    Span::raw(format!(
+                        "{}.nzb  ({} files in one release)",
+                        info.nzb_name, info.file_count
+                    )),
+                ]));
+            } else {
+                lines.push(Line::from(vec![
+                    Span::styled(" NZB     ", Style::default().fg(Color::DarkGray)),
+                    Span::raw(format!("{}.nzb", info.nzb_name)),
+                ]));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                " Press u to open the upload panel",
+                Style::default().fg(Color::DarkGray),
+            )));
+            lines.push(Line::from(Span::styled(
+                " Press Space to unqueue",
+                Style::default().fg(Color::DarkGray),
+            )));
             (" NZB Status ".to_string(), lines)
         }
 
@@ -409,10 +436,7 @@ fn draw_browser_queue(f: &mut Frame, app: &App, area: Rect) {
         .iter()
         .enumerate()
         .map(|(i, item)| {
-            let name = std::path::Path::new(item)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or(item);
+            let info = app.queue_info(item);
             let style = if i == app.upload_queue.selected {
                 Style::default()
                     .fg(Color::Yellow)
@@ -420,9 +444,28 @@ fn draw_browser_queue(f: &mut Frame, app: &App, area: Rect) {
             } else {
                 Style::default().fg(Color::White)
             };
+            let (status_glyph, status_color) = match app.item_status(item) {
+                crate::app::FileStatus::Active => ("▶ ", Color::Cyan),
+                crate::app::FileStatus::Done => ("✓ ", Color::Green),
+                crate::app::FileStatus::Failed => ("✗ ", Color::Red),
+                crate::app::FileStatus::Pending => {
+                    if app.upload_in_progress {
+                        ("· ", Color::DarkGray)
+                    } else {
+                        ("○ ", Color::DarkGray)
+                    }
+                }
+            };
+            let (icon, suffix) = if info.is_dir {
+                ("📁 ", format!("  ({} files → 1 NZB)", info.file_count))
+            } else {
+                ("📄 ", String::new())
+            };
             ratatui::widgets::ListItem::new(Line::from(vec![
-                Span::styled("  ", Style::default()),
-                Span::styled(name.to_string(), style),
+                Span::styled(status_glyph, Style::default().fg(status_color)),
+                Span::styled(icon, Style::default()),
+                Span::styled(info.nzb_name, style),
+                Span::styled(suffix, Style::default().fg(Color::DarkGray)),
             ]))
         })
         .collect();
@@ -439,6 +482,113 @@ fn draw_browser_queue(f: &mut Frame, app: &App, area: Rect) {
     if !app.upload_queue.items.is_empty() {
         state.select(Some(app.upload_queue.selected));
     }
+    f.render_stateful_widget(list, area, &mut state);
+}
+
+/// Dedicated full-height Queue screen (F2): the single home for reviewing,
+/// reordering, removing and launching the upload queue built in the Browser.
+fn draw_queue(f: &mut Frame, app: &mut App, area: Rect) {
+    use crate::app::FileStatus;
+
+    // When the upload config panel is open (after `u`), it takes over the area.
+    if app.show_upload_confirm {
+        draw_upload_config_panel(f, app, area);
+        return;
+    }
+
+    if app.upload_queue.items.is_empty() {
+        let empty = Paragraph::new(
+            "The upload queue is empty.\n\n\
+             Go to the Browser tab (Tab / F3) →\n\
+             navigate with j/k, Enter to open a folder →\n\
+             press Space to queue a file or folder →\n\
+             come back here (F2) to review and upload.",
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Upload Queue (empty) "),
+        );
+        f.render_widget(empty, area);
+        return;
+    }
+
+    let mut total_bytes = 0u64;
+    let mut done = 0usize;
+    let mut failed = 0usize;
+    let items: Vec<ListItem> = app
+        .upload_queue
+        .items
+        .iter()
+        .enumerate()
+        .map(|(i, item)| {
+            let info = app.queue_info(item);
+            total_bytes += info.size_bytes;
+            let status = app.item_status(item);
+            match status {
+                FileStatus::Done => done += 1,
+                FileStatus::Failed => failed += 1,
+                _ => {}
+            }
+            let (glyph, color) = match status {
+                FileStatus::Active => ("▶", Color::Cyan),
+                FileStatus::Done => ("✓", Color::Green),
+                FileStatus::Failed => ("✗", Color::Red),
+                FileStatus::Pending => {
+                    if app.upload_in_progress {
+                        ("·", Color::DarkGray)
+                    } else {
+                        ("○", Color::DarkGray)
+                    }
+                }
+            };
+            let icon = if info.is_dir { "📁" } else { "📄" };
+            let detail = if info.is_dir {
+                format!("  {} files → 1 NZB", info.file_count)
+            } else {
+                String::new()
+            };
+            let name_style = if i == app.upload_queue.selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{} ", glyph), Style::default().fg(color)),
+                Span::raw(format!("{} ", icon)),
+                Span::styled(info.nzb_name, name_style),
+                Span::styled(detail, Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("  ({})", format_bytes(info.size_bytes)),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]))
+        })
+        .collect();
+
+    let n = app.upload_queue.items.len();
+    let title = if app.upload_in_progress {
+        format!(" Upload Queue ({n}) — {done} done · {failed} failed ")
+    } else {
+        format!(" Upload Queue ({n}) — {} total ", format_bytes(total_bytes))
+    };
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(Style::default().fg(Color::Green)),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    let mut state = ListState::default();
+    state.select(Some(app.upload_queue.selected));
     f.render_stateful_widget(list, area, &mut state);
 }
 
@@ -483,19 +633,28 @@ fn draw_upload_config_panel(f: &mut Frame, app: &App, area: Rect) {
         .iter()
         .take(6)
         .map(|p| {
+            let info = app.queue_info(p);
+            let suffix = if info.is_dir {
+                format!(" → {}.nzb ({} files)", info.nzb_name, info.file_count)
+            } else {
+                format!(" → {}.nzb", info.nzb_name)
+            };
+            let icon = if info.is_dir { "📁 " } else { "📄 " };
             let name = std::path::Path::new(p)
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or(p);
-            let max = (vchunks[0].width as usize).saturating_sub(4);
+            let prefix_len = icon.chars().count() + suffix.chars().count();
+            let max = (vchunks[0].width as usize).saturating_sub(prefix_len + 2);
             let short = if name.len() > max && max > 3 {
                 format!("{}…", &name[..max - 1])
             } else {
                 name.to_string()
             };
             Line::from(vec![
-                Span::styled(" • ", Style::default().fg(Color::DarkGray)),
+                Span::styled(icon, Style::default().fg(Color::DarkGray)),
                 Span::raw(short),
+                Span::styled(suffix, Style::default().fg(Color::DarkGray)),
             ])
         })
         .collect();
@@ -709,9 +868,9 @@ fn draw_dashboard_idle(f: &mut Frame, app: &mut App, area: Rect) {
         let idle = Paragraph::new(
             "No files in queue.\n\n\
              Go to Browser tab (Tab) →\n\
-             navigate with j/k/Enter →\n\
-             mark with Space →\n\
-             press u to queue & upload.",
+             navigate with j/k, Enter to open →\n\
+             queue a file or folder with Space →\n\
+             press u to upload.",
         )
         .block(
             Block::default()
@@ -898,7 +1057,6 @@ fn draw_par2_bar(f: &mut Frame, app: &App, area: Rect) {
 
 fn draw_upload_bar(f: &mut Frame, app: &App, area: Rect) {
     let p = &app.progress;
-    let is_paused = app.upload_paused;
 
     let upload_pct = p.progress_pct() as u16;
 
@@ -913,33 +1071,21 @@ fn draw_upload_bar(f: &mut Frame, app: &App, area: Rect) {
         "ETA --:--".to_string()
     };
 
-    let label = if is_paused {
-        "PAUSED".to_string()
-    } else {
-        format!(
-            "{}%  {} / {}  {}  {}",
-            upload_pct,
-            pesto::progress::format_size(p.done_bytes),
-            pesto::progress::format_size(p.total_bytes),
-            speed_str,
-            eta_str,
-        )
-    };
+    let label = format!(
+        "{}%  {} / {}  {}  {}",
+        upload_pct,
+        pesto::progress::format_size(p.done_bytes),
+        pesto::progress::format_size(p.total_bytes),
+        speed_str,
+        eta_str,
+    );
 
-    let gauge_style = if is_paused {
-        Style::default().fg(Color::Yellow).bg(Color::DarkGray)
-    } else {
-        Style::default()
-            .fg(Color::Green)
-            .bg(Color::DarkGray)
-            .add_modifier(Modifier::BOLD)
-    };
+    let gauge_style = Style::default()
+        .fg(Color::Green)
+        .bg(Color::DarkGray)
+        .add_modifier(Modifier::BOLD);
 
-    let title = if is_paused {
-        " UPLOAD — PAUSED  [p: resume  x: cancel] "
-    } else {
-        " UPLOAD  [p: pause  x: cancel] "
-    };
+    let title = " UPLOAD  [x: cancel] ";
 
     let gauge = Gauge::default()
         .block(
@@ -962,7 +1108,6 @@ fn draw_upload_bar(f: &mut Frame, app: &App, area: Rect) {
 fn draw_speed_sparkline(f: &mut Frame, app: &App, area: Rect) {
     let p = &app.progress;
     let spark_data: Vec<u64> = p.speed_history.iter().map(|&s| (s * 10.0) as u64).collect();
-    let is_paused = app.upload_paused;
 
     let sparkline = Sparkline::default()
         .block(
@@ -971,11 +1116,7 @@ fn draw_speed_sparkline(f: &mut Frame, app: &App, area: Rect) {
                 .title(format!(" Speed history ({} samples) ", spark_data.len())),
         )
         .data(&spark_data)
-        .style(if is_paused {
-            Style::default().fg(Color::DarkGray)
-        } else {
-            Style::default().fg(Color::Cyan)
-        });
+        .style(Style::default().fg(Color::Cyan));
     f.render_widget(sparkline, area);
 }
 
@@ -1029,12 +1170,17 @@ fn draw_per_file_progress(f: &mut Frame, app: &App, area: Rect) {
         let name_row = rows[i * 2];
         let gauge_row = rows[i * 2 + 1];
 
-        // Name line with status icon
+        // Name line with status icon. fp.name is the queue path; show its
+        // basename so a long absolute path does not crowd the gauge.
+        let display_name = std::path::Path::new(&fp.name)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&fp.name);
         let max_name = (name_row.width as usize).saturating_sub(4);
-        let short_name = if fp.name.len() > max_name && max_name > 3 {
-            format!("{}…", &fp.name[..max_name - 1])
+        let short_name = if display_name.len() > max_name && max_name > 3 {
+            format!("{}…", &display_name[..max_name - 1])
         } else {
-            fp.name.clone()
+            display_name.to_string()
         };
         let name_line = Line::from(vec![
             Span::styled(
@@ -1113,14 +1259,9 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
     }
 
     if app.upload_in_progress {
-        let pause_resume = if app.upload_paused {
-            "p: resume"
-        } else {
-            "p: pause"
-        };
         let help = format!(
-            "{}  •  {}  •  x: cancel  •  Tab: switch  •  q: quit",
-            app.status_bar.message, pause_resume
+            "{}  •  x: cancel  •  Tab: switch  •  q: quit",
+            app.status_bar.message
         );
         let status = Paragraph::new(help)
             .style(Style::default().fg(Color::DarkGray))
@@ -1129,23 +1270,34 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
+    if app.state == AppState::Queue && !app.upload_queue.items.is_empty() {
+        let hint = format!(
+            "{}  •  u: upload  •  d: remove  •  c: clear  •  J/K: reorder  •  Tab: switch",
+            app.status_bar.message
+        );
+        let status = Paragraph::new(hint)
+            .style(Style::default().fg(Color::DarkGray))
+            .block(Block::default().borders(Borders::TOP).title(" Status "));
+        f.render_widget(status, area);
+        return;
+    }
+
     if app.state == AppState::Browser {
         let n = app.upload_queue.items.len();
-        let marked = app.file_tree.marked_count();
-        let hint = if marked > 0 {
+        let filter_hint = if app.file_tree.filter_unbacked {
+            "n: show all"
+        } else {
+            "n: unbacked only"
+        };
+        let hint = if n > 0 {
             format!(
-                "{}  •  Space: mark ({} marked)  •  u: queue & upload  •  Enter: navigate  •  Tab: switch",
-                app.status_bar.message, marked
-            )
-        } else if n > 0 {
-            format!(
-                "{}  •  Space: mark files  •  u: upload queue ({} items)  •  Tab: switch",
-                app.status_bar.message, n
+                "{}  •  Space: queue/unqueue  •  u: upload ({} queued)  •  {}  •  Tab: switch",
+                app.status_bar.message, n, filter_hint
             )
         } else {
             format!(
-                "{}  •  Space: mark files  •  Enter: navigate  •  Tab: switch  •  q: quit",
-                app.status_bar.message
+                "{}  •  Space: queue file/folder  •  {}  •  Enter: open  •  Tab: switch",
+                app.status_bar.message, filter_hint
             )
         };
         let status = Paragraph::new(hint)

--- a/crates/upapasta/src/ui/theme.rs
+++ b/crates/upapasta/src/ui/theme.rs
@@ -1,0 +1,67 @@
+//! Central visual language for the TUI.
+//!
+//! One place to define the palette and glyphs so every screen reads as a single
+//! coherent app instead of a patchwork of per-widget color choices. Prefer these
+//! over hard-coded `Color::*` in the draw functions.
+
+use ratatui::style::{Color, Modifier, Style};
+
+// ── Palette ─────────────────────────────────────────────────────────────────
+
+/// Brand / primary accent (header, focused panel borders).
+pub const ACCENT: Color = Color::Cyan;
+/// Selection and "you are editing this" highlight.
+pub const FOCUS: Color = Color::Yellow;
+/// Secondary text: field labels, hints, inactive elements.
+pub const MUTED: Color = Color::DarkGray;
+/// Directories in listings.
+pub const DIR: Color = Color::Blue;
+
+// Semantic states — used for status glyphs, gauges and badges.
+pub const OK: Color = Color::Green;
+pub const ERR: Color = Color::Red;
+pub const ACTIVE: Color = Color::Cyan;
+
+// ── Glyphs (all single-width, terminal-safe — no emoji) ───────────────────────
+
+/// Prefix marker for a directory row (paired with a blank marker for files so
+/// columns stay aligned regardless of type).
+pub const DIR_MARK: &str = "▸ ";
+pub const FILE_MARK: &str = "  ";
+
+/// Status glyphs shared by the queue and per-file progress views.
+pub const ST_ACTIVE: &str = "▶";
+pub const ST_DONE: &str = "✓";
+pub const ST_FAILED: &str = "✗";
+pub const ST_PENDING: &str = "○";
+pub const ST_PENDING_RUN: &str = "·";
+
+// ── Style helpers ─────────────────────────────────────────────────────────────
+
+/// Label / secondary-text style.
+pub fn label() -> Style {
+    Style::default().fg(MUTED)
+}
+
+/// List highlight (selected line), shared across every list screen so the
+/// cursor looks the same everywhere.
+pub fn highlight() -> Style {
+    Style::default()
+        .fg(Color::Black)
+        .bg(FOCUS)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// `(glyph, color)` for a per-item upload status, used by the queue and the
+/// per-file progress views. `running` distinguishes a pending item during an
+/// active upload (a dot) from a pending item at rest (an open circle).
+pub fn status_glyph(status: crate::app::FileStatus, running: bool) -> (&'static str, Color) {
+    use crate::app::FileStatus;
+    match status {
+        FileStatus::Active => (ST_ACTIVE, ACTIVE),
+        FileStatus::Done => (ST_DONE, OK),
+        FileStatus::Failed => (ST_FAILED, ERR),
+        FileStatus::Pending if running => (ST_PENDING_RUN, MUTED),
+        FileStatus::Pending => (ST_PENDING, MUTED),
+    }
+}


### PR DESCRIPTION
## Summary

Bigger visual redesign of the upapasta TUI, plus a latent crash fix.

- **New `ui/theme.rs`** — central palette, single-width glyphs and style helpers (`label`, `highlight`, `status_glyph`) so every screen shares one visual language instead of per-widget color choices.
- **Top bar** — collapse the bordered header + tabs boxes (6 rows of chrome) into a single brand + inline tab strip with a thin separator rule, reclaiming ~4 rows of content.
- **Status bar** — single flush line with the message plus per-screen key hints; dropped the bordered box and trimmed hints so they no longer truncate.
- **Icons** — dropped double-width emoji file icons (which misaligned box-drawing) for a blue `▸ name/` directory marker + aligned file marker, applied across the file tree, queue and upload-config panels.
- **Upload Config panel** — replaced edge-to-edge rules with section headers (FILES/DESTINATION/SETTINGS), aligned columns and a left-bar selection mark; dropped the redundant Compress line.
- **Coherence** — wrapped the NZB Status panel, unified list selection highlight everywhere, shortened Config titles (hints moved to the status bar) and widened the label column.

## Bug fix

Truncating names by byte index panicked on multibyte UTF-8 (e.g. "Programação") in the Vault and other lists. Added a char-safe `truncate_str` helper, routed all six truncations through it, and covered it with tests.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (13 pass, incl. 3 new for `truncate_str`) — all green.
- Ran the TUI via tmux and visually confirmed every screen, including the Vault with 10k+ accented filenames (previously crashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)