### PR TITLE
fix(nzb): reflect actual from/date in generated .nzb files

### DIFF
--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -995,12 +995,7 @@ async fn run_single_upload(
                         .or_else(|| effective_password.clone()),
                     category: config.nzb_category.clone(),
                 };
-                let xml = pesto::nzb::generate(
-                    &config.from,
-                    &outcome.groups,
-                    &outcome.segments,
-                    &nzb_meta,
-                );
+                let xml = pesto::nzb::generate(&outcome.groups, &outcome.segments, &nzb_meta);
                 tokio::fs::write(out, &xml)
                     .await
                     .with_context(|| format!("writing nzb file `{}`", out.display()))?;
@@ -1301,7 +1296,7 @@ async fn run_batch(
                     .or_else(|| config.compress_password.clone()),
                 category: config.nzb_category.clone(),
             };
-            let xml = pesto::nzb::generate(&config.from, &all_groups, &all_segments, &nzb_meta);
+            let xml = pesto::nzb::generate(&all_groups, &all_segments, &nzb_meta);
             tokio::fs::write(&season_path, &xml)
                 .await
                 .with_context(|| format!("writing season nzb `{}`", season_path.display()))?;
@@ -1703,7 +1698,7 @@ fn run_merge_season(dir: &Path, display_name: Option<&str>) -> Result<()> {
             password: None,
             category: None,
         };
-        let xml = pesto::nzb::generate(&poster, &all_groups, &combined_segments, &meta);
+        let xml = pesto::nzb::generate(&all_groups, &combined_segments, &meta);
 
         std::fs::write(&output_path, &xml)
             .with_context(|| format!("writing {}", output_path.display()))?;

