### PR TITLE
penne: wire live progress into `penne download`

### DIFF
--- a/crates/penne/README.md
+++ b/crates/penne/README.md
@@ -133,6 +133,15 @@ cargo run --bin penne -- download path/to/release.nzb \
 If anything is still incomplete or damaged after step 4, `penne download`
 exits non-zero and reports which files.
 
+### Progress
+
+While fetching, `penne download` prints a live status line (`fetching:
+1234/6968 segments (18%) — 3 missing, 0 corrupt`) instead of sitting silent
+until the whole queue is done — a large release can take a while, and no
+output for minutes looks like a hang even when it isn't. On an interactive
+terminal the line updates in place; redirected to a file or pipe, it prints
+one line per whole percentage point instead.
+
 ### Resume
 
 An interrupted `penne download` run doesn't start over: every successfully

--- a/crates/penne/ROADMAP.md
+++ b/crates/penne/ROADMAP.md
@@ -43,6 +43,7 @@ testable state.
 | 2 | NNTP article retrieval — `BODY` in `pesto::nntp`, `DownloadClient::body`, per-segment server failover, missing-segment tracking |
 | 3 | yEnc decoding — `pesto::yenc::decode_part`, wired into `download_queue` with per-segment corrupt-copy failover |
 | 4 | File assembly — `penne::assemble::assemble`/`assemble_all`, whole-file CRC-32, temp-file-then-rename; `penne download` CLI now performs a real end-to-end download |
+| 5 (partial) | Progress & CLI UX — live `fetching: N/M segments (P%)` status line in `penne download`, found missing while dogfooding a release build. Exit-code granularity and `--verbose`/`--quiet` still open. |
 | 6 | PAR2 verify & repair — `penne::repair::verify_and_repair`, wired into `penne download`; recreates fully-missing files and patches damaged ones via `pesto::par2` |
 | 7 | Archive extraction — `penne::extract::extract_all` (`.rar`/`.7z`/`.zip`, multi-volume, password), wired into `penne download` after PAR2 |
 | 8 | Resilience — `penne::cache` (segment-level resume), configurable retry/backoff in `download_queue` |
@@ -176,10 +177,31 @@ back.
       `std::process::Command` inside an async `tokio` test would otherwise
       risk starving the mock server's own task).
 
-## Phase 5 — Progress & CLI UX
+## Phase 5 — Progress & CLI UX (partial: live progress done; exit-code granularity and `--verbose`/`--quiet` still open)
 
-- [ ] Wire `penne::progress::ProgressEvent` into `penne download`: live
-      per-file progress, not just the current "would download" summary.
+- [x] Wire `penne::progress::ProgressEvent` into `penne download`: found
+      missing while dogfooding a release build — `download_queue` ran with
+      `progress: None`, so a real multi-thousand-segment release printed
+      nothing at all until the entire fetch finished, reading as a hang.
+      `download()` now opens a channel, spawns a task
+      (`print_progress`) that prints a live `fetching: 1234/6968 segments
+      (18%) — N missing, M corrupt` status line, and passes the sender (and
+      a clone) into both `download_queue` and `assemble_all` so
+      `FileAssembled` events show up too. Interactive terminals get an
+      in-place-updating line (`\r` + ANSI clear-line); redirected output
+      gets one line per whole percentage point instead, so a log file
+      doesn't fill up with carriage returns.
+      A real ordering bug turned up while verifying this manually under a
+      pty (`script`): the post-fetch summary line was printed immediately
+      after `download_queue` returned, but the unbounded progress channel
+      could still have buffered events the printer task hadn't drained
+      yet, so the summary interleaved mid-percentage. Fixed by awaiting the
+      printer task (after dropping the last sender) before printing
+      anything else — see `crates/penne/src/bin/penne.rs`.
+      Verified both automatically (`tests/cli_download_end_to_end.rs`,
+      captured stdout — the test harness's pipe isn't a TTY, so this
+      exercises the non-interactive one-line-per-percent path
+      deterministically) and manually under a real pty via `script`.
 - [ ] Exit codes distinguishing "fully complete", "complete after repair",
       and "incomplete/missing data" — a downloader's most important signal.
 - [ ] `--verbose`/`--quiet`, matching `pesto`'s conventions.

