### PR TITLE
fix(hooks): expose all PESTO_* env vars from library upload path

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,12 @@ Environment variables available to the pre-hook:
 | `PESTO_INPUT_PATHS` | Colon-separated list of input file/directory paths |
 | `PESTO_SERVER` | NNTP server hostname |
 | `PESTO_GROUP` | First configured newsgroup |
+| `PESTO_GROUPS` | Colon-separated list of all configured newsgroups |
+| `PESTO_CATEGORY` | Value of `--nzb-category` (empty when not set) |
+| `PESTO_NZB_NAME` | Value of `--nzb-name` (empty when not set) |
+| `PESTO_OBFUSCATE` | Obfuscation mode in use: `none`, `full`, or `paranoid` |
+| `PESTO_PAR2` | PAR2 redundancy percentage (e.g. `10`) |
+| `PESTO_TAGS` | Space-separated list of NZB tags (empty when none) |
 
 > `PESTO_NZB`, `PESTO_NFO`, and `PESTO_PASSWORD` are **not** available in the
 > pre-hook — the NZB and NFO don't exist yet, and the archive password is only
@@ -701,9 +707,15 @@ following environment variables:
 | `PESTO_NAME` | Release name / entry label |
 | `PESTO_BYTES` | Total bytes posted (decimal string) |
 | `PESTO_INPUT_PATHS` | Colon-separated list of input file/directory paths |
-| `PESTO_GROUP` | First Usenet newsgroup |
-| `PESTO_PASSWORD` | Archive password (empty when none) |
 | `PESTO_SERVER` | NNTP server hostname |
+| `PESTO_GROUP` | First Usenet newsgroup |
+| `PESTO_GROUPS` | Colon-separated list of all configured newsgroups |
+| `PESTO_PASSWORD` | Archive password (empty when none) |
+| `PESTO_CATEGORY` | Value of `--nzb-category` (empty when not set) |
+| `PESTO_NZB_NAME` | Value of `--nzb-name` (empty when not set) |
+| `PESTO_OBFUSCATE` | Obfuscation mode in use: `none`, `full`, or `paranoid` |
+| `PESTO_PAR2` | PAR2 redundancy percentage (e.g. `10`) |
+| `PESTO_TAGS` | Space-separated list of NZB tags (empty when none) |
 
 Scripts must have the executable bit set on Unix (`chmod +x`). On Windows,
 files with `.exe`, `.cmd`, `.bat`, `.ps1`, or `.py` extensions are recognised

--- a/config.example.toml
+++ b/config.example.toml
@@ -186,6 +186,12 @@ groups = ["alt.binaries.test"]
 #   PESTO_INPUT_PATHS  — colon-separated list of input file/directory paths
 #   PESTO_SERVER       — target NNTP server hostname
 #   PESTO_GROUP        — first configured newsgroup
+#   PESTO_GROUPS       — colon-separated list of all configured newsgroups
+#   PESTO_CATEGORY     — value of --nzb-category (empty when not set)
+#   PESTO_NZB_NAME     — value of --nzb-name (empty when not set)
+#   PESTO_OBFUSCATE    — obfuscation mode in use: none, full, or paranoid
+#   PESTO_PAR2         — PAR2 redundancy percentage (e.g. 10)
+#   PESTO_TAGS         — space-separated list of NZB tags (empty when none)
 #
 # Use case: query NZBHydra2 or Prowlarr before uploading to avoid duplicates.
 # Example (abort if the release is already indexed):
@@ -197,7 +203,8 @@ groups = ["alt.binaries.test"]
 # post_hook — shell command executed after each successful upload.
 # Runs via `sh -c` on Unix or `cmd /c` on Windows. The following environment
 # variables are available: PESTO_NZB, PESTO_NFO, PESTO_NAME, PESTO_BYTES,
-# PESTO_INPUT_PATHS, PESTO_GROUP, PESTO_PASSWORD, PESTO_SERVER.
+# PESTO_INPUT_PATHS, PESTO_SERVER, PESTO_GROUP, PESTO_GROUPS, PESTO_PASSWORD,
+# PESTO_CATEGORY, PESTO_NZB_NAME, PESTO_OBFUSCATE, PESTO_PAR2, PESTO_TAGS.
 # post_hook = "notify-send 'pesto' 'Upload done: $PESTO_NAME'"
 #
 # See examples/hooks/ for ready-made hook scripts (curupira.sh, generic-indexer.sh, etc.).

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -586,6 +586,12 @@ Environment variables available to the pre-hook:
 | `PESTO_INPUT_PATHS` | Colon-separated list of input file/directory paths |
 | `PESTO_SERVER` | NNTP server hostname |
 | `PESTO_GROUP` | First configured newsgroup |