--- a/crates/pesto/src/nzb.rs
+++ b/crates/pesto/src/nzb.rs
@@ -31,17 +31,11 @@ pub struct NzbMeta {
 ///
 /// The NZB always carries the real filename regardless of obfuscation mode.
 /// Only what goes on the wire (subject + yEnc `name=`) is obfuscated.
-pub fn generate(
-    poster: &str,
-    groups: &[String],
-    segments: &[PostedSegment],
-    meta: &NzbMeta,
-) -> String {
-    let date = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
+///
+/// NZB 1.1 has one `poster` and one `date` per `<file>` element. When
+/// obfuscation rotates these per article (paranoid mode) the first segment's
+/// values are used as the file-level representative.
+pub fn generate(groups: &[String], segments: &[PostedSegment], meta: &NzbMeta) -> String {
     let mut out = String::new();
     out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     out.push_str(
@@ -74,7 +68,7 @@ pub fn generate(
             .iter()
             .take_while(|s| &s.file_name == name)
             .count();
-        write_file(&mut out, poster, groups, date, &segments[i..i + count]);
+        write_file(&mut out, groups, &segments[i..i + count]);
         i += count;
     }
 
@@ -83,19 +77,20 @@ pub fn generate(
 }
 
 /// Write a single `<file>` element for one file's segments.
-fn write_file(
-    out: &mut String,
-    poster: &str,
-    groups: &[String],
-    date: u64,
-    segs: &[PostedSegment],
-) {
+fn write_file(out: &mut String, groups: &[String], segs: &[PostedSegment]) {
     let first = &segs[0];
     // The NZB always carries the real filename so that download clients can
     // restore it correctly. Only what goes on the wire (subject + yEnc name=)
     // is obfuscated — see ObfuscateMode::Full in poster/mod.rs.
     let file_name = &first.file_name;
     let subject = default_subject(&first.subject_name, 1, first.total);
+    let poster = &first.from;
+    let date = first.date.unwrap_or_else(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    });
 
     out.push_str(&format!(
         "  <file name=\"{}\" poster=\"{}\" date=\"{}\" subject=\"{}\">\n",
@@ -160,6 +155,9 @@ pub fn parse(content: &str) -> anyhow::Result<ParsedNzb> {
     let mut in_groups = false;
     let mut in_file = false;
 
+    let mut current_poster = String::new();
+    let mut current_date: Option<u64> = None;
+
     for line in content.lines() {
         let t = line.trim();
 
@@ -167,9 +165,11 @@ pub fn parse(content: &str) -> anyhow::Result<ParsedNzb> {
             in_file = true;
             in_groups = false;
             current_file_name = xml_attr(t, "name").context("<file> missing name attribute")?;
+            current_poster = xml_attr(t, "poster").unwrap_or_default();
             if poster.is_empty() {
-                poster = xml_attr(t, "poster").unwrap_or_default();
+                poster = current_poster.clone();
             }
+            current_date = xml_attr(t, "date").and_then(|s| s.parse().ok());
             let subject = xml_attr(t, "subject").unwrap_or_default();
             current_subject_name = strip_part_suffix(&subject);
             file_segment_start = segments.len();
@@ -211,7 +211,8 @@ pub fn parse(content: &str) -> anyhow::Result<ParsedNzb> {
                 total: 0, // fixed up when </file> is seen
                 message_id,
                 bytes,
-                from: String::new(),
+                from: current_poster.clone(),
+                date: current_date,
             });
         } else if t.starts_with("<meta ") {
             let kind = xml_attr(t, "type").unwrap_or_default();
@@ -327,7 +328,8 @@ mod tests {
             total,
             message_id: id.to_string(),
             bytes: 500,
-            from: String::new(),
+            from: "poster <p@x>".to_string(),
+            date: None,
         }
     }
 
@@ -337,7 +339,7 @@ mod tests {
 
     #[test]
     fn empty_input_yields_a_well_formed_skeleton() {
-        let xml = generate("p <p@x>", &["alt.test".into()], &[], &no_meta());
+        let xml = generate(&["alt.test".into()], &[], &no_meta());
         assert!(xml.starts_with("<?xml version=\"1.0\""));
         assert!(xml.contains("<nzb xmlns="));
         assert!(xml.trim_end().ends_with("</nzb>"));
@@ -351,7 +353,7 @@ mod tests {
             seg("a.bin", 2, 2, "<id-a2@pesto>"),
             seg("b.bin", 1, 1, "<id-b1@pesto>"),
         ];
-        let xml = generate("poster <p@x>", &["alt.test".into()], &segments, &no_meta());
+        let xml = generate(&["alt.test".into()], &segments, &no_meta());
 
         assert_eq!(xml.matches("<file ").count(), 2);
         assert_eq!(xml.matches("<segment ").count(), 3);
@@ -373,8 +375,9 @@ mod tests {
             message_id: "<id@x>".to_string(),
             bytes: 500,
             from: String::new(),
+            date: None,
         };
-        let xml = generate("poster <p@x>", &["alt.test".into()], &[segment], &no_meta());
+        let xml = generate(&["alt.test".into()], &[segment], &no_meta());
         // The wire subject is obfuscated; the NZB always carries the real filename.
         assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc\""));
         assert!(xml.contains("name=\"secret-movie.mkv\""));
@@ -392,8 +395,9 @@ mod tests {
             message_id: "<id@x>".to_string(),
             bytes: 500,
             from: String::new(),
+            date: None,
         };
-        let xml = generate("poster <p@x>", &["alt.test".into()], &[segment], &no_meta());
+        let xml = generate(&["alt.test".into()], &[segment], &no_meta());
         // Subject on the wire is obfuscated; NZB name= always uses the real filename.
         assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc\""));
         assert!(xml.contains("name=\"secret-movie.mkv\""));
@@ -402,8 +406,10 @@ mod tests {
 
     #[test]
     fn xml_special_characters_are_escaped() {
-        let segments = vec![seg("a&b<c>.bin", 1, 1, "<i@x>")];
-        let xml = generate("a \"b\" & <c>", &["alt.test".into()], &segments, &no_meta());
+        let mut s = seg("a&b<c>.bin", 1, 1, "<i@x>");
+        s.from = "a \"b\" & <c>".to_string();
+        let segments = vec![s];
+        let xml = generate(&["alt.test".into()], &segments, &no_meta());
         assert!(xml.contains("poster=\"a &quot;b&quot; &amp; &lt;c&gt;\""));
         assert!(xml.contains("a&amp;b&lt;c&gt;.bin"));
     }
@@ -415,7 +421,7 @@ mod tests {
             password: Some("s3cr3t".into()),
             category: Some("TV > HD".into()),
         };
-        let xml = generate("p <p@x>", &["alt.test".into()], &[], &meta);
+        let xml = generate(&["alt.test".into()], &[], &meta);
         assert!(xml.contains("<meta type=\"name\">My Upload</meta>"));
         assert!(xml.contains("<meta type=\"password\">s3cr3t</meta>"));
         assert!(xml.contains("<meta type=\"category\">TV &gt; HD</meta>"));
@@ -425,7 +431,7 @@ mod tests {
     fn head_block_always_present() {
         // <head> is emitted even when no meta fields are set, for maximum
         // compatibility with strict NZB parsers.
-        let xml = generate("p <p@x>", &["alt.test".into()], &[], &no_meta());
+        let xml = generate(&["alt.test".into()], &[], &no_meta());
         assert!(xml.contains("<head>"));
         assert!(xml.contains("</head>"));
         assert!(!xml.contains("<meta"));
@@ -441,7 +447,7 @@ mod tests {
             seg("movie.par2", 1, 1, "<p1@x>"),
             seg("movie.vol00+01.par2", 1, 1, "<p2@x>"),
         ];
-        let xml = generate("poster <p@x>", &groups, &segments, &no_meta());
+        let xml = generate(&groups, &segments, &no_meta());
 
         // Three distinct <file> blocks.
         assert_eq!(xml.matches("<file ").count(), 3);
@@ -457,12 +463,7 @@ mod tests {
     #[test]
     fn multiple_groups_all_emitted() {
         let groups = vec!["alt.binaries.a".into(), "alt.binaries.b".into()];
-        let xml = generate(
-            "p <p@x>",
-            &groups,
-            &[seg("f.bin", 1, 1, "<id@x>")],
-            &no_meta(),
-        );
+        let xml = generate(&groups, &[seg("f.bin", 1, 1, "<id@x>")], &no_meta());
         assert!(xml.contains("<group>alt.binaries.a</group>"));
         assert!(xml.contains("<group>alt.binaries.b</group>"));
         assert_eq!(xml.matches("<group>").count(), 2);
@@ -471,7 +472,6 @@ mod tests {
     #[test]
     fn single_part_subject_has_no_part_indicator() {
         let xml = generate(
-            "p <p@x>",
             &["alt.test".into()],
             &[seg("file.bin", 1, 1, "<id@x>")],
             &no_meta(),
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn escape_apostrophe() {
         let segments = vec![seg("it's.bin", 1, 1, "<id@x>")];
-        let xml = generate("p <p@x>", &["alt.test".into()], &segments, &no_meta());
+        let xml = generate(&["alt.test".into()], &segments, &no_meta());
         assert!(xml.contains("it&apos;s.bin"), "apostrophe must be escaped");
         assert!(!xml.contains("it's.bin"));
     }
@@ -495,7 +495,7 @@ mod tests {
         let mut s = seg("Season01/ep01.mkv", 1, 1, "<id@x>");
         s.file_name = "Season01/ep01.mkv".into();
         s.subject_name = "Season01/ep01.mkv".into();
-        let xml = generate("p <p@x>", &["alt.test".into()], &[s], &no_meta());
+        let xml = generate(&["alt.test".into()], &[s], &no_meta());
         assert!(xml.contains("name=\"Season01/ep01.mkv\""));
     }
 
@@ -507,7 +507,7 @@ mod tests {
             seg("big.bin", 2, 5, "<a2@x>"),
             seg("big.bin", 3, 5, "<a3@x>"),
         ];
-        let xml = generate("p <p@x>", &["alt.test".into()], &segments, &no_meta());
+        let xml = generate(&["alt.test".into()], &segments, &no_meta());
         assert!(xml.contains("subject=\"&quot;big.bin&quot; yEnc (1/5)\""));
         assert!(!xml.contains("(2/5)"));
     }
@@ -516,14 +516,13 @@ mod tests {
     fn segment_bytes_attribute_is_exact() {
         let mut s = seg("f.bin", 1, 1, "<id@x>");
         s.bytes = 123_456;
-        let xml = generate("p <p@x>", &["alt.test".into()], &[s], &no_meta());
+        let xml = generate(&["alt.test".into()], &[s], &no_meta());
         assert!(xml.contains("bytes=\"123456\""));
     }
 
     #[test]
     fn date_attribute_is_a_nonzero_number() {
         let xml = generate(
-            "p <p@x>",
             &["alt.test".into()],
             &[seg("f.bin", 1, 1, "<id@x>")],
             &no_meta(),
@@ -546,7 +545,7 @@ mod tests {
             password: Some("hunter2".into()),
             category: None,
         };
-        let xml = generate("p <p@x>", &["alt.test".into()], &[], &meta);
+        let xml = generate(&["alt.test".into()], &[], &meta);
         assert!(xml.contains("<meta type=\"password\">hunter2</meta>"));
         assert!(!xml.contains("type=\"name\""));
         assert!(!xml.contains("type=\"category\""));
@@ -567,7 +566,7 @@ mod tests {
             password: None,
             category: Some("TV".into()),
         };
-        let xml = generate("poster <p@x>", &groups, &segs, &meta);
+        let xml = generate(&groups, &segs, &meta);
         let parsed = parse(&xml).expect("parse must succeed");
 
         assert_eq!(parsed.poster, "poster <p@x>");
@@ -589,7 +588,7 @@ mod tests {
             seg("ep01.mkv", 2, 2, "<e1p2@x>"),
             seg("ep02.mkv", 1, 1, "<e2p1@x>"),
         ];
-        let xml = generate("p <p@x>", &groups, &segs, &no_meta());
+        let xml = generate(&groups, &segs, &no_meta());
         let parsed = parse(&xml).expect("parse must succeed");
 
         assert_eq!(parsed.segments.len(), 3);
@@ -603,7 +602,7 @@ mod tests {
     #[test]
     fn parse_strips_angle_brackets_and_re_adds_them() {
         let segs = vec![seg("f.bin", 1, 1, "<msgid@host>")];
-        let xml = generate("p <p@x>", &["alt.test".into()], &segs, &no_meta());
+        let xml = generate(&["alt.test".into()], &segs, &no_meta());
         let parsed = parse(&xml).expect("parse must succeed");
         // message_id must carry angle brackets.
         assert_eq!(parsed.segments[0].message_id, "<msgid@host>");

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -2017,11 +2017,7 @@ pub async fn repost_failed_tasks(
             });
             if let Some(tx) = events {
                 let _ = tx.send(ProgressEvent::Status {
-                    text: format!(
-                        "retry: {}/{} segment(s) recovered",
-                        recovered.len(),
-                        i + 1
-                    ),
+                    text: format!("retry: {}/{} segment(s) recovered", recovered.len(), i + 1),
                 });
             }
         } else {
@@ -2034,7 +2030,9 @@ pub async fn repost_failed_tasks(
     }
 
     if let Some(tx) = events {
-        let _ = tx.send(ProgressEvent::Status { text: String::new() });
+        let _ = tx.send(ProgressEvent::Status {
+            text: String::new(),
+        });
     }
 
     Ok(recovered)

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -121,6 +121,9 @@ pub struct PostedSegment {
     pub message_id: String,
     pub bytes: u64,
     pub from: String,
+    /// Unix timestamp of the `Date` header used on the wire, or `None` when
+    /// the config omitted the date (so the server supplies it).
+    pub date: Option<u64>,
 }
 
 /// A segment that failed to post during the upload run. Carries enough
@@ -1296,6 +1299,8 @@ async fn worker(
             headers: Vec<u8>,
             encoded: yenc::EncodedPart,
             encode_time: Duration,
+            /// Unix timestamp of the Date header used for this article.
+            date: Option<u64>,
         }
         let mut pending: Vec<Pending> = Vec::with_capacity(batch.len());
 
@@ -1312,6 +1317,7 @@ async fn worker(
                     .get(&task.meta.real_name, task.part)
                     .map(str::to_string)
                 {
+                    let (_, date_ts) = resolve_date(shared.config.date.as_deref());
                     shared.results.lock().unwrap().push(PostedSegment {
                         file_name: task.meta.real_name.clone(),
                         subject_name: task.subject_name.clone(),
@@ -1321,6 +1327,7 @@ async fn worker(
                         message_id: existing_id,
                         bytes: 0,
                         from: task.from.clone(),
+                        date: date_ts,
                     });
                     let bytes = task.data.len() as u64;
                     shared.release_buffer(task.data);
@@ -1348,12 +1355,13 @@ async fn worker(
             );
             let encode_time = t_enc.elapsed();
             let message_id = generate_message_id(shared.config.message_id_domain.as_deref());
+            let (date_str, date_ts) = resolve_date(shared.config.date.as_deref());
             let article = Article {
                 message_id: message_id.clone(),
                 from: task.from.clone(),
                 newsgroups: shared.post_group.clone(),
                 subject: default_subject(&task.meta.subject_name, task.part, task.total),
-                date: resolve_date(shared.config.date.as_deref()),
+                date: date_str,
                 no_archive: shared.config.no_archive,
             };
             let headers = article.build_headers();
@@ -1363,6 +1371,7 @@ async fn worker(
                 headers,
                 encoded,
                 encode_time,
+                date: date_ts,
             });
         }
 
@@ -1381,6 +1390,7 @@ async fn worker(
                     message_id: p.message_id,
                     bytes: (p.headers.len() + p.encoded.body.len()) as u64,
                     from: p.task.from.clone(),
+                    date: p.date,
                 });
                 let bytes = p.task.data.len() as u64;
                 shared.release_buffer(p.task.data);
@@ -1489,6 +1499,7 @@ async fn worker(
                 p.headers.len() + p.encoded.body.len(),
                 posted,
                 &last_err,
+                p.date,
             );
         } else {
             // ── Pipelined path ───────────────────────────────────────────────
@@ -1584,6 +1595,7 @@ async fn worker(
                     p.headers.len() + p.encoded.body.len(),
                     posted,
                     &last_err,
+                    p.date,
                 );
             }
         }
@@ -1636,15 +1648,26 @@ fn pick_post_group(groups: &[String]) -> Vec<String> {
     }
 }
 
-/// Compute the `Date:` header value from the config `date` option.
+/// Compute the `Date:` header value and its Unix timestamp from the config
+/// `date` option.
 ///
-/// - `None` / `"now"` → current UTC time formatted as RFC 2822
-/// - `"random"` → random time within the last 30 days
-/// - any other string → used verbatim (caller-supplied RFC 2822 timestamp)
-fn resolve_date(mode: Option<&str>) -> Option<String> {
+/// - `None` → `(None, None)` — header omitted, server fills it in.
+/// - `"now"` → current UTC time formatted as RFC 2822.
+/// - `"random"` → random time within the last 30 days.
+/// - any other string → used verbatim (caller-supplied RFC 2822 timestamp).
+///
+/// Returns `(rfc_2822_string, unix_timestamp_secs)`.
+fn resolve_date(mode: Option<&str>) -> (Option<String>, Option<u64>) {
     match mode {
-        None => None,
-        Some("now") => Some(format_rfc2822(SystemTime::now())),
+        None => (None, None),
+        Some("now") => {
+            let now = SystemTime::now();
+            let ts = now
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_secs();
+            (Some(format_rfc2822(now)), Some(ts))
+        }
         Some("random") => {
             // Pick a random offset in [0, 30 days) before now.
             use std::collections::hash_map::RandomState;
@@ -1654,9 +1677,17 @@ fn resolve_date(mode: Option<&str>) -> Option<String> {
             let t = SystemTime::now()
                 .checked_sub(Duration::from_secs(offset_secs))
                 .unwrap_or(UNIX_EPOCH);
-            Some(format_rfc2822(t))
+            let ts = t
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_secs();
+            (Some(format_rfc2822(t)), Some(ts))
         }
-        Some(fixed) => Some(fixed.to_string()),
+        Some(fixed) => {
+            // For fixed dates we don't parse back to unix; the NZB will fall
+            // back to SystemTime::now() if the caller needs a timestamp.
+            (Some(fixed.to_string()), None)
+        }
     }
 }
 
@@ -1669,6 +1700,7 @@ fn commit_result(
     wire_bytes: usize,
     posted: bool,
     last_err: &str,
+    date: Option<u64>,
 ) {
     if posted {
         if let Some(resume) = &shared.resume {
@@ -1687,6 +1719,7 @@ fn commit_result(
             message_id,
             bytes: wire_bytes as u64,
             from: task.from.clone(),
+            date,
         });
     } else {
         record_failure(shared, &task.meta, &task, last_err);
@@ -1933,12 +1966,13 @@ pub async fn repost_failed_tasks(
             None,
         );
         let message_id = generate_message_id(config.message_id_domain.as_deref());
+        let (date_str, date_ts) = resolve_date(config.date.as_deref());
         let article = Article {
             message_id: message_id.clone(),
             from: task.from.clone(),
             newsgroups: groups.to_vec(),
             subject: default_subject(&task.subject_name, task.part, task.total),
-            date: resolve_date(config.date.as_deref()),
+            date: date_str,
             no_archive: config.no_archive,
         };
         let headers = article.build_headers();
@@ -1979,6 +2013,7 @@ pub async fn repost_failed_tasks(
                 message_id,
                 bytes: wire_bytes,
                 from: task.from.clone(),
+                date: date_ts,
             });
             if let Some(tx) = events {
                 let _ = tx.send(ProgressEvent::Status {
@@ -2260,27 +2295,33 @@ mod tests {
 
     #[test]
     fn resolve_date_none_omits_header() {
-        assert_eq!(resolve_date(None), None);
+        assert_eq!(resolve_date(None), (None, None));
     }
 
     #[test]
     fn resolve_date_now_returns_rfc2822() {
-        let d = resolve_date(Some("now")).unwrap();
+        let (d, ts) = resolve_date(Some("now"));
+        let d = d.unwrap();
         // Should look like "Mon, 01 Jan 2024 00:00:00 +0000".
         assert!(d.ends_with("+0000"));
         assert!(d.contains(':'));
+        assert!(ts.unwrap() > 0);
     }
 
     #[test]
     fn resolve_date_random_returns_rfc2822() {
-        let d = resolve_date(Some("random")).unwrap();
+        let (d, ts) = resolve_date(Some("random"));
+        let d = d.unwrap();
         assert!(d.ends_with("+0000"));
+        assert!(ts.unwrap() > 0);
     }
 
     #[test]
     fn resolve_date_fixed_is_returned_verbatim() {
         let fixed = "Tue, 14 Jan 2025 10:00:00 +0000";
-        assert_eq!(resolve_date(Some(fixed)).as_deref(), Some(fixed));
+        let (d, ts) = resolve_date(Some(fixed));
+        assert_eq!(d.as_deref(), Some(fixed));
+        assert!(ts.is_none());
     }
 
     // ── RateLimiter ───────────────────────────────────────────────────────────

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -275,8 +275,7 @@ pub async fn run_upload(
                     .or_else(|| effective_password.clone()),
                 category: config.nzb_category.clone(),
             };
-            let xml =
-                crate::nzb::generate(&config.from, &outcome.groups, &outcome.segments, &nzb_meta);
+            let xml = crate::nzb::generate(&outcome.groups, &outcome.segments, &nzb_meta);
             match tokio::fs::write(&out, &xml).await {
                 Ok(()) => {
                     emit_status(&progress_tx, format!("wrote nzb: {}", out.display()));

--- a/crates/pesto/tests/integration.rs
+++ b/crates/pesto/tests/integration.rs
@@ -157,7 +157,6 @@ async fn posts_every_segment_to_a_mock_server() {
 
     // The collected segments must be enough to build a valid .nzb.
     let nzb = pesto::nzb::generate(
-        &config.from,
         &config.groups,
         &outcome.segments,
         &pesto::nzb::NzbMeta::default(),

--- a/crates/pesto/tests/obfuscated_directory.rs
+++ b/crates/pesto/tests/obfuscated_directory.rs
@@ -138,7 +138,6 @@ async fn full_obfuscation_randomises_subjects_but_keeps_paths_in_nzb() {
 
     // The NZB always carries the real filename even in full obfuscation mode.
     let nzb = pesto::nzb::generate(
-        &config.from,
         &config.groups,
         &outcome.segments,
         &pesto::nzb::NzbMeta::default(),
@@ -152,6 +151,67 @@ async fn full_obfuscation_randomises_subjects_but_keeps_paths_in_nzb() {
     assert!(
         !nzb.contains("subject=\"Show"),
         "a real path leaked into the nzb subject"
+    );
+
+    // Verify that each <file> element has a distinct poster (from) value.
+    let mut posters: Vec<&str> = Vec::new();
+    for line in nzb.lines() {
+        if line.trim().starts_with("<file ") {
+            if let Some(start) = line.find("poster=\"") {
+                let start = start + 8;
+                if let Some(end) = line[start..].find('"') {
+                    posters.push(&line[start..start + end]);
+                }
+            }
+        }
+    }
+    // Distinct files should have distinct posters in full obfuscation mode.
+    let unique_posters: std::collections::HashSet<_> = posters.iter().copied().collect();
+    assert_eq!(
+        unique_posters.len(),
+        posters.len(),
+        "posters should be unique per file in full obfuscation mode"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn full_obfuscation_nzb_reflects_random_dates() {
+    let (root, args, _expected) = build_tree();
+
+    let mut config = dry_run_config(ObfuscateMode::Full);
+    config.date = Some("random".into());
+    let inputs = expand_inputs(&args).unwrap();
+    let outcome = post_files(&config, &inputs).await.unwrap();
+
+    let nzb = pesto::nzb::generate(
+        &config.groups,
+        &outcome.segments,
+        &pesto::nzb::NzbMeta::default(),
+    );
+
+    // Collect all date="..." values from the NZB.
+    let mut dates: Vec<u64> = Vec::new();
+    for line in nzb.lines() {
+        if line.trim().starts_with("<file ") {
+            if let Some(start) = line.find("date=\"") {
+                let start = start + 6;
+                if let Some(end) = line[start..].find('"') {
+                    let date_str = &line[start..start + end];
+                    if let Ok(ts) = date_str.parse::<u64>() {
+                        dates.push(ts);
+                    }
+                }
+            }
+        }
+    }
+
+    // Distinct files should have distinct dates when date = random.
+    let unique_dates: std::collections::HashSet<_> = dates.iter().copied().collect();
+    assert!(
+        unique_dates.len() > 1 || dates.len() <= 1,
+        "random dates should vary across files; got {dates:?}"
     );
 
     std::fs::remove_dir_all(&root).ok();

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1594,8 +1594,7 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
                             .or_else(|| config.compress_password.clone()),
                         category: config.nzb_category.clone(),
                     };
-                    let xml =
-                        pesto::nzb::generate(&config.from, &config.groups, &all_segments, &meta);
+                    let xml = pesto::nzb::generate(&config.groups, &all_segments, &meta);
                     match std::fs::write(&out, xml) {
                         Ok(()) => {
                             let _ = tx.send(AppEvent::Progress(format!(


### PR DESCRIPTION
Generated .nzb files were always using `config.from` and `SystemTime::now()` regardless of what was actually posted on the wire. In full/paranoid obfuscation mode this leads to incorrect metadata into the .nzb.

`resolve_date()` now returns both the RFC 2822 string (for the wire) and the Unix timestamp (for the .nzb) so both use the same value. The timestamp is stored in `PostedSegment.date` and read back when generating the .nzb instead of inventing a fresh timestamp at write time.

Also fixes `nzb::parse` to preserve poster/date in segments so the parse → generate → parse round-trip works correctly (needed for --merge-season).

Assisted-By: AI Assistant <ai@assistant.com>