--- a/crates/penne/src/bin/penne.rs
+++ b/crates/penne/src/bin/penne.rs
@@ -8,10 +8,12 @@
 //! (Phase 3), file assembly (Phase 4), PAR2 verify/repair (Phase 6), and
 //! archive extraction (Phase 7).
 
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use penne::progress::ProgressEvent;
 
 #[derive(Parser)]
 #[command(
@@ -125,9 +127,32 @@ async fn download(
     );
     let dest_dir = out_dir.unwrap_or(config.download_dir);
 
-    let outcome =
-        penne::download::download_queue(&queue, &config.servers, &dest_dir, config.retries, None)
+    let total_segments: usize = queue.files.iter().map(|f| f.segments.len()).sum();
+    let (tx, rx) = penne::progress::channel();
+    let tx_for_assemble = tx.clone();
+    let progress_task = tokio::spawn(print_progress(rx, total_segments));
+
+    let outcome = penne::download::download_queue(
+        &queue,
+        &config.servers,
+        &dest_dir,
+        config.retries,
+        Some(tx),
+    )
+    .await?;
+
+    let assembled =
+        penne::assemble::assemble_all(&queue, &outcome.segments, &dest_dir, Some(&tx_for_assemble))
             .await?;
+    // The download's sender was consumed by `download_queue`; this is the
+    // last copy, so dropping it lets `print_progress`'s receive loop end.
+    // Awaiting it before printing anything else guarantees every live
+    // progress line has already been flushed, so the summary below can't
+    // interleave with it (the unbounded channel means `download_queue` can
+    // return well before `print_progress` finishes draining it).
+    drop(tx_for_assemble);
+    progress_task.await.ok();
+
     println!(
         "fetched {} segment(s); {} missing; {} corrupt",
         outcome.segments.len(),
@@ -144,8 +169,6 @@ async fn download(
         );
     }
 
