### PR TITLE
fix(cancel): unify signal handling and make all phases cancellable

### DIFF
--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -544,6 +545,7 @@ async fn run_single_upload(
     params: &UploadParams,
     entry_paths: &[PathBuf],
     entry_label: &str,
+    cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Result<UploadResult> {
     let config = &params.config;
     let upload_start = std::time::Instant::now();
@@ -819,11 +821,12 @@ async fn run_single_upload(
     let nzb_out_path: Option<String> = nzb_stem.clone();
 
     let t_post = std::time::Instant::now();
-    let outcome = pesto::poster::post_files_with_progress(
+    let outcome = pesto::poster::post_files_with_progress_and_cancel(
         config,
         &inputs,
         Some(progress_tx),
         resume_path.as_deref(),
+        cancel.cloned(),
     )
     .await?;
     let _ = renderer.await;
@@ -850,6 +853,7 @@ async fn run_single_upload(
             &outcome.failed_tasks,
             &outcome.groups,
             Some(&retry_tx),
+            cancel,
         )
         .await
         .unwrap_or_else(|e| {
@@ -877,10 +881,11 @@ async fn run_single_upload(
     }
 
     // ── Post-check STAT pass ──────────────────────────────────────────────────
+    let mut cancelled = outcome.cancelled || cancel.is_some_and(|f| f.load(Ordering::Relaxed));
     let check_missing: Vec<String> = if config.check
         && !config.dry_run
         && !config.par2_only
-        && !outcome.cancelled
+        && !cancelled
         && !outcome.segments.is_empty()
     {
         let (check_tx, check_renderer) = if params.json_mode {
@@ -889,13 +894,15 @@ async fn run_single_upload(
             pesto::ui::terminal::spawn_renderer_with(params.renderer_opts.clone())
         };
         let t_check = std::time::Instant::now();
-        let missing = pesto::poster::check_articles(config, &outcome.segments, Some(&check_tx))
-            .await
-            .unwrap_or_else(|e| {
-                eprintln!("check: error during STAT pass: {e:#}");
-                error!(error = %e, "check: STAT pass failed");
-                Vec::new()
-            });
+        let missing =
+            pesto::poster::check_articles(config, &outcome.segments, Some(&check_tx), cancel)
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("check: error during STAT pass: {e:#}");
+                    error!(error = %e, "check: STAT pass failed");
+                    Vec::new()
+                });
+        cancelled = cancelled || cancel.is_some_and(|f| f.load(Ordering::Relaxed));
         drop(check_tx);
         let _ = check_renderer.await;
         let check_ms = t_check.elapsed().as_millis();
@@ -907,18 +914,18 @@ async fn run_single_upload(
     };
 
     if !params.json_mode && config.par2_only {
-        if outcome.cancelled {
+        if cancelled {
             println!("PAR2 generation interrupted.");
         } else {
             println!("PAR2 generation complete.");
         }
     }
 
-    if outcome.cancelled {
+    if cancelled {
         if config.par2_only {
             eprintln!("interrupted — stopped before finishing PAR2 generation");
         } else {
-            eprintln!("interrupted — stopped before posting every requested segment");
+            eprintln!("interrupted — upload incomplete");
         }
     }
     if !outcome.failures.is_empty() {
@@ -927,7 +934,7 @@ async fn run_single_upload(
             eprintln!("  - {failure}");
         }
     }
-    let check_missing = if !check_missing.is_empty() {
+    let check_missing = if !cancelled && !check_missing.is_empty() {
         eprintln!(
             "check: {} article(s) not found — reposting…",
             check_missing.len()
@@ -948,6 +955,7 @@ async fn run_single_upload(
             &outcome.segments,
             &check_missing,
             Some(&repost_tx),
+            cancel,
         )
         .await
         .unwrap_or_else(|e| {
@@ -964,43 +972,60 @@ async fn run_single_upload(
             check_missing.len()
         );
 
+        cancelled = cancelled || cancel.is_some_and(|f| f.load(Ordering::Relaxed));
+
         // Second STAT pass to confirm reposts landed (no extra delay — they
         // were just posted so propagation should be immediate).
-        let (verify_tx, verify_renderer) = if params.json_mode {
-            pesto::progress::spawn_json_emitter()
+        if cancelled {
+            eprintln!("check: interrupted — skipping verify after repost");
+            check_missing
         } else {
-            pesto::ui::terminal::spawn_renderer_with(params.renderer_opts.clone())
-        };
-        let still_missing =
-            pesto::poster::check_articles(config, &outcome.segments, Some(&verify_tx))
-                .await
-                .unwrap_or_else(|e| {
-                    eprintln!("check: verify after repost failed: {e:#}");
-                    error!(error = %e, "check: second STAT pass (post-repost verify) failed");
-                    check_missing.clone()
-                });
-        drop(verify_tx);
-        let _ = verify_renderer.await;
+            let (verify_tx, verify_renderer) = if params.json_mode {
+                pesto::progress::spawn_json_emitter()
+            } else {
+                pesto::ui::terminal::spawn_renderer_with(params.renderer_opts.clone())
+            };
+            let still_missing =
+                pesto::poster::check_articles(config, &outcome.segments, Some(&verify_tx), cancel)
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("check: verify after repost failed: {e:#}");
+                        error!(error = %e, "check: second STAT pass (post-repost verify) failed");
+                        check_missing.clone()
+                    });
+            cancelled = cancelled || cancel.is_some_and(|f| f.load(Ordering::Relaxed));
+            drop(verify_tx);
+            let _ = verify_renderer.await;
 
-        if still_missing.is_empty() {
-            eprintln!("check: all article(s) confirmed after repost");
-        } else {
-            eprintln!(
-                "check: {} article(s) still missing after repost:",
-                still_missing.len()
-            );
-            for id in &still_missing {
-                eprintln!("  - {id}");
+            if cancelled {
+                eprintln!("check: interrupted during verify after repost");
+                still_missing
+            } else if still_missing.is_empty() {
+                eprintln!("check: all article(s) confirmed after repost");
+                still_missing
+            } else {
+                eprintln!(
+                    "check: {} article(s) still missing after repost:",
+                    still_missing.len()
+                );
+                for id in &still_missing {
+                    eprintln!("  - {id}");
+                }
+                error!(
+                    count = still_missing.len(),
+                    ids = ?still_missing,
+                    "check: articles still missing after repost"
+                );
+                still_missing
             }
-            error!(
-                count = still_missing.len(),
-                ids = ?still_missing,
-                "check: articles still missing after repost"
-            );
         }
-        still_missing
     } else {
-        if config.check && !config.dry_run && !config.par2_only && !outcome.cancelled {
+        if config.check
+            && !config.dry_run
+            && !config.par2_only
+            && !cancelled
+            && !outcome.segments.is_empty()
+        {
             eprintln!("check: all {} article(s) verified", outcome.segments.len());
         }
         Vec::new()
@@ -1037,14 +1062,23 @@ async fn run_single_upload(
     // If the user specified a destination (--out or nzb_dir), a hardlink (or
     // copy when cross-device) is placed there so re-uploads never collide.
     let out: Option<PathBuf> = if let Some(stem) = nzb_out_path {
-        Some(nzb_archive_path(&stem).await)
+        if !cancelled || config.resume {
+            Some(nzb_archive_path(&stem).await)
+        } else {
+            eprintln!("interrupted — skipping nzb output");
+            None
+        }
     } else {
         None
     };
 
     // nzb_reported_path: the path shown to the user and passed to hooks/history.
     // It is the user-dest (hardlink) when set, otherwise the archive copy.
-    let mut nzb_reported_path: Option<PathBuf> = nzb_user_dest.clone().or_else(|| out.clone());
+    let mut nzb_reported_path: Option<PathBuf> = if cancelled && !config.resume {
+        None
+    } else {
+        nzb_user_dest.clone().or_else(|| out.clone())
+    };
 
     let _nzb_xml: Option<String> = if let Some(out) = &out {
         if !config.par2_only {
@@ -1140,9 +1174,8 @@ async fn run_single_upload(
     // Send completion notifications.
     let notify_enabled = config.notify.unwrap_or(true)
         && (config.notify_webhook.is_some() || config.notify_ntfy.is_some());
-    if notify_enabled && !config.par2_only && !config.dry_run {
-        let had_failures =
-            outcome.cancelled || !outcome.failures.is_empty() || has_unrecoverable_failures;
+    if notify_enabled && !config.par2_only && !config.dry_run && !cancelled {
+        let had_failures = !outcome.failures.is_empty() || has_unrecoverable_failures;
         pesto::notify::send_all(&pesto::notify::NotifyConfig {
             webhook_url: config.notify_webhook.as_deref(),
             ntfy_topic: config.notify_ntfy.as_deref(),
@@ -1155,9 +1188,8 @@ async fn run_single_upload(
         .await;
     }
 
-    // Generate .nfo unconditionally — it is a local artifact and does not
-    // depend on a live NNTP connection, --dry-run, or --no-upload.
-    let nfo_path: Option<PathBuf> = if config.nfo && !config.par2_only {
+    // Generate .nfo as a local artifact when the upload was not cancelled.
+    let nfo_path: Option<PathBuf> = if config.nfo && !config.par2_only && !cancelled {
         let base = nzb_reported_path
             .as_ref()
             .map(|p| p.with_extension("nfo"))
@@ -1192,8 +1224,7 @@ async fn run_single_upload(
     };
 
     // Run post-upload hooks only when the upload actually succeeded.
-    let upload_ok =
-        !outcome.cancelled && outcome.failures.is_empty() && !has_unrecoverable_failures;
+    let upload_ok = !cancelled && outcome.failures.is_empty() && !has_unrecoverable_failures;
     if upload_ok && !config.par2_only && !config.dry_run {
         let post_input_paths = inputs
             .iter()
@@ -1252,7 +1283,7 @@ async fn run_single_upload(
     Ok(UploadResult {
         segments: outcome.segments,
         groups: outcome.groups,
-        cancelled: outcome.cancelled,
+        cancelled,
         had_failures: !outcome.failures.is_empty()
             || !check_missing.is_empty()
             || has_unrecoverable_failures,
@@ -1281,6 +1312,7 @@ async fn run_batch(
     dirs: &[PathBuf],
     jobs: usize,
     season_nzb: Option<PathBuf>,
+    cancel: Arc<AtomicBool>,
 ) -> Result<(Vec<PostedSegment>, bool, bool)> {
     // Collect all entries from every directory argument.
     let mut entries: Vec<PathBuf> = Vec::new();
@@ -1315,6 +1347,7 @@ async fn run_batch(
         let entry = entry.clone();
         let params = Arc::clone(&params);
         let sem = Arc::clone(&semaphore);
+        let task_cancel = cancel.clone();
         let label = entry
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
@@ -1325,7 +1358,7 @@ async fn run_batch(
             if !params.json_mode {
                 println!("\n── {} ──", label);
             }
-            run_single_upload(&params, &[entry], &label).await
+            run_single_upload(&params, &[entry], &label, Some(&task_cancel)).await
         });
         handles.push(handle);
     }
@@ -1359,7 +1392,9 @@ async fn run_batch(
 
     // Write consolidated season NZB (and matching .nfo + hooks) when requested.
     if let Some(season_path) = season_nzb {
-        if !all_segments.is_empty() {
+        if any_cancelled {
+            eprintln!("interrupted — skipping season nzb output");
+        } else if !all_segments.is_empty() {
             let config = &params.config;
             let season_name = config.nzb_name.clone().or_else(|| {
                 season_path
@@ -1477,8 +1512,8 @@ async fn run_watch(
     watch_done: Option<&Path>,
     poll_interval: u64,
     jobs: usize,
-) -> Result<()> {
-    use tokio::signal;
+    cancel: Arc<AtomicBool>,
+) -> Result<bool> {
     use tokio::sync::mpsc;
 
     eprintln!(
@@ -1486,32 +1521,6 @@ async fn run_watch(
         watch_dir.display(),
         poll_interval
     );
-
-    let shutdown = Arc::new(tokio::sync::Notify::new());
-    let shutdown_clone = Arc::clone(&shutdown);
-
-    // Listen for Ctrl-C / SIGTERM on a background task.
-    tokio::spawn(async move {
-        let ctrl_c = async {
-            signal::ctrl_c().await.ok();
-        };
-        #[cfg(unix)]
-        let sigterm = async {
-            signal::unix::signal(signal::unix::SignalKind::terminate())
-                .expect("SIGTERM handler")
-                .recv()
-                .await;
-        };
-        #[cfg(not(unix))]
-        let sigterm = std::future::pending::<()>();
-
-        tokio::select! {
-            _ = ctrl_c => {},
-            _ = sigterm => {},
-        }
-        eprintln!("\nshutdown requested — finishing in-progress uploads");
-        shutdown_clone.notify_waiters();
-    });
 
     // `done`: entries that have been successfully uploaded (or permanently failed).
     let mut done: HashSet<PathBuf> = HashSet::new();
@@ -1537,19 +1546,31 @@ async fn run_watch(
     };
     let semaphore = Arc::new(tokio::sync::Semaphore::new(effective_jobs));
 
-    // Channel for completed tasks to report back (path, success).
-    let (result_tx, mut result_rx) = mpsc::unbounded_channel::<(PathBuf, bool)>();
+    // Channel for completed tasks to report back (path, success, cancelled).
+    let (result_tx, mut result_rx) = mpsc::unbounded_channel::<(PathBuf, bool, bool)>();
+
+    let mut any_cancelled = false;
 
     loop {
         // Check for shutdown between polls.
         tokio::select! {
             _ = tokio::time::sleep(std::time::Duration::from_secs(poll_interval)) => {}
-            _ = shutdown.notified() => { break; }
+            _ = async {
+                while !cancel.load(Ordering::Relaxed) {
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                }
+            } => {
+                eprintln!("\nshutdown requested — finishing in-progress uploads");
+                break;
+            }
         }
 
         // Drain completed-task notifications before scanning for new entries.
-        while let Ok((entry, success)) = result_rx.try_recv() {
-            if success {
+        while let Ok((entry, success, task_cancelled)) = result_rx.try_recv() {
+            if task_cancelled {
+                any_cancelled = true;
+                eprintln!("watch: upload of `{}` was cancelled", entry.display());
+            } else if success {
                 done.insert(entry);
             } else {
                 let attempts = retry_counts.entry(entry.clone()).or_insert(0);
@@ -1617,41 +1638,43 @@ async fn run_watch(
                         .file_name()
                         .map(|n| n.to_string_lossy().into_owned())
                         .unwrap_or_else(|| "entry".to_string());
+                    let task_cancel = cancel.clone();
 
                     tokio::spawn(async move {
                         let _permit = sem.acquire().await.expect("semaphore closed");
                         if !params.json_mode {
                             println!("\n── watch: {} ──", label);
                         }
-                        let success =
-                            match run_single_upload(&params, std::slice::from_ref(&entry), &label)
-                                .await
-                            {
-                                Ok(_) => {
-                                    // Move to --watch-done if specified; otherwise leave in place.
-                                    if let Some(done_dir) = &watch_done {
-                                        let dest =
-                                            done_dir.join(entry.file_name().unwrap_or_default());
-                                        if let Err(e) = std::fs::rename(&entry, &dest) {
-                                            eprintln!(
-                                                "watch: could not move `{}` to `{}`: {e}",
-                                                entry.display(),
-                                                dest.display()
-                                            );
-                                        }
+                        let (success, task_cancelled) = match run_single_upload(
+                            &params,
+                            std::slice::from_ref(&entry),
+                            &label,
+                            Some(&task_cancel),
+                        )
+                        .await
+                        {
+                            Ok(result) if result.cancelled => (false, true),
+                            Ok(_) => {
+                                // Move to --watch-done if specified; otherwise leave in place.
+                                if let Some(done_dir) = &watch_done {
+                                    let dest = done_dir.join(entry.file_name().unwrap_or_default());
+                                    if let Err(e) = std::fs::rename(&entry, &dest) {
+                                        eprintln!(
+                                            "watch: could not move `{}` to `{}`: {e}",
+                                            entry.display(),
+                                            dest.display()
+                                        );
                                     }
-                                    true
                                 }
-                                Err(e) => {
-                                    eprintln!(
-                                        "watch: upload failed for `{}`: {e:#}",
-                                        entry.display()
-                                    );
-                                    false
-                                }
-                            };
+                                (true, false)
+                            }
+                            Err(e) => {
+                                eprintln!("watch: upload failed for `{}`: {e:#}", entry.display());
+                                (false, false)
+                            }
+                        };
                         // Report outcome; if the channel is closed we're shutting down.
-                        let _ = tx.send((entry, success));
+                        let _ = tx.send((entry, success, task_cancelled));
                     });
                 }
             }
@@ -1666,7 +1689,7 @@ async fn run_watch(
     };
     let _ = semaphore.acquire_many(effective_jobs as u32).await;
     eprintln!("watch: all uploads finished, exiting");
-    Ok(())
+    Ok(any_cancelled)
 }
 
 // ── merge-season ─────────────────────────────────────────────────────────────
@@ -2026,16 +2049,25 @@ async fn main() -> Result<()> {
         },
     });
 
+    // Unified cancellation flag: one signal listener for the whole process.
+    let cancel = Arc::new(AtomicBool::new(false));
+    pesto::cancel::spawn_listener(cancel.clone());
+
     // ── --watch mode ──────────────────────────────────────────────────────────
     if let Some(watch_dir) = &cli.watch {
-        return run_watch(
+        let any_cancelled = run_watch(
             params,
             watch_dir,
             cli.watch_done.as_deref(),
             cli.watch_interval,
             cli.jobs,
+            cancel,
         )
-        .await;
+        .await?;
+        if any_cancelled {
+            std::process::exit(130);
+        }
+        return Ok(());
     }
 
     // ── --each / --season batch mode ─────────────────────────────────────────
@@ -2065,7 +2097,7 @@ async fn main() -> Result<()> {
         };
 
         let (_, any_cancelled, any_failures) =
-            run_batch(params, &cli.files, cli.jobs, season_nzb).await?;
+            run_batch(params, &cli.files, cli.jobs, season_nzb, cancel).await?;
 
         if any_cancelled {
             std::process::exit(130);
@@ -2090,7 +2122,7 @@ async fn main() -> Result<()> {
             p.file_stem().unwrap_or(s).to_string_lossy().into_owned()
         })
         .unwrap_or_else(|| format!("{}", std::process::id()));
-    let result = run_single_upload(&params, &cli.files, &label).await?;
+    let result = run_single_upload(&params, &cli.files, &label, Some(&cancel)).await?;
 
     if let Some(ref p) = session_log {
         write_session_summary(

--- a/crates/pesto/src/cancel.rs
+++ b/crates/pesto/src/cancel.rs
@@ -1,0 +1,37 @@
+//! Unified cancellation support for pesto.
+//!
+//! Provides a single signal listener that flips a shared [`AtomicBool`] on
+//! Ctrl-C or SIGTERM.  Library code should **never** install its own signal
+//! handler; instead it accepts an `Arc<AtomicBool>` and polls it at safe
+//! boundaries.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Spawn a background task that listens for Ctrl-C (and SIGTERM on Unix) and
+/// sets `flag` to `true` when either fires.
+///
+/// Call this **once** per binary invocation / per run, then pass `flag` to
+/// every long-running phase (posting, check, repost, etc.).
+pub fn spawn_listener(flag: Arc<AtomicBool>) {
+    tokio::spawn(async move {
+        let ctrl_c = async {
+            tokio::signal::ctrl_c().await.ok();
+        };
+        #[cfg(unix)]
+        let sigterm = async {
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("SIGTERM handler")
+                .recv()
+                .await;
+        };
+        #[cfg(not(unix))]
+        let sigterm = std::future::pending::<()>();
+
+        tokio::select! {
+            _ = ctrl_c => {},
+            _ = sigterm => {},
+        }
+        flag.store(true, Ordering::Relaxed);
+    });
+}

--- a/crates/pesto/src/lib.rs
+++ b/crates/pesto/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 
 pub mod article;
+pub mod cancel;
 pub mod compress;
 pub mod config;
 pub mod history;
@@ -52,7 +53,11 @@ pub async fn post(
     files: Vec<walk::InputFile>,
 ) -> anyhow::Result<(poster::PostOutcome, progress::ProgressReceiver)> {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let outcome = poster::post_files_with_progress(&config, &files, Some(tx), None).await?;
+    let flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    cancel::spawn_listener(flag.clone());
+    let outcome =
+        poster::post_files_with_progress_and_cancel(&config, &files, Some(tx), None, Some(flag))
+            .await?;
     Ok((outcome, rx))
 }
 

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -444,25 +444,17 @@ pub async fn post_files_with_progress_and_cancel(
     let cancel_handle = {
         let shared = shared.clone();
         tokio::spawn(async move {
-            tokio::select! {
-                biased;
-                _ = async {
-                    if let Some(ref flag) = external_cancel {
-                        loop {
-                            if flag.load(Ordering::Relaxed) { break; }
-                            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-                        }
-                    } else {
-                        std::future::pending::<()>().await;
+            if let Some(ref flag) = external_cancel {
+                loop {
+                    if flag.load(Ordering::Relaxed) {
+                        break;
                     }
-                } => {
-                    shared.cancelled.store(true, Ordering::Relaxed);
-                    shared.emit(ProgressEvent::Interrupted);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 }
-                _ = tokio::signal::ctrl_c() => {
-                    shared.cancelled.store(true, Ordering::Relaxed);
-                    shared.emit(ProgressEvent::Interrupted);
-                }
+                shared.cancelled.store(true, Ordering::Relaxed);
+                shared.emit(ProgressEvent::Interrupted);
+            } else {
+                std::future::pending::<()>().await;
             }
         })
     };
@@ -1797,6 +1789,7 @@ pub async fn repost_missing_segments(
     all_segments: &[PostedSegment],
     missing_ids: &[String],
     events: Option<&ProgressSender>,
+    cancel: Option<&Arc<AtomicBool>>,
 ) -> Result<usize> {
     if missing_ids.is_empty() {
         return Ok(0);
@@ -1823,6 +1816,9 @@ pub async fn repost_missing_segments(
     let mut reposted = 0usize;
 
     for seg in &to_repost {
+        if cancel.is_some_and(|f| f.load(Ordering::Relaxed)) {
+            break;
+        }
         // Derive the file path from the segment's file_name relative to the
         // working directory. This matches how InputFile paths are resolved.
         let path = PathBuf::from(&seg.file_name);
@@ -1891,6 +1887,9 @@ pub async fn repost_missing_segments(
                             });
                         }
                         if attempt < max_retries {
+                            if cancel.is_some_and(|f| f.load(Ordering::Relaxed)) {
+                                break;
+                            }
                             tokio::time::sleep(Duration::from_secs(1)).await;
                         }
                     }
@@ -1903,6 +1902,9 @@ pub async fn repost_missing_segments(
                         });
                     }
                     if attempt < max_retries {
+                        if cancel.is_some_and(|f| f.load(Ordering::Relaxed)) {
+                            break;
+                        }
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                 }
@@ -1947,6 +1949,7 @@ pub async fn repost_failed_tasks(
     failed: &[FailedTask],
     groups: &[String],
     events: Option<&ProgressSender>,
+    cancel: Option<&Arc<AtomicBool>>,
 ) -> Result<Vec<PostedSegment>> {
     if failed.is_empty() {
         return Ok(Vec::new());
@@ -1963,6 +1966,9 @@ pub async fn repost_failed_tasks(
     let mut recovered: Vec<PostedSegment> = Vec::new();
 
     for (i, task) in failed.iter().enumerate() {
+        if cancel.is_some_and(|f| f.load(Ordering::Relaxed)) {
+            break;
+        }
         let offset = (task.part as u64 - 1) * article_size;
         let read_len = (task.file_size - offset).min(article_size) as usize;
 
@@ -2025,6 +2031,9 @@ pub async fn repost_failed_tasks(
                         slot.invalidate();
                         warn!(file = %task.file_name, part = task.part, attempt, "retry attempt failed: {e}");
                         if attempt < max_retries {
+                            if cancel.is_some_and(|f| f.load(Ordering::Relaxed)) {
+                                break;
+                            }
                             tokio::time::sleep(Duration::from_secs(config.retry_delay)).await;
                         }
                     }
@@ -2032,6 +2041,9 @@ pub async fn repost_failed_tasks(
                 Err(e) => {
                     warn!(attempt, "retry: connect failed: {e}");
                     if attempt < max_retries {
+                        if cancel.is_some_and(|f| f.load(Ordering::Relaxed)) {
+                            break;
+                        }
                         tokio::time::sleep(Duration::from_secs(config.retry_delay)).await;
                     }
                 }
@@ -2086,6 +2098,7 @@ pub async fn check_articles(
     config: &Config,
     segments: &[PostedSegment],
     events: Option<&ProgressSender>,
+    cancel: Option<&Arc<AtomicBool>>,
 ) -> Result<Vec<String>> {
     if segments.is_empty() {
         return Ok(Vec::new());
@@ -2101,6 +2114,9 @@ pub async fn check_articles(
     if config.check_delay_secs > 0 {
         let mut remaining = config.check_delay_secs;
         while remaining > 0 {
+            if cancel.is_some_and(|f| f.load(Ordering::Relaxed)) {
+                break;
+            }
             if let Some(tx) = events {
                 let _ = tx.send(ProgressEvent::CheckWaiting {
                     remaining_secs: remaining,
@@ -2136,6 +2152,7 @@ pub async fn check_articles(
     };
 
     let events_tx: Option<ProgressSender> = events.cloned();
+    let cancel_flag: Option<Arc<AtomicBool>> = cancel.map(Arc::clone);
 
     let mut handles = Vec::with_capacity(n_workers);
     for (worker_idx, chunk) in chunks.into_iter().enumerate() {
@@ -2143,6 +2160,7 @@ pub async fn check_articles(
         let missing_ids = Arc::clone(&missing_ids);
         let done_count = Arc::clone(&done_count);
         let tx = events_tx.clone();
+        let worker_cancel = cancel_flag.clone();
 
         handles.push(tokio::spawn(async move {
             let server_idx = if servers.is_empty() {
@@ -2153,8 +2171,20 @@ pub async fn check_articles(
             let mut slot = ConnectionSlot::new(Arc::clone(&servers), server_idx);
 
             for seg in &chunk {
+                if worker_cancel
+                    .as_ref()
+                    .is_some_and(|f| f.load(Ordering::Relaxed))
+                {
+                    break;
+                }
                 let mut found = false;
                 for attempt in 1..=max_attempts {
+                    if worker_cancel
+                        .as_ref()
+                        .is_some_and(|f| f.load(Ordering::Relaxed))
+                    {
+                        break;
+                    }
                     match slot.ensure_connected().await {
                         Ok(conn) => match conn.stat(&seg.message_id).await {
                             Ok(true) => {
@@ -2163,6 +2193,12 @@ pub async fn check_articles(
                             }
                             Ok(false) => {
                                 if attempt < max_attempts {
+                                    if worker_cancel
+                                        .as_ref()
+                                        .is_some_and(|f| f.load(Ordering::Relaxed))
+                                    {
+                                        break;
+                                    }
                                     let delay = 20u64;
                                     if let Some(tx) = &tx {
                                         let _ = tx.send(ProgressEvent::CheckRetrying {
@@ -2177,12 +2213,24 @@ pub async fn check_articles(
                             Err(_) => {
                                 slot.invalidate();
                                 if attempt < max_attempts {
+                                    if worker_cancel
+                                        .as_ref()
+                                        .is_some_and(|f| f.load(Ordering::Relaxed))
+                                    {
+                                        break;
+                                    }
                                     tokio::time::sleep(Duration::from_secs(2)).await;
                                 }
                             }
                         },
                         Err(_) => {
                             if attempt < max_attempts {
+                                if worker_cancel
+                                    .as_ref()
+                                    .is_some_and(|f| f.load(Ordering::Relaxed))
+                                {
+                                    break;
+                                }
                                 tokio::time::sleep(Duration::from_secs(2)).await;
                             }
                         }
@@ -2211,8 +2259,13 @@ pub async fn check_articles(
         .unwrap();
 
     let failed = missing.len() as u64;
+    let cancelled = cancel.is_some_and(|f| f.load(Ordering::Relaxed));
     if let Some(tx) = events {
-        let _ = tx.send(ProgressEvent::CheckDone { failed });
+        if cancelled {
+            let _ = tx.send(ProgressEvent::Interrupted);
+        } else {
+            let _ = tx.send(ProgressEvent::CheckDone { failed });
+        }
     }
 
     Ok(missing)

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -88,6 +88,7 @@ enum ConnState {
 }
 
 /// Mutable view the renderer builds up from the event stream.
+#[allow(dead_code)]
 struct RenderState {
     started: bool,
     finished: bool,

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -6,7 +6,8 @@
 //! converge over time.
 
 use std::path::{Path, PathBuf};
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use anyhow::Context;
 
@@ -205,13 +206,13 @@ pub async fn run_upload(
 
     // ── Post ─────────────────────────────────────────────────────────────────
     let post_tx = progress_tx.clone();
-    let outcome = if let Some(cancel_flag) = cancel {
+    let outcome = if let Some(ref cancel_flag) = cancel {
         crate::poster::post_files_with_progress_and_cancel(
             config,
             &inputs,
             post_tx,
             resume_path.as_deref(),
-            Some(cancel_flag),
+            Some(cancel_flag.clone()),
         )
         .await?
     } else {
@@ -221,23 +222,29 @@ pub async fn run_upload(
     // ─────────────────────────────────────────────────────────────────────────
 
     let mut had_failures = !outcome.failures.is_empty();
+    let mut cancelled = outcome.cancelled;
 
     // ── Post-check STAT pass ──────────────────────────────────────────────────
     if config.check
         && !config.dry_run
         && !config.par2_only
-        && !outcome.cancelled
+        && !cancelled
         && !outcome.segments.is_empty()
     {
         emit_status(
             &progress_tx,
             format!("checking {} article(s) via STAT…", outcome.segments.len()),
         );
-        match crate::poster::check_articles(config, &outcome.segments, progress_tx.as_ref()).await {
-            Ok(missing) if missing.is_empty() => {
-                // CheckDone { failed: 0 } already emitted by check_articles.
-            }
-            Ok(missing) => {
+        let check_result = crate::poster::check_articles(
+            config,
+            &outcome.segments,
+            progress_tx.as_ref(),
+            cancel.as_ref(),
+        )
+        .await;
+        cancelled = cancelled || cancel.as_ref().is_some_and(|f| f.load(Ordering::Relaxed));
+        match check_result {
+            Ok(missing) if !cancelled && !missing.is_empty() => {
                 emit_status(
                     &progress_tx,
                     format!("check: {} article(s) not found — reposting…", missing.len()),
@@ -249,6 +256,7 @@ pub async fn run_upload(
                     &outcome.segments,
                     &missing,
                     progress_tx.as_ref(),
+                    cancel.as_ref(),
                 )
                 .await
                 .unwrap_or_else(|e| {
@@ -262,40 +270,59 @@ pub async fn run_upload(
                     format!("check: reposted {reposted}/{} article(s)", missing.len()),
                 );
 
-                // Second STAT pass to confirm reposts landed.
-                match crate::poster::check_articles(config, &outcome.segments, progress_tx.as_ref())
+                cancelled = cancelled || cancel.as_ref().is_some_and(|f| f.load(Ordering::Relaxed));
+
+                // Second STAT pass to confirm reposts landed (only if not cancelled).
+                if cancelled {
+                    emit_status(
+                        &progress_tx,
+                        "check: interrupted — skipping verify after repost".to_string(),
+                    );
+                } else {
+                    match crate::poster::check_articles(
+                        config,
+                        &outcome.segments,
+                        progress_tx.as_ref(),
+                        cancel.as_ref(),
+                    )
                     .await
-                {
-                    Ok(still_missing) if still_missing.is_empty() => {
-                        // CheckDone { failed: 0 } already emitted by check_articles.
-                    }
-                    Ok(still_missing) => {
-                        emit_status(
-                            &progress_tx,
-                            format!(
-                                "check: {} article(s) still missing after repost",
-                                still_missing.len()
-                            ),
-                        );
-                        for id in &still_missing {
-                            emit_status(&progress_tx, format!("  missing: {id}"));
+                    {
+                        Ok(still_missing) if still_missing.is_empty() => {
+                            // CheckDone { failed: 0 } already emitted by check_articles.
                         }
-                        tracing::error!(
-                            count = still_missing.len(),
-                            ids = ?still_missing,
-                            "check: articles still missing after repost"
-                        );
-                        had_failures = true;
+                        Ok(still_missing) => {
+                            emit_status(
+                                &progress_tx,
+                                format!(
+                                    "check: {} article(s) still missing after repost",
+                                    still_missing.len()
+                                ),
+                            );
+                            for id in &still_missing {
+                                emit_status(&progress_tx, format!("  missing: {id}"));
+                            }
+                            tracing::error!(
+                                count = still_missing.len(),
+                                ids = ?still_missing,
+                                "check: articles still missing after repost"
+                            );
+                            had_failures = true;
+                        }
+                        Err(e) => {
+                            emit_status(
+                                &progress_tx,
+                                format!("check: verify after repost failed: {e:#}"),
+                            );
+                            tracing::error!(error = %e, "check: second STAT pass failed");
+                            had_failures = true;
+                        }
                     }
-                    Err(e) => {
-                        emit_status(
-                            &progress_tx,
-                            format!("check: verify after repost failed: {e:#}"),
-                        );
-                        tracing::error!(error = %e, "check: second STAT pass failed");
-                        had_failures = true;
-                    }
+                    cancelled =
+                        cancelled || cancel.as_ref().is_some_and(|f| f.load(Ordering::Relaxed));
                 }
+            }
+            Ok(_) => {
+                // Either all verified or cancelled before/during check.
             }
             Err(e) => {
                 emit_status(&progress_tx, format!("check: STAT pass error: {e:#}"));
@@ -306,7 +333,7 @@ pub async fn run_upload(
     // ─────────────────────────────────────────────────────────────────────────
 
     // ── Write NZB ────────────────────────────────────────────────────────────
-    let nzb_path: Option<PathBuf> = if outcome.cancelled
+    let nzb_path: Option<PathBuf> = if (cancelled && !config.resume)
         || outcome.segments.is_empty()
         || config.dry_run
         || config.par2_only
@@ -377,7 +404,7 @@ pub async fn run_upload(
     // ── Notifications ────────────────────────────────────────────────────────
     let notify_enabled = config.notify.unwrap_or(true)
         && (config.notify_webhook.is_some() || config.notify_ntfy.is_some());
-    if notify_enabled && !config.par2_only && !config.dry_run && !outcome.cancelled {
+    if notify_enabled && !config.par2_only && !config.dry_run && !cancelled {
         crate::notify::send_all(&crate::notify::NotifyConfig {
             webhook_url: config.notify_webhook.as_deref(),
             ntfy_topic: config.notify_ntfy.as_deref(),
@@ -392,7 +419,7 @@ pub async fn run_upload(
     // ─────────────────────────────────────────────────────────────────────────
 
     // ── NFO + post-upload hooks ──────────────────────────────────────────────
-    if !outcome.cancelled && !had_failures && !config.par2_only && !config.dry_run {
+    if !cancelled && !had_failures && !config.par2_only && !config.dry_run {
         // Generate .nfo next to the .nzb (or next to the source files).
         let nfo_path: Option<PathBuf> = if config.nfo {
             let base = nzb_path
@@ -463,7 +490,7 @@ pub async fn run_upload(
     Ok(UploadOutcome {
         segments: outcome.segments,
         groups: outcome.groups,
-        cancelled: outcome.cancelled,
+        cancelled,
         had_failures,
         nzb_path,
         total_bytes,

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1800,12 +1800,15 @@ async fn run_real_upload(
         let _ = pesto::logging::set_session_log(p);
     }
 
-    // Bridge CancellationToken → AtomicBool (pesto's cancel mechanism).
+    // Bridge CancellationToken + signals → AtomicBool (pesto's cancel mechanism).
     let cancel_flag = Arc::new(AtomicBool::new(false));
     {
         let flag = cancel_flag.clone();
         tokio::spawn(async move {
-            cancel_token.cancelled().await;
+            tokio::select! {
+                _ = cancel_token.cancelled() => {},
+                _ = tokio::signal::ctrl_c() => {},
+            }
             flag.store(true, Ordering::Relaxed);
         });
     }


### PR DESCRIPTION
Add a single process-level signal listener, `pesto::cancel::spawn_listener`, that listens for Ctrl-C/SIGTERM and flips a shared `Arc<AtomicBool>`. Remove the duplicated signal handlers from `post_files_with_progress_and_cancel`, watch mode, and the library internals, and pass the flag through every long-running phase: post, retry, check, repost, and verify.

Bug fixes:
- Cancel during check no longer emits a false "all verified" message; it now emits `ProgressEvent::Interrupted`.
- Cancelled uploads no longer write partial NZBs, history entries, NFOs, notifications, or post-upload hooks (unless `resume = true`, in which case the partial NZB is kept for the next run).
- Watch mode no longer moves cancelled uploads to `--watch-done` and exits with code 130.
- Batch `--season` consolidation is skipped when any entry was cancelled.

Assisted-By: AI Assistant <ai@assistant.com>