+| `PESTO_GROUPS` | Colon-separated list of all configured newsgroups |
+| `PESTO_CATEGORY` | Value of `--nzb-category` (empty when not set) |
+| `PESTO_NZB_NAME` | Value of `--nzb-name` (empty when not set) |
+| `PESTO_OBFUSCATE` | Obfuscation mode in use: `none`, `full`, or `paranoid` |
+| `PESTO_PAR2` | PAR2 redundancy percentage (e.g. `10`) |
+| `PESTO_TAGS` | Space-separated list of NZB tags (empty when none) |
 
 > `PESTO_NZB`, `PESTO_NFO`, and `PESTO_PASSWORD` are **not** available in the
 > pre-hook — the NZB and NFO don't exist yet, and the archive password is only
@@ -609,9 +615,15 @@ following environment variables:
 | `PESTO_NAME` | Release name / entry label |
 | `PESTO_BYTES` | Total bytes posted (decimal string) |
 | `PESTO_INPUT_PATHS` | Colon-separated list of input file/directory paths |
-| `PESTO_GROUP` | First Usenet newsgroup |
-| `PESTO_PASSWORD` | Archive password (empty when none) |
 | `PESTO_SERVER` | NNTP server hostname |
+| `PESTO_GROUP` | First Usenet newsgroup |
+| `PESTO_GROUPS` | Colon-separated list of all configured newsgroups |
+| `PESTO_PASSWORD` | Archive password (empty when none) |
+| `PESTO_CATEGORY` | Value of `--nzb-category` (empty when not set) |
+| `PESTO_NZB_NAME` | Value of `--nzb-name` (empty when not set) |
+| `PESTO_OBFUSCATE` | Obfuscation mode in use: `none`, `full`, or `paranoid` |
+| `PESTO_PAR2` | PAR2 redundancy percentage (e.g. `10`) |
+| `PESTO_TAGS` | Space-separated list of NZB tags (empty when none) |
 
 Scripts must have the executable bit set on Unix (`chmod +x`). On Windows,
 files with `.exe`, `.cmd`, `.bat`, `.ps1`, or `.py` extensions are recognised

--- a/crates/pesto/examples/hooks/generic-indexer.sh
+++ b/crates/pesto/examples/hooks/generic-indexer.sh
@@ -11,7 +11,7 @@
 # Dependencies: curl, ffmpeg (only required for video files), jq
 
 # ╔══════════════════════════════════════════════════════════════╗
-# ║                      CONFIGURATION                          ║
+# ║                      CONFIGURATION                           ║
 # ╚══════════════════════════════════════════════════════════════╝
 
 IMGBB_API_KEY="YOUR_IMGBB_API_KEY"   # https://api.imgbb.com/
@@ -22,18 +22,20 @@ INDEXER_API_KEY="YOUR_API_KEY"
 CATEGORY_ID=0  # Newznab category (0 = auto-detect). e.g. 5040 for TV/HD, 2040 for Movies/HD
 
 # ╔══════════════════════════════════════════════════════════════╗
-# ║                   END OF CONFIGURATION                      ║
+# ║                   END OF CONFIGURATION                       ║
 # ╚══════════════════════════════════════════════════════════════╝
 
 # --- pesto variables available in this hook ---
 # PESTO_NZB          — path to the generated .nzb
 # PESTO_NFO          — path to the .nfo (empty when --nfo was not used)
 # PESTO_NAME         — release name
-# PESTO_INPUT_PATHS  — newline-separated list of uploaded file paths
+# PESTO_INPUT_PATHS  — colon-separated list of uploaded file paths
 # PESTO_BYTES        — total uploaded bytes
 # PESTO_SERVER       — server hostname
-# PESTO_GROUP        — Usenet group
+# PESTO_GROUP        — first Usenet group
+# PESTO_GROUPS       — colon-separated list of all Usenet groups
 # PESTO_PASSWORD     — yEnc password (if any)
+# PESTO_TAGS         — space-separated list of NZB tags (empty when none)
 
 set -euo pipefail
 