-    let assembled =
-        penne::assemble::assemble_all(&queue, &outcome.segments, &dest_dir, None).await?;
     let mut needs_repair = 0u32;
     for (name, result) in &assembled {
         match result {
@@ -200,4 +223,56 @@ async fn download(
     penne::cache::clear(&dest_dir)?;
 
     Ok(())
+}
+
+/// Drain `rx` and print a live status line while fetch/assembly run,
+/// otherwise the terminal sits silent for however long a large release
+/// takes to download — which reads as a hang, not progress.
+///
+/// On an interactive terminal the status line overwrites itself in place
+/// (`\r`); redirected to a file or pipe, that would just fill a log with
+/// carriage returns, so it instead prints one line per whole percentage
+/// point.
+async fn print_progress(mut rx: penne::progress::ProgressReceiver, total_segments: usize) {
+    let interactive = std::io::stdout().is_terminal();
+    let mut done = 0usize;
+    let mut missing = 0usize;
+    let mut corrupt = 0usize;
+    let mut last_printed_pct = None;
+
+    while let Some(event) = rx.recv().await {
+        match event {
+            ProgressEvent::SegmentDownloaded { .. } => done += 1,
+            ProgressEvent::SegmentMissing { .. } => {
+                done += 1;
+                missing += 1;
+            }
+            ProgressEvent::SegmentCorrupt { .. } => {
+                done += 1;
+                corrupt += 1;
+            }
+            ProgressEvent::FileAssembled { file_name } => {
+                if interactive {
+                    print!("\r\x1b[2K");
+                }
+                println!("  assembled: {file_name}");
+                continue;
+            }
+        }
+
+        let pct = (done * 100).checked_div(total_segments).unwrap_or(100);
+        let line =
+            format!("fetching: {done}/{total_segments} segments ({pct}%) — {missing} missing, {corrupt} corrupt");
+        if interactive {
+            print!("\r\x1b[2K{line}");
+            std::io::stdout().flush().ok();
+        } else if last_printed_pct != Some(pct) {
+            println!("{line}");
+            last_printed_pct = Some(pct);
+        }
+    }
+
+    if interactive && total_segments > 0 {
+        println!();
+    }
 }

--- a/crates/penne/tests/cli_download_end_to_end.rs
+++ b/crates/penne/tests/cli_download_end_to_end.rs
@@ -314,3 +314,80 @@ fn download_recovers_a_fully_missing_segment_via_par2() {
     let recovered = std::fs::read(download_dir.join("movie.bin")).unwrap();
     assert_eq!(recovered, original);
 }
+
+#[test]
+fn download_prints_live_progress_instead_of_staying_silent_until_done() {
+    // Regression test: `penne download` used to build the whole
+    // `DownloadOutcome` before printing anything at all, so a large release
+    // looked hung for however long the fetch took. `print_progress` should
+    // now report as segments land.
+    let part1 = b"first half of the file".to_vec();
+    let part2 = b"second half of the file".to_vec();
+    let encoded1 = encode_part(
+        "movie.bin",
+        (part1.len() + part2.len()) as u64,
+        PartSpec {
+            number: 1,
+            total: 2,
+            offset: 0,
+        },
+        &part1,
+        128,
+        None,
+    );
+    let encoded2 = encode_part(
+        "movie.bin",
+        (part1.len() + part2.len()) as u64,
+        PartSpec {
+            number: 2,
+            total: 2,
+            offset: part1.len() as u64,
+        },
+        &part2,
+        128,
+        None,
+    );
+
+    let mut known = HashMap::new();
+    known.insert("seg1@test", encoded1.body);
+    known.insert("seg2@test", encoded2.body);
+    let addr = spawn_fake_server(known);
+
+    let dir = tempfile::tempdir().unwrap();
+    let download_dir = dir.path().join("downloads");
+
+    let nzb_path = write_nzb(
+        dir.path(),
+        vec![
+            segment("movie.bin", 1, 2, "seg1@test", part1.len() as u64),
+            segment("movie.bin", 2, 2, "seg2@test", part2.len() as u64),
+        ],
+    );
+    let config_path = write_config(dir.path(), &download_dir, addr.port());
+
+    let output = run_penne_download(&nzb_path, &config_path);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The test harness captures the child's stdout via a pipe, not a TTY,
+    // so `print_progress` takes its non-interactive, one-line-per-percent
+    // path — deterministic and easy to assert on, unlike the `\r`-driven
+    // interactive path.
+    assert!(
+        stdout.contains("fetching: 1/2 segments (50%)"),
+        "stdout did not contain a progress line at 50%%:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("fetching: 2/2 segments (100%)"),
+        "stdout did not contain a progress line at 100%%:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("assembled: movie.bin"),
+        "stdout did not report the file being assembled:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Reported by the user while testing a release build: `penne download` prints "using config: ..." and then nothing at all until the entire fetch finishes. Root cause: `download_queue` and `assemble_all` were both called with `progress: None`, so the progress-event plumbing that already existed (`penne::progress`) was never actually wired into the CLI. For a real release with thousands of segments, this is indistinguishable from a hang.

## Fix

- `download()` now opens a progress channel, spawns a `print_progress` task, and passes the sender into both `download_queue` and `assemble_all` (via a clone).
- Live status line: `fetching: 1234/6968 segments (18%) — N missing, M corrupt`. On an interactive terminal it updates in place (`\r` + ANSI clear-line); redirected to a file/pipe it prints one line per whole percentage point instead, so logs don't fill up with carriage returns.
- `FileAssembled` events print as `  assembled: <name>` alongside the live line.
- Found and fixed a real ordering bug while verifying this manually under a pty (`script`): the post-fetch summary line printed immediately after `download_queue` returned, but the *unbounded* progress channel could still have buffered events the printer task hadn't drained yet — so the summary interleaved mid-percentage with the live line. Fixed by awaiting the printer task (after dropping the last sender) before printing anything else.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --all` passes
- [x] New regression test (`tests/cli_download_end_to_end.rs`) captures the child process's stdout and asserts on the progress lines — the test harness's pipe isn't a TTY, so this deterministically exercises the non-interactive one-line-per-percent path
- [x] Manually verified the interactive (`\r`-updating) path under a real pty via `script`, including confirming the ordering fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE8yJP8SM5wft5VAYKcz1A