### PR TITLE
fix(resume): parse resume from the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,15 +433,25 @@ deleted if `--watch-done` is not set.
 
 ### Upload resume
 
-If a posting run is interrupted (Ctrl-C, network failure, etc.), `pesto` saves
+If a posting run is interrupted (Ctrl-C, network failure, etc.), `pesto` can save
 state to a `.pesto-state` sidecar file next to the `.nzb`. On the next run with
 the same output path, already-posted articles are skipped and their `Message-ID`s
 are reused, so the final `.nzb` is complete and correct.
 
+Resume is **off by default**. Enable it for a single run:
+
 ```bash
-# Disable resume — ignore any existing state and start from scratch
-pesto --no-resume movie.mkv
+pesto --resume movie.mkv
 ```
+
+Or enable it permanently in config.toml:
+```toml
+[output]
+resume = true
+```
+
+State files are created beside the `.nzb` and are not automatically cleaned up.
+You can delete them manually when you no longer need them.
 
 ### Post-verification via STAT
 
@@ -668,7 +678,6 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--par2 <PERCENT>` | `posting.par2` | `10` | PAR2 recovery percentage (0 = off) |
 | `--par2-only` | — | off | Write PAR2 files only; do not post |
 | `--dry-run` | — | off | Encode only; never touch the network |
-| `--no-resume` | — | off | Ignore existing state; start fresh |
 | `--verify` | `posting.verify` | off | Confirm each article inline with STAT (one round-trip per article) |
 | `--check` | `posting.check` | off | Run a STAT pass over all articles after the upload completes |
 | `--check-delay <SECS>` | `posting.check_delay` | `30` | Seconds to wait before the STAT pass; implies `--check` |

--- a/README.md
+++ b/README.md
@@ -674,10 +674,19 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--date <VALUE>` | `posting.date` | server-supplied (random when obfuscating) | `now`, `random` (last 24 h), or an RFC 2822 timestamp |
 | `--no-archive` | `posting.no_archive` | off | Add `X-No-Archive: yes` to every article |
 | `--message-id-domain <D>` | `posting.message_id_domain` | random | Fixed domain for `Message-ID` headers |
+| `--pipeline-depth <N>` | `posting.pipeline_depth` | `0` | Articles to pipeline per connection (`0` = adaptive) |
+| `--stdin-name <NAME>` | — | — | Filename for stdin (`-`) input |
 | **Reliability** | | | |
 | `--par2 <PERCENT>` | `posting.par2` | `10` | PAR2 recovery percentage (0 = off) |
 | `--par2-only` | — | off | Write PAR2 files only; do not post |
 | `--dry-run` | — | off | Encode only; never touch the network |
+| `--resume` | `output.resume` | off | Resume interrupted upload from `.pesto-state` file |
+| `--slice-size <SIZE>` | — | auto | Manual PAR2 slice size (e.g. `"1 MiB"`) |
+| `--slice-count <N>` | — | auto | Target number of PAR2 input slices |
+| `--recovery-count <N>` | — | auto | Exact number of PAR2 recovery blocks |
+| `--memory-limit <SIZE>` | `posting.par2_memory_limit` | `"1 GiB"` | Max RAM for PAR2 recovery buffers |
+| `--threads <N>` | — | auto | Threads for PAR2 compute (`0` = physical cores) |
+| `--simd <MODE>` | — | auto | Force SIMD: `auto`, `avx2-gfni`, `avx2`, `ssse3`, `scalar` |
 | `--verify` | `posting.verify` | off | Confirm each article inline with STAT (one round-trip per article) |
 | `--check` | `posting.check` | off | Run a STAT pass over all articles after the upload completes |
 | `--check-delay <SECS>` | `posting.check_delay` | `30` | Seconds to wait before the STAT pass; implies `--check` |