--- a/crates/pesto/examples/hooks/other-indexer.sh
+++ b/crates/pesto/examples/hooks/other-indexer.sh
@@ -17,9 +17,16 @@ LANGUAGE=""    # leave empty to auto-detect from the NFO (mediainfo output),
                # or set a fixed value (e.g. "Portuguese") to always send it
 
 # --- pesto variables ---
-# PESTO_NZB  — path to the generated .nzb
-# PESTO_NFO  — path to the .nfo (empty when --nfo was not used)
-# PESTO_NAME — release name
+# PESTO_NZB          — path to the generated .nzb
+# PESTO_NFO          — path to the .nfo (empty when --nfo was not used)
+# PESTO_NAME         — release name
+# PESTO_INPUT_PATHS  — colon-separated list of uploaded file paths
+# PESTO_BYTES        — total uploaded bytes
+# PESTO_SERVER       — server hostname
+# PESTO_GROUP        — first Usenet group
+# PESTO_GROUPS       — colon-separated list of all Usenet groups
+# PESTO_PASSWORD     — yEnc password (if any)
+# PESTO_TAGS         — space-separated list of NZB tags (empty when none)
 
 if [ -z "$PESTO_NZB" ] || [ ! -f "$PESTO_NZB" ]; then
     echo "[Indexer] Error: NZB not found (PESTO_NZB=$PESTO_NZB)."

--- a/crates/pesto/examples/hooks/print-vars.sh
+++ b/crates/pesto/examples/hooks/print-vars.sh
@@ -8,15 +8,15 @@
 # pesto sets the following variables before running every hook:
 #   PESTO_NAME        — release name / entry label (derived from the input path)
 #   PESTO_BYTES       — total bytes posted (decimal)
-#   PESTO_INPUT_PATHS — space-separated list of input paths that were posted
+#   PESTO_INPUT_PATHS — colon-separated list of input paths that were posted
 #   PESTO_SERVER      — NNTP server hostname
 #   PESTO_GROUP       — first Usenet newsgroup
-#   PESTO_GROUPS      — space-separated list of all newsgroups
+#   PESTO_GROUPS      — colon-separated list of all newsgroups
 #   PESTO_PASSWORD    — archive password (empty when none)
 #   PESTO_CATEGORY    — NZB category (empty when none)
 #   PESTO_NZB_NAME    — value of --nzb-name, emitted as <meta type="name"> in the .nzb (empty when not set)
 #   PESTO_OBFUSCATE   — obfuscation mode in use
-#   PESTO_PAR2        — true/false — whether PAR2 recovery files were generated
+#   PESTO_PAR2        — PAR2 redundancy percentage (e.g. 10)
 #   PESTO_TAGS        — space-separated list of NZB tags (empty when none)
 #
 # Post-upload hooks additionally receive:

--- a/crates/pesto/src/hooks.rs
+++ b/crates/pesto/src/hooks.rs
@@ -20,9 +20,16 @@ use crate::config::Config;
 pub struct HookContext {
     pub name: String,
     pub total_bytes: u64,
+    pub input_paths: String,
     pub server: String,
     pub group: String,
+    pub groups: String,
     pub password: String,
+    pub category: String,
+    pub nzb_name: String,
+    pub obfuscate: String,
+    pub par2: u8,
+    pub tags: String,
     pub nzb_path: String,
     pub nfo_path: String,
 }
