### PR TITLE
fix(cli): --no-hooks no longer suppresses explicit pre/post hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `PESTO_PAR2` — PAR2 redundancy percentage (e.g. `10`).
   - `PESTO_TAGS` — space-separated list of NZB tags set via `--nzb-tag`
     (empty string when none).
+### Fixed
+- **`--no-hooks` now also leaves `--pre-hook` / `--post-hook` running in the
+  `pesto` CLI**: the library side was aligned in 0.3.31, but the CLI binary still
+  blocked both explicit hooks behind the `--no-hooks` guard. Explicit hooks now
+  always run; `--no-hooks` disables only the executable scripts in
+  `~/.config/pesto/hooks/`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -643,6 +643,10 @@ and `~/nzb/pesto/arquivo.nfo` on every run without any extra flags.
 pesto supports two hook points: **pre-upload** (runs before anything is posted,
 can abort the upload) and **post-upload** (runs after a successful upload).
 
+`--no-hooks` disables only the executable scripts found in `~/.config/pesto/hooks/`;
+explicit `--pre-hook` and `--post-hook` commands are unaffected. This lets you
+run a single explicit hook without triggering every directory script.
+
 ### Pre-upload hook
 
 A pre-upload hook runs **before compression, PAR2 generation, and NNTP
@@ -679,7 +683,10 @@ Environment variables available to the pre-hook:
 > pre-hook — the NZB and NFO don't exist yet, and the archive password is only
 > resolved after compression.
 
-The pre-hook is suppressed by `--no-hooks` and is not run during `--dry-run`.
+The pre-hook is suppressed by `--dry-run` (because nothing is uploaded) but
+still runs when combined with `--no-hooks` and `--pre-hook`. `--no-hooks`
+disables only the directory scripts in `~/.config/pesto/hooks/`; hooks passed
+explicitly via `--pre-hook` or `--post-hook` are unaffected.
 
 ### Post-upload hooks
 

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -551,6 +551,10 @@ and `~/nzb/pesto/arquivo.nfo` on every run without any extra flags.
 pesto supports two hook points: **pre-upload** (runs before anything is posted,
 can abort the upload) and **post-upload** (runs after a successful upload).
 
+`--no-hooks` disables only the executable scripts found in `~/.config/pesto/hooks/`;
+explicit `--pre-hook` and `--post-hook` commands are unaffected. This lets you
+run a single explicit hook without triggering every directory script.
+
 ### Pre-upload hook
 
 A pre-upload hook runs **before compression, PAR2 generation, and NNTP
@@ -587,7 +591,10 @@ Environment variables available to the pre-hook:
 > pre-hook — the NZB and NFO don't exist yet, and the archive password is only
 > resolved after compression.
 
-The pre-hook is suppressed by `--no-hooks` and is not run during `--dry-run`.
+The pre-hook is suppressed by `--dry-run` (because nothing is uploaded) but
+still runs when combined with `--no-hooks` and `--pre-hook`. `--no-hooks`
+disables only the directory scripts in `~/.config/pesto/hooks/`; hooks passed
+explicitly via `--pre-hook` or `--post-hook` are unaffected.
 
 ### Post-upload hooks
 

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -568,7 +568,9 @@ async fn run_single_upload(
 
     // Run pre-hook before anything else (before compression, PAR2, or NNTP).
     // Non-zero exit aborts the upload immediately.
-    if !config.no_hooks && !config.dry_run {
+    // --no-hooks suppresses only the directory scripts in ~/.config/pesto/hooks/;
+    // an explicit --pre-hook still runs.
+    if !config.dry_run {
         if let Some(cmd) = &config.pre_hook {
             let input_paths_str = inputs
                 .iter()
@@ -1284,12 +1286,13 @@ async fn run_single_upload(
             tags: &post_tags_str,
         };
 
-        if !config.no_hooks {
-            // Run --post-hook command.
-            if let Some(cmd) = &config.post_hook {
-                run_post_hook(cmd, &hook_env);
-            }
+        // --no-hooks suppresses only the directory scripts in ~/.config/pesto/hooks/.
+        // An explicit --post-hook still runs.
+        if let Some(cmd) = &config.post_hook {
+            run_post_hook(cmd, &hook_env);
+        }
 
+        if !config.no_hooks {
             // Run every executable script found in ~/.config/pesto/hooks/.
             if let Some(hooks_dir) = pesto::config::config_dir().map(|d| d.join("hooks")) {
                 run_hooks_dir(&hooks_dir, &hook_env);
@@ -1543,12 +1546,16 @@ async fn run_batch(
             };
             // Skip hooks for --dry-run / --par2-only, matching the per-entry
             // path: no real upload happened, so post-upload hooks must not fire.
-            if !config.no_hooks && !config.dry_run && !config.par2_only {
+            // --no-hooks suppresses only the directory scripts in ~/.config/pesto/hooks/;
+            // an explicit --post-hook still runs.
+            if !config.dry_run && !config.par2_only {
                 if let Some(cmd) = &config.post_hook {
                     run_post_hook(cmd, &hook_env);
                 }
-                if let Some(hooks_dir) = pesto::config::config_dir().map(|d| d.join("hooks")) {
-                    run_hooks_dir(&hooks_dir, &hook_env);
+                if !config.no_hooks {
+                    if let Some(hooks_dir) = pesto::config::config_dir().map(|d| d.join("hooks")) {
+                        run_hooks_dir(&hooks_dir, &hook_env);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Commit 62cc698 fixed hook discovery in the library, but the CLI binary still gated all hook execution behind `!config.no_hooks`. This meant `--no-hooks --pre-hook ... --post-hook ...` silently skipped the explicit hooks, contrary to the help text and user expectation.

Change the three hook call sites in `src/bin/pesto.rs` so that:

- explicit `--pre-hook` and `--post-hook` arguments always run (unless `--dry-run` is active)
- directory hook scripts under `~/.config/pesto/hooks/` are still suppressed by `--no-hooks`

Also update README.md, crates/pesto/README.md and CHANGELOG.md.

Assisted-By: AI Assistant <ai@assistant.com>