@@ -693,6 +702,10 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--nzb-name <NAME>` | `output.nzb_name` | — | `<meta type="name">` in the `.nzb` |
 | `--nzb-password <PASS>` | `output.nzb_password` | — | `<meta type="password">` in the `.nzb` |
 | `--nzb-category <CAT>` | `output.nzb_category` | — | `<meta type="category">` in the `.nzb` |
+| `--nzb-conflict <MODE>` | `output.nzb_conflict` | overwrite | `overwrite`, `rename`, or `fail` on existing NZB |
+| `--no-overwrite` | — | — | Alias for `--nzb-conflict=rename` |
+| `-v`, `--verbose` | — | off | Increase log verbosity (`-v`=INFO, `-vv`=DEBUG, `-vvv`=TRACE) |
+| `--log-file <FILE>` | — | — | Redirect verbose logs to file (requires `-v`) |
 | `--nfo` / `--no-nfo` | `output.nfo` | off | Generate a `.nfo` file alongside the `.nzb` |
 | `--post-hook <CMD>` | `output.post_hook` | — | Shell command run after each successful upload |
 | `--history` / `--no-history` | `output.history` | on | Write a record to the upload history log |
@@ -703,6 +716,7 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | **Batch / watch** | | | |
 | `--each` | — | off | Post each top-level entry as its own release |
 | `--season` | — | off | Like `--each`, plus a consolidated season `.nzb` |
+| `--merge-season <DIR>` | — | — | Merge per-episode NZBs in DIR into season NZBs (offline) |
 | `--jobs <N>` | — | `1` | Parallel uploads for `--each`/`--season` (0 = CPU count) |
 | `--watch <DIR>` | — | — | Watch a directory and post new entries automatically |
 | `--watch-done <DIR>` | — | delete | Move completed watch entries here instead of deleting |

--- a/config.example.toml
+++ b/config.example.toml
@@ -155,8 +155,9 @@ groups = ["alt.binaries.test"]
 # resume — save upload progress to a .pesto-state sidecar file after every
 # article. If the upload is interrupted, re-running the same command resumes
 # from where it stopped instead of starting over. The state file is placed
-# beside the .nzb output (same name, .pesto-state extension) and deleted
-# automatically on successful completion. Default: false.
+# beside the .nzb output (same name, .pesto-state extension). Note: state
+# files are NOT automatically deleted on success — remove them manually.
+# Default: false.
 # resume = false
 
 # nfo — generate a .nfo text file alongside the .nzb. Default: false.

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -439,15 +439,25 @@ deleted if `--watch-done` is not set.
 
 ### Upload resume
 
-If a posting run is interrupted (Ctrl-C, network failure, etc.), `pesto` saves
+If a posting run is interrupted (Ctrl-C, network failure, etc.), `pesto` can save
 state to a `.pesto-state` sidecar file next to the `.nzb`. On the next run with
 the same output path, already-posted articles are skipped and their `Message-ID`s
 are reused, so the final `.nzb` is complete and correct.
 
+Resume is **off by default**. Enable it for a single run:
+
 ```bash
-# Disable resume — ignore any existing state and start from scratch
-pesto --no-resume movie.mkv
+pesto --resume movie.mkv
 ```
+
+Or enable it permanently in config.toml:
+```toml
+[output]
+resume = true
+```
+
+State files are created beside the .nzb and are not automatically cleaned up.
+You can delete them manually when you no longer need them.
 
 ### Post-verification via STAT
 
@@ -626,7 +636,6 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--par2 <PERCENT>` | `posting.par2` | `10` | PAR2 recovery percentage (0 = off) |
 | `--par2-only` | — | off | Write PAR2 files only; do not post |
 | `--dry-run` | — | off | Encode only; never touch the network |
