### PR TITLE
fix(report): PAR2 slices in input progress

### DIFF
--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -681,9 +681,14 @@ async fn par2_only_ingest(
         }
 
         // Flush the final partial slice for this file (zero-padded inside
-        // feed_par2_slice). No Par2InputProgress here, matching the standard path.
+        // feed_par2_slice).
         if !slice_buf.is_empty() {
             feed_par2_slice(&mut slice_buf, par2_slice_size, worker, true);
+            *par2_slices_fed += 1;
+            shared.emit(ProgressEvent::Par2InputProgress {
+                done: *par2_slices_fed,
+                total: total_slices,
+            });
         }
     }
 
@@ -1007,6 +1012,11 @@ async fn producer(
                 if let Some(worker) = &worker_opt {
                     if !par2_accum.is_empty() {
                         feed_par2_slice(&mut par2_accum, par2_slice_size, worker, true);
+                        par2_slices_fed += 1;
+                        shared.emit(crate::progress::ProgressEvent::Par2InputProgress {
+                            done: par2_slices_fed,
+                            total: total_slices,
+                        });
                     }
                 }
             }

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -702,8 +702,12 @@ impl RenderState {
 
         // --- overall posting box (only after posting has started) --------
         if !self.files.is_empty() {
-            let frac = if self.total_bytes > 0 {
-                (self.done_bytes as f64 / self.total_bytes as f64).clamp(0.0, 1.0)
+            // Use segment ratio for the bar percentage so it stays in sync with
+            // the N/N seg counter.  total_bytes is pre-seeded with an estimated
+            // PAR2 size, so a byte-ratio bar could stop at ~99% while segments
+            // already read N/N.  Bytes remain the basis for speed/ETA/size.
+            let frac = if self.total_segments > 0 {
+                (self.done_segments as f64 / self.total_segments as f64).clamp(0.0, 1.0)
             } else {
                 0.0
             };


### PR DESCRIPTION
`Par2InputProgress` was emitted only when the accumulated slice buffer reached the full slice size. The trailing partial slice of each source file was still fed to the worker, but no progress event followed it, so the encode bar stopped at `N-1/N` (e.g. `963/964 slices`).

Emit `Par2InputProgress` after flushing the final partial slice in both the standard posting path and the `--par2-only` fast path, so the counter now reaches the computed total exactly (e.g. `964/964 slices`).

The count remains bounded by `total_slices` because `total_slices` is defined as the exact number of `feed_par2_slice` calls across all files.

Assisted-By: AI Assistant <ai@assistant.com>