### PR TITLE
fix(subject): follow yEnc draft v1.3 subject line specification

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -453,3 +453,26 @@ everything in a new `pesto::upload::run_upload()` public API.
   - `nzb_dir/downloaded/` — NZBs fetched from Prowlarr/indexers (badge `↓` yellow)
   - `nzb_dir/` and any other subdirectory — manually placed NZBs (badge `m` gray)
 - [x] **Fully recursive vault scan** — `collect_nzbs_recursive()` walks all subdirectories at any depth; origin derived from immediate parent folder name
+
+---
+
+## Deferred / Intentionally Not Implemented
+
+### Subject file counter `[N/M]`
+
+**Status:** Intentionally deferred.  
+**Rationale:** Tools like `nyuu` prefix subjects with `[filenum/total]` (e.g. `[1/5] "movie.mkv" yEnc (1/3)`).
+This requires knowing the total file count before posting the first article.
+
+In `pesto`, PAR2 files are generated asynchronously and appended to the queue after data files begin posting.
+Two-pass approaches (compute PAR2 first, then post) would add latency and complexity.
+One-pass with subject rewriting would require reposting already-sent articles.
+
+References:
+- yEnc draft v1.3: <http://www.yenc.org/yenc-draft.1.3.txt>
+- Mirror: <https://github.com/caronc/newsreap/blob/master/docs/yenc-draft.1.3.txt>
+
+This is a cosmetic nicety, _not a spec requirement_. If needed in the future, options include:
+- Count only source files (ignore PAR2 in total) — simple but inconsistent
+- Two-pass mode (compute PAR2 before posting) — adds latency
+- Post-PAR2-only subjects without counters — already works today

--- a/crates/pesto/src/article.rs
+++ b/crates/pesto/src/article.rs
@@ -193,12 +193,20 @@ pub fn random_from() -> String {
 
 /// Build a default subject line for one part of a file.
 ///
-/// Single-part files use just the name; multi-part files append `(part/total)`.
+/// Follows the yEnc draft v1.3 specification:
+/// - Primary: <http://www.yenc.org/yenc-draft.1.3.txt>
+/// - Mirror:  <https://github.com/caronc/newsreap/blob/master/docs/yenc-draft.1.3.txt>
+///
+/// Formats:
+/// - Single-part: `"name" yEnc`
+/// - Multi-part:  `"name" yEnc (part/total)`
+///
+/// See ROADMAP.md "Subject file counter" for why `[N/M]` prefixes are omitted.
 pub fn default_subject(name: &str, part: u32, total: u32) -> String {
     if total > 1 {
-        format!("{name} ({part}/{total})")
+        format!("\"{name}\" yEnc ({part}/{total})")
     } else {
-        name.to_string()
+        format!("\"{name}\" yEnc")
     }
 }
 
@@ -232,14 +240,14 @@ mod tests {
             message_id: "<id@pesto>".into(),
             from: "poster <p@example.com>".into(),
             newsgroups: vec!["alt.binaries.test".into(), "alt.binaries.misc".into()],
-            subject: "file.bin (1/2)".into(),
+            subject: "\"file.bin\" yEnc (1/2)".into(),
             date: None,
             no_archive: false,
         };
         let serialized = String::from_utf8(article.serialize(b"BODY")).unwrap();
         assert!(serialized.contains("From: poster <p@example.com>\r\n"));
         assert!(serialized.contains("Newsgroups: alt.binaries.test,alt.binaries.misc\r\n"));
-        assert!(serialized.contains("Subject: file.bin (1/2)\r\n"));
+        assert!(serialized.contains("Subject: \"file.bin\" yEnc (1/2)\r\n"));
         assert!(serialized.contains("Message-ID: <id@pesto>\r\n"));
         assert!(serialized.ends_with("\r\n\r\nBODY"));
     }
