### PR TITLE
fix(obfuscate): resolve date once per file

### DIFF
--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -673,7 +673,7 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--line-length <CHARS>` | `posting.line_length` | `128` | yEnc encoded line length |
 | `--retries <N>` | `posting.retries` | `3` | Post attempts per segment |
 | `--obfuscate[=MODE]` | `posting.obfuscate` | `none` | `none` or `full`; bare flag = `full` |
-| `--date <VALUE>` | `posting.date` | server-supplied | `now`, `random`, or an RFC 2822 timestamp |
+| `--date <VALUE>` | `posting.date` | server-supplied (random when obfuscating) | `now`, `random`, or an RFC 2822 timestamp |
 | `--no-archive` | `posting.no_archive` | off | Add `X-No-Archive: yes` to every article |
 | `--message-id-domain <D>` | `posting.message_id_domain` | random | Fixed domain for `Message-ID` headers |
 | `--pipeline-depth <N>` | `posting.pipeline_depth` | `0` | Articles to pipeline per connection (`0` = adaptive) |

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -230,8 +230,9 @@ struct Cli {
     nzb_category: Option<String>,
 
     /// `Date:` header for each article: `now` (current time), `random`
-    /// (random time within the last 30 days), or a fixed RFC 2822 timestamp.
-    /// Omit to let the server supply the date [config: posting.date].
+    /// (random time within the last 24 hours), or a fixed RFC 2822 timestamp.
+    /// Omit to let the server supply the date. When obfuscation is active
+    /// and no date is set, the default changes to `random` [config: posting.date].
     #[arg(long, value_name = "DATE")]
     date: Option<String>,
 

--- a/crates/pesto/src/nzb.rs
+++ b/crates/pesto/src/nzb.rs
@@ -85,7 +85,8 @@ fn write_file(out: &mut String, groups: &[String], segs: &[PostedSegment]) {
     let file_name = &first.file_name;
     let subject = default_subject(&first.subject_name, 1, first.total);
     let poster = &first.from;
-    let date = first.date.unwrap_or_else(|| {
+    let (_rfc_date, unix_date) = &first.date;
+    let date = unix_date.unwrap_or_else(|| {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -212,7 +213,7 @@ pub fn parse(content: &str) -> anyhow::Result<ParsedNzb> {
                 message_id,
                 bytes,
                 from: current_poster.clone(),
-                date: current_date,
+                date: (None, current_date),
             });
         } else if t.starts_with("<meta ") {
             let kind = xml_attr(t, "type").unwrap_or_default();
@@ -329,7 +330,7 @@ mod tests {
             message_id: id.to_string(),
             bytes: 500,
             from: "poster <p@x>".to_string(),
-            date: None,
+            date: (None, None),
         }
     }
 
@@ -375,7 +376,7 @@ mod tests {
             message_id: "<id@x>".to_string(),
             bytes: 500,
             from: String::new(),
-            date: None,
+            date: (None, None),
         };
         let xml = generate(&["alt.test".into()], &[segment], &no_meta());
         // The wire subject is obfuscated; the NZB always carries the real filename.
@@ -395,7 +396,7 @@ mod tests {
             message_id: "<id@x>".to_string(),
             bytes: 500,
             from: String::new(),
-            date: None,
+            date: (None, None),
         };
         let xml = generate(&["alt.test".into()], &[segment], &no_meta());
         // Subject on the wire is obfuscated; NZB name= always uses the real filename.

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -121,9 +121,9 @@ pub struct PostedSegment {
     pub message_id: String,
     pub bytes: u64,
     pub from: String,
-    /// Unix timestamp of the `Date` header used on the wire, or `None` when
-    /// the config omitted the date (so the server supplies it).
-    pub date: Option<u64>,
+    /// Date header as `(rfc_string, unix_timestamp)`. Both parts are preserved
+    /// so fixed dates survive round-trips and retries.
+    pub date: (Option<String>, Option<u64>),
 }
 
 /// A segment that failed to post during the upload run. Carries enough
@@ -136,6 +136,9 @@ pub struct FailedTask {
     pub part: u32,
     pub total: u32,
     pub from: String,
+    /// Date header as `(rfc_string, unix_timestamp)`. Both are preserved so
+    /// fixed dates (which have `Some` RFC but `None` timestamp) are not lost.
+    pub date: (Option<String>, Option<u64>),
 }
 
 /// The result of a posting run.
@@ -161,6 +164,9 @@ struct FileMeta {
     /// identity is generated per file so segments cannot be correlated
     /// across files by the From header.
     from: String,
+    /// Date header resolved once per file: `(rfc_string, unix_timestamp)`.
+    /// Fixed dates have `Some` RFC but `None` timestamp.
+    date: (Option<String>, Option<u64>),
     size: u64,
 }
 
@@ -176,6 +182,10 @@ struct PostTask {
     /// Per-article From header. In paranoid mode each article gets a unique
     /// identity; otherwise this mirrors `meta.from`.
     from: String,
+    /// Date header for this article: `(rfc_string, unix_timestamp)`.
+    /// In paranoid mode each article gets a unique value; otherwise this
+    /// mirrors `meta.date`.
+    date: (Option<String>, Option<u64>),
 }
 
 struct Shared {
@@ -295,12 +305,14 @@ pub async fn post_files_with_progress_and_cancel(
                 (obfuscated.clone(), obfuscated, random_from())
             }
         };
+        let date = resolve_date(config.date.as_deref());
         metas.push(Arc::new(FileMeta {
             path: path.clone(),
             real_name,
             subject_name,
             yenc_name,
             from,
+            date,
             size: md.len(),
         }));
     }
@@ -1161,6 +1173,7 @@ async fn push_par2_file(
             (obfuscated.clone(), obfuscated, random_from())
         }
     };
+    let date = resolve_date(shared.config.date.as_deref());
 
     let meta = Arc::new(FileMeta {
         path: path.clone(),
@@ -1168,6 +1181,7 @@ async fn push_par2_file(
         subject_name,
         yenc_name,
         from,
+        date,
         size,
     });
 
@@ -1299,8 +1313,8 @@ async fn worker(
             headers: Vec<u8>,
             encoded: yenc::EncodedPart,
             encode_time: Duration,
-            /// Unix timestamp of the Date header used for this article.
-            date: Option<u64>,
+            /// Date header as (rfc_string, unix_timestamp) for this article.
+            date: (Option<String>, Option<u64>),
         }
         let mut pending: Vec<Pending> = Vec::with_capacity(batch.len());
 
@@ -1317,7 +1331,6 @@ async fn worker(
                     .get(&task.meta.real_name, task.part)
                     .map(str::to_string)
                 {
-                    let (_, date_ts) = resolve_date(shared.config.date.as_deref());
                     shared.results.lock().unwrap().push(PostedSegment {
                         file_name: task.meta.real_name.clone(),
                         subject_name: task.subject_name.clone(),
@@ -1327,7 +1340,7 @@ async fn worker(
                         message_id: existing_id,
                         bytes: 0,
                         from: task.from.clone(),
-                        date: date_ts,
+                        date: task.date.clone(),
                     });
                     let bytes = task.data.len() as u64;
                     shared.release_buffer(task.data);
@@ -1355,8 +1368,8 @@ async fn worker(
             );
             let encode_time = t_enc.elapsed();
             let message_id = generate_message_id(shared.config.message_id_domain.as_deref());
-            let (date_str, date_ts) = resolve_date(shared.config.date.as_deref());
-            if let Some(d) = &date_str {
+            let (rfc_date, _ts) = &task.date;
+            if let Some(d) = &rfc_date {
                 debug!(segment = %message_id, date = %d, "article date");
             }
             let article = Article {
@@ -1364,17 +1377,18 @@ async fn worker(
                 from: task.from.clone(),
                 newsgroups: shared.post_group.clone(),
                 subject: default_subject(&task.meta.subject_name, task.part, task.total),
-                date: date_str,
+                date: rfc_date.clone(),
                 no_archive: shared.config.no_archive,
             };
             let headers = article.build_headers();
+            let task_date = task.date.clone();
             pending.push(Pending {
                 task,
                 message_id,
                 headers,
                 encoded,
                 encode_time,
-                date: date_ts,
+                date: task_date,
             });
         }
 
@@ -1393,7 +1407,7 @@ async fn worker(
                     message_id: p.message_id,
                     bytes: (p.headers.len() + p.encoded.body.len()) as u64,
                     from: p.task.from.clone(),
-                    date: p.date,
+                    date: p.date.clone(),
                 });
                 let bytes = p.task.data.len() as u64;
                 shared.release_buffer(p.task.data);
@@ -1623,10 +1637,15 @@ fn make_task(
     data: Vec<u8>,
     config: &Config,
 ) -> PostTask {
-    let (subject_name, from) = if config.obfuscate == ObfuscateMode::Paranoid {
-        (obfuscated_name(), random_from())
+    let (subject_name, from, date) = if config.obfuscate == ObfuscateMode::Paranoid {
+        let date = resolve_date(config.date.as_deref());
+        (obfuscated_name(), random_from(), date)
     } else {
-        (meta.subject_name.clone(), meta.from.clone())
+        (
+            meta.subject_name.clone(),
+            meta.from.clone(),
+            meta.date.clone(),
+        )
     };
     PostTask {
         meta,
@@ -1636,6 +1655,7 @@ fn make_task(
         data,
         subject_name,
         from,
+        date,
     }
 }
 
@@ -1709,7 +1729,7 @@ fn commit_result(
     wire_bytes: usize,
     posted: bool,
     last_err: &str,
-    date: Option<u64>,
+    date: (Option<String>, Option<u64>),
 ) {
     if posted {
         if let Some(resume) = &shared.resume {
@@ -1758,6 +1778,7 @@ fn record_failure(shared: &Shared, meta: &FileMeta, task: &PostTask, error: &str
         part: task.part,
         total: task.total,
         from: task.from.clone(),
+        date: task.date.clone(),
     });
 }
 
@@ -1837,12 +1858,13 @@ pub async fn repost_missing_segments(
             config.line_length,
             None,
         );
+        let (rfc_date, _ts) = &seg.date;
         let article = Article {
             message_id: seg.message_id.clone(),
             from: seg.from.clone(),
             newsgroups: config.groups.clone(),
             subject: default_subject(&seg.subject_name, seg.part, seg.total),
-            date: None,
+            date: rfc_date.clone(),
             no_archive: config.no_archive,
         };
         let headers = article.build_headers();
@@ -1975,13 +1997,13 @@ pub async fn repost_failed_tasks(
             None,
         );
         let message_id = generate_message_id(config.message_id_domain.as_deref());
-        let (date_str, date_ts) = resolve_date(config.date.as_deref());
+        let (rfc_date, _ts) = &task.date;
         let article = Article {
             message_id: message_id.clone(),
             from: task.from.clone(),
             newsgroups: groups.to_vec(),
             subject: default_subject(&task.subject_name, task.part, task.total),
-            date: date_str,
+            date: rfc_date.clone(),
             no_archive: config.no_archive,
         };
         let headers = article.build_headers();
@@ -2022,7 +2044,7 @@ pub async fn repost_failed_tasks(
                 message_id,
                 bytes: wire_bytes,
                 from: task.from.clone(),
-                date: date_ts,
+                date: task.date.clone(),
             });
             if let Some(tx) = events {
                 let _ = tx.send(ProgressEvent::Status {
@@ -2437,6 +2459,7 @@ mod tests {
             subject_name: name.into(),
             yenc_name: name.into(),
             from: String::new(),
+            date: (None, None),
             size: 0,
         }
     }
@@ -2576,6 +2599,7 @@ mod tests {
             data: vec![],
             subject_name: "ep.mkv".into(),
             from: String::new(),
+            date: (None, None),
         };
         record_failure(&shared, &task.meta, &task, "timeout");
         let failures = shared.failures.lock().unwrap();

--- a/crates/pesto/tests/obfuscated_directory.rs
+++ b/crates/pesto/tests/obfuscated_directory.rs
@@ -90,7 +90,7 @@ fn build_tree() -> (std::path::PathBuf, Vec<std::path::PathBuf>, Vec<String>) {
     for rel in rels {
         let path = root.join(rel);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(&path, vec![0x5Au8; 1000]).unwrap();
+        std::fs::write(&path, vec![0x5Au8; 100_000]).unwrap();
     }
 
     let args = vec![root.join("ShowA"), root.join("ShowB")];
@@ -214,6 +214,39 @@ async fn full_obfuscation_nzb_reflects_random_dates() {
         unique_dates.len() > 1 || dates.len() <= 1,
         "random dates should vary across files; got {dates:?}"
     );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn full_obfuscation_same_file_same_date() {
+    let (root, args, expected) = build_tree();
+
+    let mut config = dry_run_config(ObfuscateMode::Full);
+    config.date = Some("random".into());
+    let inputs = expand_inputs(&args).unwrap();
+    let outcome = post_files(&config, &inputs).await.unwrap();
+
+    // Every segment of the same file must share the exact same date.
+    for rel in &expected {
+        let segs: Vec<_> = outcome
+            .segments
+            .iter()
+            .filter(|s| &s.file_name == rel)
+            .collect();
+        assert!(
+            segs.len() > 1 || expected.len() == 1,
+            "need multiple segments per file to test date sharing"
+        );
+        let first_date = segs[0].date.clone();
+        for seg in &segs[1..] {
+            assert_eq!(
+                seg.date, first_date,
+                "segments of `{rel}` have different dates: {:?} vs {:?}",
+                first_date, seg.date
+            );
+        }
+    }
 
     std::fs::remove_dir_all(&root).ok();
 }


### PR DESCRIPTION
08e37a6 added `PostedSegment.date` so the NZB could reflect what was
actually sent on the wire.  That fixed the output side but left the
input side unchanged: `resolve_date()` was still called once per
segment in the worker loop.

In `ObfuscateMode::Full` with date = "random", every segment of the
same file received a different random timestamp on the wire, while
the NZB (one date per `<file>`) could only record the first
segment's value.  The wire and the NZB disagreed for all
subsequent segments.

Move the `resolve_date()` call to where the file-level metadata is
built (`post_files` / `post_one_file`) and thread the resulting tuple
through `FileMeta` -> `PostTask` -> `PostedSegment` so every segment of
a file shares the exact same date.

For Paranoid mode we keep the per-segment behaviour:
`make_task()` calls `resolve_date()` again when building each task.

Storing the full `(Option<String>, Option<u64>)` tuple (instead of
just the timestamp) preserves fixed dates: `resolve_date("Tue, 14
Jan 2025...")` returns `(Some("..."), None)`, and we need the
`Some(...)` part for the wire.

Change `PostedSegment.date` from `Option<u64>` to `(Option<String>,
Option<u64>)` so the full tuple is preserved end-to-end.  This
ensures:

  * Fixed dates survive round-trips — `resolve_date("Tue, 14 Jan
    2025...")` returns `(Some("..."), None)` and we need the
    `Some(...)` part for the wire on retries

  * `repost_missing_segments()` and `repost_failed_tasks()` reuse the
    exact original date instead of generating a new random one

  * Every struct uses the same type, making the data flow
    consistent across the whole pipeline

Also preserve the date in `FailedTask` so retries stay consistent
with the existing NZB, and increase test file sizes so the
multi-segment per-file date sharing is actually exercised.

Note: setting an explicit date  (`date = "now"` or `date = "Tue, 14
Jan 2025 10:00:00 +0000"`) suppresses the default random behaviour
to either full or paranoid.

Assisted-By: AI Assistant <ai@assistant.com>