### PR TITLE
fix: normalize angle brackets in STAT commands

### DIFF
--- a/crates/pesto/src/nntp/mod.rs
+++ b/crates/pesto/src/nntp/mod.rs
@@ -233,13 +233,17 @@ impl Connection {
         }
     }
 
-    /// Check whether an article with `message_id` (without angle brackets) is
-    /// present on the server, using the `STAT` command (RFC 3977 §6.2.4).
+    /// Check whether an article with `message_id` is present on the server,
+    /// using the `STAT` command (RFC 3977 §6.2.4).
+    ///
+    /// The `message_id` may be passed with or without angle brackets; they are
+    /// stripped before the command is sent.
     ///
     /// Returns `true` when the server responds 223 (article exists), `false`
     /// on 430 (not found). Any other response code is returned as an error.
     pub async fn stat(&mut self, message_id: &str) -> Result<bool> {
-        let resp = self.command(&format!("STAT <{message_id}>")).await?;
+        let id = message_id.trim_start_matches('<').trim_end_matches('>');
+        let resp = self.command(&format!("STAT <{id}>")).await?;
         match resp.code {
             223 => Ok(true),
             430 => Ok(false),

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -1681,13 +1681,10 @@ pub async fn check_articles(
     let max_attempts = config.check_retries.max(1) as usize;
 
     for (idx, seg) in segments.iter().enumerate() {
-        // Strip angle brackets for the STAT command.
-        let id = seg.message_id.trim_start_matches('<').trim_end_matches('>');
-
         let mut found = false;
         for attempt in 1..=max_attempts {
             match slot.ensure_connected().await {
-                Ok(conn) => match conn.stat(id).await {
+                Ok(conn) => match conn.stat(&seg.message_id).await {
                     Ok(true) => {
                         found = true;
                         break;


### PR DESCRIPTION
The sequential verify path (poster/mod.rs) passes Message-IDs to conn.stat() with angle brackets already present, but stat() wraps the argument in brackets unconditionally, producing malformed commands like "STAT <<<id@domain>>>".

check_articles() in the same file already worked around this by stripping brackets before calling. Move the normalization into stat() itself so callers can pass either format safely.

Without this fix --verify mode fails because servers reject the malformed STAT command as "not found", triggering useless retries.

Assisted-By: AI Assistant <ai@assistant.com>