@@ -115,9 +122,16 @@ pub fn run_one_hook(path: &Path, ctx: &HookContext) -> (bool, Vec<String>) {
 fn apply_env(cmd: &mut Command, ctx: &HookContext) {
     cmd.env("PESTO_NAME", &ctx.name)
         .env("PESTO_BYTES", ctx.total_bytes.to_string())
+        .env("PESTO_INPUT_PATHS", &ctx.input_paths)
         .env("PESTO_SERVER", &ctx.server)
         .env("PESTO_GROUP", &ctx.group)
+        .env("PESTO_GROUPS", &ctx.groups)
         .env("PESTO_PASSWORD", &ctx.password)
+        .env("PESTO_CATEGORY", &ctx.category)
+        .env("PESTO_NZB_NAME", &ctx.nzb_name)
+        .env("PESTO_OBFUSCATE", &ctx.obfuscate)
+        .env("PESTO_PAR2", ctx.par2.to_string())
+        .env("PESTO_TAGS", &ctx.tags)
         .env("PESTO_NZB", &ctx.nzb_path)
         .env("PESTO_NFO", &ctx.nfo_path);
 }

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -456,14 +456,30 @@ pub async fn run_upload(
         let hook_ctx = crate::hooks::HookContext {
             name: entry_label.to_string(),
             total_bytes,
+            input_paths: entry_paths
+                .iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join(":"),
             server: config.host.clone(),
             group: config.groups.first().cloned().unwrap_or_default(),
+            groups: config.groups.join(":"),
             password: config
                 .nzb_password
                 .as_deref()
                 .or(config.compress_password.as_deref())
                 .unwrap_or("")
                 .to_string(),
+            category: config.nzb_category.clone().unwrap_or_default(),
+            nzb_name: config.nzb_name.clone().unwrap_or_default(),
+            obfuscate: match config.obfuscate {
+                ObfuscateMode::None => "none",
+                ObfuscateMode::Full => "full",
+                ObfuscateMode::Paranoid => "paranoid",
+            }
+            .to_string(),
+            par2: config.par2,
+            tags: config.nzb_tags.join(" "),
             nzb_path: nzb_path
                 .as_ref()
                 .map(|p| p.to_string_lossy().into_owned())

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1007,14 +1007,26 @@ fn run_selected_hook(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
         let ctx = pesto::hooks::HookContext {
             name: release_name.clone(),
             total_bytes,
+            input_paths: String::new(),
             server: cfg.host.clone(),
             group: cfg.groups.first().cloned().unwrap_or_default(),
+            groups: cfg.groups.join(":"),
             password: cfg
                 .nzb_password
                 .as_deref()
                 .or(cfg.compress_password.as_deref())
                 .unwrap_or("")
                 .to_string(),
+            category: cfg.nzb_category.clone().unwrap_or_default(),
+            nzb_name: cfg.nzb_name.clone().unwrap_or_default(),
+            obfuscate: match cfg.obfuscate {
+                ObfuscateMode::None => "none",
+                ObfuscateMode::Full => "full",
+                ObfuscateMode::Paranoid => "paranoid",
+            }
+            .to_string(),
+            par2: cfg.par2,
+            tags: cfg.nzb_tags.join(" "),
             nzb_path: nzb_path.to_string_lossy().into_owned(),
             nfo_path: nfo_path
                 .as_ref()
@@ -1763,14 +1775,26 @@ async fn run_season_hooks(
     let ctx = pesto::hooks::HookContext {
         name: label.to_string(),
         total_bytes,
+        input_paths: String::new(),
         server: config.host.clone(),
         group: config.groups.first().cloned().unwrap_or_default(),
+        groups: config.groups.join(":"),
         password: config
             .nzb_password
             .as_deref()
             .or(config.compress_password.as_deref())
             .unwrap_or("")
             .to_string(),
+        category: config.nzb_category.clone().unwrap_or_default(),
+        nzb_name: config.nzb_name.clone().unwrap_or_default(),
+        obfuscate: match config.obfuscate {
+            ObfuscateMode::None => "none",
+            ObfuscateMode::Full => "full",
+            ObfuscateMode::Paranoid => "paranoid",
+        }
+        .to_string(),
+        par2: config.par2,
+        tags: config.nzb_tags.join(" "),
         nzb_path: nzb_path.to_string_lossy().into_owned(),
         nfo_path: nfo_path
             .as_ref()


### PR DESCRIPTION
The CLI binary (`crates/pesto/src/bin/pesto.rs`) already set the full set
of hook environment variables, but the shared library path in
`crates/pesto/src/hooks.rs` only exported the original subset. This meant
embedders like upapasta, and the library upload path in
`crates/pesto/src/upload.rs`, did not expose:

- PESTO_INPUT_PATHS
- PESTO_GROUPS
- PESTO_CATEGORY
- PESTO_NZB_NAME
- PESTO_OBFUSCATE
- PESTO_PAR2
- PESTO_TAGS

Extend `HookContext` with the missing fields, update `apply_env` to export
them, and populate them in `upload.rs` and `upapasta/src/main.rs` so all
hook consumers receive the same variables regardless of entry point

Also:

Update `config.example.toml`, `README.md`, and `crates/pesto/README.md` hook
sections to list every variable exposed by the code.

Also fix example hook comments:
- `print-vars.sh`: `PESTO_PAR2` is the numeric percentage, not a boolean
- `print-vars.sh`: `PESTO_INPUT_PATHS` and `PESTO_GROUPS` are colon-separated
- `generic-indexer.sh`: `PESTO_INPUT_PATHS` is colon-separated, not newline
- `other-indexer.sh`: expand variable list and note separators