-| `--no-resume` | — | off | Ignore existing state; start fresh |
 | `--verify` | `posting.verify` | off | Confirm each article with STAT |
 | `--rate <RATE>` | `posting.upload_rate` | unlimited | Max upload rate (e.g. `"50 MiB/s"`) |
 | **Compression** | | | |

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -632,11 +632,24 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--date <VALUE>` | `posting.date` | server-supplied | `now`, `random`, or an RFC 2822 timestamp |
 | `--no-archive` | `posting.no_archive` | off | Add `X-No-Archive: yes` to every article |
 | `--message-id-domain <D>` | `posting.message_id_domain` | random | Fixed domain for `Message-ID` headers |
+| `--pipeline-depth <N>` | `posting.pipeline_depth` | `0` | Articles to pipeline per connection (`0` = adaptive) |
+| `--stdin-name <NAME>` | — | — | Filename for stdin (`-`) input |
 | **Reliability** | | | |
 | `--par2 <PERCENT>` | `posting.par2` | `10` | PAR2 recovery percentage (0 = off) |
 | `--par2-only` | — | off | Write PAR2 files only; do not post |
 | `--dry-run` | — | off | Encode only; never touch the network |
+| `--resume` | `output.resume` | off | Resume interrupted upload from `.pesto-state` file |
+| `--slice-size <SIZE>` | — | auto | Manual PAR2 slice size (e.g. `"1 MiB"`) |
+| `--slice-count <N>` | — | auto | Target number of PAR2 input slices |
+| `--recovery-count <N>` | — | auto | Exact number of PAR2 recovery blocks |
+| `--memory-limit <SIZE>` | `posting.par2_memory_limit` | `"1 GiB"` | Max RAM for PAR2 recovery buffers |
+| `--threads <N>` | — | auto | Threads for PAR2 compute (`0` = physical cores) |
+| `--simd <MODE>` | — | auto | Force SIMD: `auto`, `avx2-gfni`, `avx2`, `ssse3`, `scalar` |
 | `--verify` | `posting.verify` | off | Confirm each article with STAT |
+| `--check` | `posting.check` | off | Run a STAT pass over all articles after upload |
+| `--check-delay <SECS>` | `posting.check_delay` | `30` | Seconds to wait before STAT pass; implies `--check` |
+| `--check-retries <N>` | `posting.check_retries` | `3` | STAT attempts per article during check pass |
+| `--check-connections <N>` | `posting.check_connections` | same as upload | Parallel connections for STAT pass |
 | `--rate <RATE>` | `posting.upload_rate` | unlimited | Max upload rate (e.g. `"50 MiB/s"`) |
 | **Compression** | | | |
 | `--compress [FORMAT]` | `compression.format` | off | Bundle into an archive (`7z`, `zip`, `rar`) |
@@ -647,6 +660,10 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--nzb-name <NAME>` | `output.nzb_name` | — | `<meta type="name">` in the `.nzb` |
 | `--nzb-password <PASS>` | `output.nzb_password` | — | `<meta type="password">` in the `.nzb` |
 | `--nzb-category <CAT>` | `output.nzb_category` | — | `<meta type="category">` in the `.nzb` |
+| `--nzb-conflict <MODE>` | `output.nzb_conflict` | overwrite | `overwrite`, `rename`, or `fail` on existing NZB |
+| `--no-overwrite` | — | — | Alias for `--nzb-conflict=rename` |
+| `-v`, `--verbose` | — | off | Increase log verbosity (`-v`=INFO, `-vv`=DEBUG, `-vvv`=TRACE) |
+| `--log-file <FILE>` | — | — | Redirect verbose logs to file (requires `-v`) |
 | `--nfo` / `--no-nfo` | `output.nfo` | off | Generate a `.nfo` file alongside the `.nzb` |
 | `--post-hook <CMD>` | `output.post_hook` | — | Shell command run after each successful upload |
 | `--history` / `--no-history` | `output.history` | on | Write a record to the upload history log |

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -189,10 +189,6 @@ struct Cli {
     #[arg(long)]
     resume: bool,
 
-    /// Accepted for backward compatibility; no-op (resume is off by default).
-    #[arg(long, hide = true)]
-    no_resume: bool,
-
     /// After posting each article, confirm it is present on the server with
     /// STAT and repost if not found [config: posting.verify, default false].
     #[arg(long)]

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -380,7 +380,7 @@ struct Cli {
 
     /// Redirect verbose log output to FILE instead of stderr. The terminal
     /// progress panel is kept active when this flag is set. Has no effect
-    /// without -v [config: output.log_file].
+    /// without -v.
     #[arg(long, value_name = "FILE")]
     log_file: Option<PathBuf>,
 

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -440,7 +440,7 @@ impl Cli {
             par2_recovery_count: self.recovery_count,
             threads: self.threads,
             simd: Some(self.simd),
-            resume: if self.resume { Some(true) } else { Some(false) },
+            resume: if self.resume { Some(true) } else { None },
             verify: if self.verify { Some(true) } else { None },
             upload_rate: self
                 .rate


### PR DESCRIPTION
`resume = true` from config.toml were not been correct parsed.

Also update some documentation related to it (and other flags).

Remove the `--no-resume` as not implemented.