### PR TITLE
fix(config): enable check when check_delay is set in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--jobs <N>` | — | `1` | Parallel uploads for `--each`/`--season` (0 = CPU count) |
 | `--watch <DIR>` | — | — | Watch a directory and post new entries automatically |
 | `--watch-done <DIR>` | — | delete | Move completed watch entries here instead of deleting |
-| `--watch-interval <SECS>` | `watch.poll_interval` | `30` | Poll interval for `--watch` |
+| `--watch-interval <SECS>` | — | `30` | Poll interval for `--watch` |
 
 ---
 

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -723,7 +723,7 @@ post_hook = "powershell -ExecutionPolicy Bypass -File \"%APPDATA%\\pesto\\hooks\
 | `--jobs <N>` | — | `1` | Parallel uploads for `--each`/`--season` (0 = CPU count) |
 | `--watch <DIR>` | — | — | Watch a directory and post new entries automatically |
 | `--watch-done <DIR>` | — | delete | Move completed watch entries here instead of deleting |
-| `--watch-interval <SECS>` | `watch.poll_interval` | `30` | Poll interval for `--watch` |
+| `--watch-interval <SECS>` | — | `30` | Poll interval for `--watch` |
 
 ---
 

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -347,7 +347,7 @@ struct Cli {
     watch_done: Option<PathBuf>,
 
     /// How often (in seconds) to poll the watched directory for new entries
-    /// [config: watch.poll_interval, default 30].
+    /// [default: 30].
     #[arg(long, value_name = "SECS", default_value = "30")]
     watch_interval: u64,
 

--- a/crates/pesto/src/config/parse.rs
+++ b/crates/pesto/src/config/parse.rs
@@ -235,7 +235,8 @@ impl Config {
             check: cli
                 .check
                 .unwrap_or_else(|| file.posting.check.unwrap_or(false))
-                || cli.check_delay_secs.is_some(),
+                || cli.check_delay_secs.is_some()
+                || file.posting.check_delay.is_some(),
             check_retries: cli
                 .check_retries
                 .unwrap_or_else(|| file.posting.check_retries.unwrap_or(3)),

--- a/crates/pesto/src/config/parse.rs
+++ b/crates/pesto/src/config/parse.rs
@@ -173,9 +173,7 @@ impl Config {
             threads: cli.threads.unwrap_or(0), // 0 means auto
             simd: cli.simd.unwrap_or_default(),
             verify: cli.verify.or(file.posting.verify).unwrap_or(false),
-            resume: cli
-                .resume
-                .unwrap_or_else(|| file.output.resume.unwrap_or(false)),
+            resume: cli.resume.or(file.output.resume).unwrap_or(false),
             upload_rate: {
                 if let Some(rate) = cli.upload_rate {
                     rate
@@ -193,9 +191,7 @@ impl Config {
             nzb_dir: cli.nzb_dir.or(file.output.nzb_dir),
             indexer_url: file.output.indexer.url,
             indexer_api_key: file.output.indexer.api_key,
-            history: cli
-                .history
-                .unwrap_or_else(|| file.output.history.unwrap_or(true)),
+            history: cli.history.or(file.output.history).unwrap_or(true),
             history_dir: file.output.history_dir.map(|s| {
                 if s.starts_with("~/") {
                     std::env::var_os("HOME")
@@ -222,7 +218,7 @@ impl Config {
             pre_hook: cli.pre_hook.or(file.output.pre_hook),
             post_hook: cli.post_hook.or(file.output.post_hook),
             no_hooks: cli.no_hooks,
-            nfo: cli.nfo.unwrap_or_else(|| file.output.nfo.unwrap_or(false)),
+            nfo: cli.nfo.or(file.output.nfo).unwrap_or(false),
             nzb_conflict: cli
                 .nzb_conflict
                 .or(file.output.nzb_conflict)
@@ -231,18 +227,19 @@ impl Config {
             bell: file.output.bell.unwrap_or(false),
             check_delay_secs: cli
                 .check_delay_secs
-                .unwrap_or_else(|| file.posting.check_delay.unwrap_or(30)),
-            check: cli
-                .check
-                .unwrap_or_else(|| file.posting.check.unwrap_or(false))
+                .or(file.posting.check_delay)
+                .unwrap_or(30),
+            check: cli.check.or(file.posting.check).unwrap_or(false)
                 || cli.check_delay_secs.is_some()
                 || file.posting.check_delay.is_some(),
             check_retries: cli
                 .check_retries
-                .unwrap_or_else(|| file.posting.check_retries.unwrap_or(3)),
+                .or(file.posting.check_retries)
+                .unwrap_or(3),
             check_connections: cli
                 .check_connections
-                .unwrap_or_else(|| file.posting.check_connections.unwrap_or(0)),
+                .or(file.posting.check_connections)
+                .unwrap_or(0),
             // 0 = adaptive; any positive value is the explicit fixed depth.
             pipeline_depth: cli
                 .pipeline_depth


### PR DESCRIPTION
The `check` flag was only auto-enabled when `--check-delay` was passed
as a CLI flag, but not when `check_delay` was set in the TOML config.
This meant `posting.check_delay = 60` without an explicit `check = true`
would silently skip the check.

Now `check_delay` in the config file correctly implies `check = true`,
matching the documented CLI behavior.

There are also other 2 small commits related to the config flags and TOML.