@@ -290,8 +298,8 @@ mod tests {
 
     #[test]
     fn default_subject_handles_single_and_multi_part() {
-        assert_eq!(default_subject("file.bin", 1, 1), "file.bin");
-        assert_eq!(default_subject("file.bin", 2, 5), "file.bin (2/5)");
+        assert_eq!(default_subject("file.bin", 1, 1), "\"file.bin\" yEnc");
+        assert_eq!(default_subject("file.bin", 2, 5), "\"file.bin\" yEnc (2/5)");
     }
 
     #[test]
@@ -360,13 +368,13 @@ mod tests {
     #[test]
     fn default_subject_single_part_has_no_parens() {
         let s = default_subject("movie.mkv", 1, 1);
-        assert!(!s.contains('('));
-        assert_eq!(s, "movie.mkv");
+        assert!(!s.contains("(1/1)"));
+        assert_eq!(s, "\"movie.mkv\" yEnc");
     }
 
     #[test]
     fn default_subject_last_part() {
-        assert_eq!(default_subject("f.bin", 10, 10), "f.bin (10/10)");
+        assert_eq!(default_subject("f.bin", 10, 10), "\"f.bin\" yEnc (10/10)");
     }
 
     // ── format_rfc2822 additional edge cases ──────────────────────────────────

--- a/crates/pesto/src/nzb.rs
+++ b/crates/pesto/src/nzb.rs
@@ -271,8 +271,30 @@ fn xml_text(line: &str, tag: &str) -> Option<String> {
     Some(xml_unescape(&line[open_end + 1..close_start]))
 }
 
-/// Strip the ` (N/M)` part-indicator suffix from a subject line.
+/// Strip the `"name" yEnc (N/M)` or `"name" yEnc` wrapper from a subject line.
+///
+/// Handles both the current yEnc-spec format and the legacy `name (N/M)` format.
+/// Backward compatibility is needed because `pesto --merge-season` can read
+/// NZBs created before the yEnc spec fix (e.g. subjects like `movie.mkv (1/3)`).
 fn strip_part_suffix(subject: &str) -> String {
+    let unquote = |s: &str| {
+        if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+            s[1..s.len() - 1].to_string()
+        } else {
+            s.to_string()
+        }
+    };
+
+    // New format: "name" yEnc (N/M)  →  strip " yEnc (N/M)"
+    // New format: "name" yEnc        →  strip " yEnc"
+    if let Some(pos) = subject.rfind(" yEnc") {
+        let tail = &subject[pos + 5..];
+        if tail.is_empty() || tail.starts_with(" (") {
+            return unquote(&subject[..pos]);
+        }
+    }
+
+    // Legacy format: name (N/M)
     if let Some(pos) = subject.rfind(" (") {
         let tail = &subject[pos..];
         if tail.contains('/') && tail.ends_with(')') {
@@ -380,8 +402,8 @@ mod tests {
             &no_meta(),
             false,
         );
-        // The subject is the obfuscated name; the real name lives in `name`.
-        assert!(xml.contains("subject=\"deadbeefcafe0000\""));
+        // The subject is the obfuscated name wrapped in quotes; the real name lives in `name`.
+        assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc\""));
         assert!(xml.contains("name=\"secret-movie.mkv\""));
         assert!(!xml.contains("subject=\"secret-movie.mkv\""));
     }
@@ -405,7 +427,7 @@ mod tests {
             true,
         );
         // Both subject= and name= must show only the obfuscated token.
-        assert!(xml.contains("subject=\"deadbeefcafe0000\""));
+        assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc\""));
         assert!(xml.contains("name=\"deadbeefcafe0000\""));
         assert!(!xml.contains("secret-movie.mkv"));
     }
@@ -467,7 +489,7 @@ mod tests {
         assert!(xml.contains("name=\"movie.par2\""));
         assert!(xml.contains("name=\"movie.vol00+01.par2\""));
         // Multi-part subject rendered correctly for movie.mkv.
-        assert!(xml.contains("subject=\"movie.mkv (1/3)\""));
+        assert!(xml.contains("subject=\"&quot;movie.mkv&quot; yEnc (1/3)\""));
     }
 
     #[test]
@@ -494,7 +516,7 @@ mod tests {
             &no_meta(),
             false,
         );
-        assert!(xml.contains("subject=\"file.bin\""));
+        assert!(xml.contains("subject=\"&quot;file.bin&quot; yEnc\""));
         assert!(!xml.contains("(1/1)"));
     }
 
@@ -538,7 +560,7 @@ mod tests {
             &no_meta(),
             false,
         );
-        assert!(xml.contains("subject=\"big.bin (1/5)\""));
+        assert!(xml.contains("subject=\"&quot;big.bin&quot; yEnc (1/5)\""));
         assert!(!xml.contains("(2/5)"));
     }
 
@@ -638,5 +660,20 @@ mod tests {
         let parsed = parse(&xml).expect("parse must succeed");
         // message_id must carry angle brackets.
         assert_eq!(parsed.segments[0].message_id, "<msgid@host>");
+    }
+
+    #[test]
+    fn strip_part_suffix_new_format_multi_part() {
+        assert_eq!(strip_part_suffix("\"name\" yEnc (1/3)"), "name");
+    }
+
+    #[test]
+    fn strip_part_suffix_new_format_single_part() {
+        assert_eq!(strip_part_suffix("\"name\" yEnc"), "name");
+    }
+
+    #[test]
+    fn strip_part_suffix_legacy_format() {
+        assert_eq!(strip_part_suffix("name (1/3)"), "name");
     }
 }


### PR DESCRIPTION
References:
- yEnc draft v1.3: http://www.yenc.org/yenc-draft.1.3.txt
- Mirror: https://github.com/caronc/newsreap/blob/master/docs/yenc-draft.1.3.txt

Subjects were missing the mandatory `"yEnc"` keyword and quotes around the filename, producing `movie.mkv (1/3)` instead of the spec format `"movie.mkv" yEnc (1/3)`

The yEnc draft v1.3 allows an optional file size in bytes, e.g. `"name" yEnc 12345` or `"name" yEnc (part/total) 12345` but the size is optional. We intentionally omit it to keep subjects concise:

- Single-part: `"name" yEnc`
- Multi-part: `"name" yEnc (part/total)`

This applies to all posts (obfuscated and non-obfuscated), since the yEnc keyword only signals the encoding type — it doesn't leak content.

NZB parser retains backward compatibility for `pesto --merge-season` so old NZBs with the previous format still parse correctly.

ROADMAP.md documents why a `[N/M]` file counter prefix (like nyuu uses) is intentionally omitted (also optional) — PAR2 files are generated asynchronously, so the total file count isn't known before posting begins.

Assisted-By: AI Assistant <ai@assistant.com>