### PR TITLE
feat(batch): use natural sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_ascii"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1012,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-sort"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c09e4591611e231daf4d4c685a66cb0410cc1e502027a20ae55f2bb9e997207a"
+dependencies = [
+ "any_ascii",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1276,7 @@ dependencies = [
  "chrono",
  "clap",
  "crc32fast",
+ "lexical-sort",
  "md-5",
  "parmesan-par2",
  "rayon",

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -39,6 +39,7 @@ sysinfo = { version = "0.36.1", default-features = false, features = ["system"] 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+lexical-sort = "0.3"
 
 [features]
 bench-internals = ["parmesan/bench-internals"]

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -1312,16 +1312,22 @@ async fn run_batch(
 
     let mut handles = Vec::new();
     for entry in &entries {
+        // Acquire the permit before spawning so uploads start in the sorted
+        // order. With the permit inside the task, the scheduler decided which
+        // upload ran first, making --each non-deterministic.
+        let permit = Arc::clone(&semaphore)
+            .acquire_owned()
+            .await
+            .expect("semaphore closed");
         let entry = entry.clone();
         let params = Arc::clone(&params);
-        let sem = Arc::clone(&semaphore);
         let label = entry
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| "entry".to_string());
 
         let handle = tokio::spawn(async move {
-            let _permit = sem.acquire().await.expect("semaphore closed");
+            let _permit = permit;
             if !params.json_mode {
                 println!("\n── {} ──", label);
             }
@@ -1605,12 +1611,17 @@ async fn run_watch(
                 Some(_) => {
                     // Size unchanged since last poll: entry is stable, dispatch it.
                     pending.remove(&entry);
+                    // Acquire the permit before spawning so uploads start in the
+                    // sorted order returned by top_level_entries().
+                    let permit = Arc::clone(&semaphore)
+                        .acquire_owned()
+                        .await
+                        .expect("semaphore closed");
                     // Mark as done immediately so a second poll won't re-queue it
                     // while the upload task holds the semaphore permit.
                     done.insert(entry.clone());
 
                     let params = Arc::clone(&params);
-                    let sem = Arc::clone(&semaphore);
                     let watch_done = watch_done.map(PathBuf::from);
                     let tx = result_tx.clone();
                     let label = entry
@@ -1619,7 +1630,7 @@ async fn run_watch(
                         .unwrap_or_else(|| "entry".to_string());
 
                     tokio::spawn(async move {
-                        let _permit = sem.acquire().await.expect("semaphore closed");
+                        let _permit = permit;
                         if !params.json_mode {
                             println!("\n── watch: {} ──", label);
                         }

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -1261,14 +1261,17 @@ async fn run_single_upload(
     })
 }
 
-/// Enumerate top-level entries of `dir` (files and subdirectories), sorted by name.
+/// Enumerate top-level entries of `dir` (files and subdirectories), sorted by
+/// name using natural lexical ordering (so `E02` comes before `E10`).
 fn top_level_entries(dir: &Path) -> Result<Vec<PathBuf>> {
     let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
         .with_context(|| format!("reading directory `{}`", dir.display()))?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .collect();
-    entries.sort();
+    entries.sort_by(|a, b| {
+        lexical_sort::natural_lexical_cmp(&a.to_string_lossy(), &b.to_string_lossy())
+    });
     Ok(entries)
 }
 

--- a/crates/pesto/tests/batch_order.rs
+++ b/crates/pesto/tests/batch_order.rs
@@ -1,0 +1,53 @@
+//! End-to-end CLI test: verify `--each` processes top-level entries in the
+//! deterministic order returned by the platform's native `PathBuf` sort. The
+//! test computes the expected order using the same sort the binary uses, so it
+//! is robust across macOS and Linux while still catching scheduler-dependent
+//! reordering bugs.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn each_processes_entries_in_sorted_order() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("Season01");
+    std::fs::create_dir(&dir).unwrap();
+    let names = ["Show.S01E10.mkv", "Show.S01E01.mkv", "Show.S01E02.mkv"];
+    for name in names {
+        std::fs::write(dir.join(name), b"x").unwrap();
+    }
+
+    let mut sorted = names.map(PathBuf::from);
+    sorted.sort();
+    let expected: Vec<_> = sorted
+        .iter()
+        .map(|p| format!("── {} ──", p.file_name().unwrap().to_string_lossy()))
+        .collect();
+
+    let bin = env!("CARGO_BIN_EXE_pesto");
+    let output = Command::new(bin)
+        .arg("--dry-run")
+        .arg("--groups")
+        .arg("alt.binaries.test")
+        .arg("--each")
+        .arg(&dir)
+        .output()
+        .expect("failed to run pesto");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let labels: Vec<_> = stdout
+        .lines()
+        .filter(|l| l.starts_with("── ") && l.ends_with(" ──"))
+        .map(|l| l.to_string())
+        .collect();
+
+    assert!(
+        output.status.success(),
+        "pesto exited with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(labels, expected, "unexpected order in stdout:\n{}", stdout);
+}

--- a/crates/pesto/tests/batch_order.rs
+++ b/crates/pesto/tests/batch_order.rs
@@ -1,28 +1,17 @@
-//! End-to-end CLI test: verify `--each` processes top-level entries in the
-//! deterministic order returned by the platform's native `PathBuf` sort. The
-//! test computes the expected order using the same sort the binary uses, so it
-//! is robust across macOS and Linux while still catching scheduler-dependent
-//! reordering bugs.
+//! End-to-end CLI test: verify `--each` processes top-level entries in natural
+//! lexical order. This makes episode numbering human-friendly (`E01`, `E02`,
+//! `E10` instead of `E01`, `E10`, `E02`).
 
-use std::path::PathBuf;
 use std::process::Command;
 
 #[test]
-fn each_processes_entries_in_sorted_order() {
+fn each_processes_entries_in_natural_order() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path().join("Season01");
     std::fs::create_dir(&dir).unwrap();
-    let names = ["Show.S01E10.mkv", "Show.S01E01.mkv", "Show.S01E02.mkv"];
-    for name in names {
+    for name in ["Show.S01E10.mkv", "Show.S01E01.mkv", "Show.S01E02.mkv"] {
         std::fs::write(dir.join(name), b"x").unwrap();
     }
-
-    let mut sorted = names.map(PathBuf::from);
-    sorted.sort();
-    let expected: Vec<_> = sorted
-        .iter()
-        .map(|p| format!("── {} ──", p.file_name().unwrap().to_string_lossy()))
-        .collect();
 
     let bin = env!("CARGO_BIN_EXE_pesto");
     let output = Command::new(bin)
@@ -49,5 +38,14 @@ fn each_processes_entries_in_sorted_order() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    assert_eq!(labels, expected, "unexpected order in stdout:\n{}", stdout);
+    assert_eq!(
+        labels,
+        vec![
+            "── Show.S01E01.mkv ──",
+            "── Show.S01E02.mkv ──",
+            "── Show.S01E10.mkv ──",
+        ],
+        "unexpected order in stdout:\n{}",
+        stdout
+    );
 }


### PR DESCRIPTION
`top_level_entries()` sorted entries alphabetically, but the semaphore
permit was acquired inside the spawned tokio task. Because all tasks
were created upfront, the scheduler decided which upload actually
started first, so episodes could be processed out of order.

Move the semaphore acquisition before `tokio::spawn` so uploads start
strictly in the sorted order. With `--jobs 1` (the default) this makes
`--each` deterministic.

Switch `--each/--season/--watch` from byte-level `PathBuf` sorting to
lexical-sort's natural comparison. This makes episode ordering match
file managers, e.g. `E01`, `E02`, `E10` instead of `E01`, `E10`, `E02`.