### PR TITLE
pesto: bump to v0.3.62, own versioning/release like parmesan and penne

### DIFF
--- a/.github/workflows/release-parmesan.yml
+++ b/.github/workflows/release-parmesan.yml
@@ -1,9 +1,10 @@
 name: Release parmesan
 
-# Separate from release.yml (which builds/releases the `pesto` binary on
-# `v*` tags): parmesan is versioned and published independently — see
-# crates/parmesan/CHANGELOG.md — so it gets its own tag prefix and its own
-# GitHub Release, on its own cadence, entirely decoupled from pesto's.
+# Separate from release-pesto.yml (which builds/releases the `pesto` binary
+# on `pesto-v*` tags) and release-penne.yml: parmesan is versioned and
+# published independently — see crates/parmesan/CHANGELOG.md — so it gets
+# its own tag prefix and its own GitHub Release, on its own cadence,
+# entirely decoupled from pesto's and penne's.
 #
 # To ship a new parmesan binary release:
 #   git tag parmesan-v<version>   # matching crates/parmesan/Cargo.toml

--- a/.github/workflows/release-penne.yml
+++ b/.github/workflows/release-penne.yml
@@ -1,10 +1,10 @@
 name: Release penne
 
-# Separate from release.yml (which builds/releases the `pesto` binary on
-# `v*` tags) and release-parmesan.yml: penne is versioned and published
-# independently — see crates/penne/CHANGELOG.md — so it gets its own tag
-# prefix and its own GitHub Release, on its own cadence, entirely decoupled
-# from pesto's and parmesan's.
+# Separate from release-pesto.yml (which builds/releases the `pesto` binary
+# on `pesto-v*` tags) and release-parmesan.yml: penne is versioned and
+# published independently — see crates/penne/CHANGELOG.md — so it gets its
+# own tag prefix and its own GitHub Release, on its own cadence, entirely
+# decoupled from pesto's and parmesan's.
 #
 # To ship a new penne binary release:
 #   git tag penne-v<version>   # matching crates/penne/Cargo.toml

--- a/.github/workflows/release-pesto.yml
+++ b/.github/workflows/release-pesto.yml
@@ -1,9 +1,19 @@
-name: Release
+name: Release pesto
+
+# Separate from release-parmesan.yml and release-penne.yml: pesto is
+# versioned and published independently — see crates/pesto/CHANGELOG.md and
+# crates/pesto/RELEASING.md — so it gets its own tag prefix and its own
+# GitHub Release, on its own cadence, entirely decoupled from parmesan's and
+# penne's.
+#
+# To ship a new pesto binary release:
+#   git tag pesto-v<version>   # matching crates/pesto/Cargo.toml
+#   git push origin pesto-v<version>
 
 on:
   push:
     tags:
-      - 'v*'
+      - 'pesto-v*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -43,10 +53,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-pesto-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release -p pesto-poster --bin pesto --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -77,4 +87,12 @@ jobs:
             pesto-linux-x86_64
             pesto-linux-x86_64-musl
             pesto-windows-x86_64.exe
-          generate_release_notes: true
+          # Not `generate_release_notes: true` — GitHub's auto-generated notes
+          # pick the previous *tag by creation time* across the whole repo,
+          # which would pull in unrelated `parmesan-v*`/`penne-v*` tags
+          # interleaved with `pesto-v*` ones. Point at the crate's own
+          # changelog instead.
+          body: |
+            See [`crates/pesto/CHANGELOG.md`](https://github.com/franzopl/pesto/blob/main/crates/pesto/CHANGELOG.md) for what changed in this release.
+
+            Also published to [crates.io](https://crates.io/crates/pesto-poster) and documented on [docs.rs](https://docs.rs/pesto-poster).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.3.61"
+version = "0.3.62"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/crates/parmesan/RELEASING.md
+++ b/crates/parmesan/RELEASING.md
@@ -7,8 +7,8 @@ which exercised every step here.
 `parmesan` is versioned, published, and released **independently of
 `pesto`** — different cadence, different tags, different crates.io package.
 Don't confuse this with `pesto`'s own release process
-(`.github/workflows/release.yml`, tags `v*`): that one builds and releases
-the `pesto` binary and has nothing to do with `parmesan`.
+(`.github/workflows/release-pesto.yml`, tags `pesto-v*`): that one builds
+and releases the `pesto` binary and has nothing to do with `parmesan`.
 
 ## Prerequisites
 

--- a/crates/penne/ROADMAP.md
+++ b/crates/penne/ROADMAP.md
@@ -427,8 +427,8 @@ back.
       that file; omitted entirely → the default path, with a clear error
       (not a silent no-servers run) if nothing exists there yet.
 - [ ] Add `penne` to the release workflow once it has a stable CLI surface
-      (see `.github/workflows/release.yml` / `release-parmesan.yml` for the
-      pattern to follow).
+      (see `.github/workflows/release-pesto.yml` / `release-parmesan.yml`
+      for the pattern to follow).
 
 ## Phase 11 — De-obfuscation ✅ (core done; multi-recovery-set clustering and multi-volume ZIP guessing explicitly out of scope)
 

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -1,34 +1,33 @@
-# Changelog
+# Changelog — pesto
 
 All notable changes to `pesto` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+`pesto` is versioned, published, and released independently of the rest of
+the workspace — see [`RELEASING.md`](RELEASING.md). Entries here cover the
+`pesto` binary/library only; `penne` and `parmesan` keep their own
+changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ---
 
 ## [Unreleased]
 
-### Added (penne)
-- **`HEAD`/`BODY`-based availability checks** (`--stat=head`/`--stat=body`,
-  alongside the existing `STAT`-only `--stat`) **plus `--sample <N>`** to
-  bound a `body` check's real bandwidth cost to the first `N` segment(s)
-  per file: `pesto::nntp::Connection::head` usually (not always — see the
-  `penne` changelog) reads from the same article storage `BODY` does,
-  catching a provider whose `STAT` index says an article is present when
-  it actually isn't — a real report during development (99.99% "present"
-  via `STAT`, 0% actually downloadable, and in that specific case `HEAD`
-  agreed with `STAT` — only a real `BODY` check caught it).
-- **Named/selectable `[[servers]]` entries**: an entry can carry a `name`
-  for `--server <NAME>` (repeatable) to run `penne download`/`--stat`
-  against one or more specific configured providers instead of always
-  drawing on every configured server, and `explicit_only = true` to
-  exclude a quota/block account from that default set unless named
-  directly — for a provider that must never be a silent automatic
-  fallback.
-- **Config-driven default `--mode`**: the config file can now set `mode`
-  (`download`/`repair`/`unpack`/`delete`) as the default processing level
-  for `penne download`, still overridable per run with `--mode`; the
-  interactive `penne --config` wizard now prompts for it, explaining what
-  each level does.
+## [0.3.62] — 2026-07-22
+
+### Added
+- **External-ID reference flags**: `--tmdb <movie|tv>/<id>` (`:` also
+  accepted as the separator, e.g. `movie:12345`), `--imdb-id <id>`,
+  `--tvdb-id <id>` and `--mal-id <id>`. Each is written as a structured
+  `<meta type="tmdbid"/"imdbid"/"tvdbid"/"malid">` element in the `.nzb`
+  and, when `--nfo` is set, as an `IMDb:`/`TMDb:`/`TVDB:`/`MAL:` header
+  line in the generated `.nfo`. `--tmdb`'s `movie`/`tv` prefix also derives
+  a default `--nzb-category` (`movies`/`tv`) when the user hasn't set one
+  explicitly — resolved entirely from the flag's own value, no TMDb/IMDb
+  API calls are made (metadata *lookup*/enrichment stays `upapasta`'s job
+  per the workspace's architecture principles). `--imdb-id` accepts the ID
+  with or without its `tt` prefix and zero-pads it to 7 digits (`133093`
+  normalizes to `tt0133093`); `--tvdb-id`/`--mal-id` take a plain numeric
+  ID.
 
 ---
 

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "pesto-poster"
-version.workspace = true
+# pesto is versioned, published, and released independently of the rest of
+# the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
+version = "0.3.62"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."

--- a/crates/pesto/RELEASING.md
+++ b/crates/pesto/RELEASING.md
@@ -1,0 +1,141 @@
+# Releasing `pesto`
+
+How to cut a new release of `pesto-poster`: crates.io, docs.rs, and a
+GitHub release with prebuilt binaries.
+
+`pesto` is versioned, published, and released **independently of the rest
+of the workspace** — own cadence, own tags, own crates.io package. Don't
+confuse this with `parmesan`'s or `penne`'s release processes
+(`.github/workflows/release-parmesan.yml` / `release-penne.yml`, tags
+`parmesan-v*` / `penne-v*`): those build and release their own binaries and
+have nothing to do with `pesto`.
+
+## Prerequisites
+
+- Push access to `main` (or an approved PR).
+- A crates.io API token for the `pesto-poster` crate, logged in locally
+  (`cargo login`) or already present in `~/.cargo/credentials.toml`.
+- The full pre-commit checklist passing — see the root `CLAUDE.md` — before
+  you start: `cargo fmt --check`, `cargo clippy --all-targets -- -D
+  warnings`, `cargo test`, all from the workspace root.
+
+## Steps
+
+### 1. Decide the version bump
+
+`pesto-poster` is pre-1.0, so Cargo's semver rules for `0.x` apply: the
+**second** number is the effective "major" — bump it for anything that
+could break a consumer (new required behavior, changed output format,
+removed/renamed public items) or that ships a substantial new feature
+surface. Bump the **third** number for backwards-compatible fixes and
+additions.
+
+### 2. Update `crates/pesto/Cargo.toml`
+
+Bump `version`. If the change is significant enough, consider whether
+`description` still accurately describes the crate (it does not
+auto-update).
+
+### 3. Update every workspace crate that pins a version on `pesto-poster`
+
+Not just the `path` — Cargo enforces the version *requirement* string too,
+even for path dependencies within a workspace. Check:
+
+```bash
+grep -rn 'pesto-poster' --include=Cargo.toml crates/
+```
+
+As of this writing, `crates/penne/Cargo.toml`, `crates/sugo/Cargo.toml` and
+`crates/upapasta/Cargo.toml` all depend on it path-only (no version
+requirement), so none of them need updating when `pesto`'s version bumps.
+
+### 4. Update `crates/pesto/CHANGELOG.md`
+
+Rename the `## [Unreleased]` header to `## [<version>] — <YYYY-MM-DD>`, and
+add a fresh empty `## [Unreleased]` above it for whatever comes next.
+
+### 5. Run the full checklist and commit
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo doc --no-deps -p pesto-poster   # should produce zero warnings
+```
+
+Commit the version bump (`Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`) and
+push to `main` (directly, or via PR — whichever the change warrants).
+
+### 6. Publish to crates.io
+
+Dry-run first — it catches packaging problems without doing anything
+irreversible:
+
+```bash
+cd crates/pesto
+cargo publish --dry-run
+cargo publish
+```
+
+`cargo publish` waits for the new version to become available on the
+registry before it returns, so a successful exit means it's live.
+
+**This step cannot be undone.** A published version can be `cargo yank`ed
+(hidden from new dependents) but never deleted or overwritten.
+
+### 7. Confirm docs.rs picked it up
+
+docs.rs builds automatically after a crates.io publish; it usually takes a
+few minutes.
+
+```bash
+curl -s "https://docs.rs/crate/pesto-poster/<version>/status.json"
+# {"doc_status":true,"version":"<version>"} once it's built
+```
+
+If `doc_status` is `false` after a reasonable wait, check the build log
+linked from `https://docs.rs/crate/pesto-poster/<version>/builds`.
+
+### 8. Tag and push to trigger the GitHub release
+
+```bash
+git tag -a pesto-v<version> -m "pesto-poster v<version>: <one-line summary>"
+git push origin pesto-v<version>
+```
+
+Pushing a `pesto-v*` tag triggers `.github/workflows/release-pesto.yml`,
+which builds the `pesto` binary for `x86_64-unknown-linux-gnu`,
+`x86_64-unknown-linux-musl`, and `x86_64-pc-windows-msvc`, then creates a
+GitHub Release at that tag with all three attached. It does **not** use
+GitHub's auto-generated release notes — those pick the "previous tag" by
+creation time across the *whole repo*, which would pull in unrelated
+`parmesan-v*`/`penne-v*` tags interleaved with `pesto-v*` ones. The release
+body just links to `CHANGELOG.md`, crates.io, and docs.rs instead.
+
+Watch it with:
+
+```bash
+gh run list --workflow="Release pesto" --limit 1
+gh run watch <run-id>
+```
+
+### 9. Verify
+
+```bash
+gh release view pesto-v<version> --json url,assets -q '{url, assets: [.assets[].name]}'
+```
+
+Should list all three binaries and a working URL.
+
+## Checklist summary
+
+- [ ] Decide version bump (semver 0.x rules)
+- [ ] Bump `crates/pesto/Cargo.toml` version (and `description` if stale)
+- [ ] Bump the version requirement in any workspace `Cargo.toml` that pins one (none as of this writing — all path-only)
+- [ ] `CHANGELOG.md`: `[Unreleased]` → `[<version>] — <date>`, fresh empty `[Unreleased]` above
+- [ ] `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` / `cargo doc --no-deps -p pesto-poster` all clean
+- [ ] Commit + push to `main`
+- [ ] `cargo publish --dry-run` then `cargo publish`
+- [ ] Confirm docs.rs built (`status.json`)
+- [ ] `git tag pesto-v<version>` + push
+- [ ] Confirm the GitHub Actions run succeeded and the release has all three binaries


### PR DESCRIPTION
## Summary
- `pesto` now owns its version independently (`crates/pesto/Cargo.toml`, detached from `workspace.version`) — `0.3.61` → `0.3.62`.
- Moved `CHANGELOG.md` → `crates/pesto/CHANGELOG.md` and added `crates/pesto/RELEASING.md`, matching `parmesan`/`penne`'s per-crate docs. Dropped the stale `(penne)`-labeled `[Unreleased]` block that duplicated `crates/penne/CHANGELOG.md`; added the `[0.3.62]` entry for the TMDb/IMDb/TVDB/MAL flags from #53.
- Renamed `.github/workflows/release.yml` → `release-pesto.yml`, now triggered by `pesto-v*` tags (was unprefixed `v*`) and scoped to `-p pesto-poster --bin pesto` (previously an unscoped `cargo build --release`, which built every workspace binary). Matches `release-parmesan.yml`/`release-penne.yml`.
- Updated cross-references in `release-parmesan.yml`, `release-penne.yml`, `crates/parmesan/RELEASING.md`, `crates/penne/ROADMAP.md` that pointed at the old `release.yml`/`v*` naming.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo doc --no-deps -p pesto-poster` (pre-existing unrelated warnings only, none from this change)
- [ ] After merge: tag `pesto-v0.3.62`, push, confirm `release-pesto.yml` builds all 3 targets and publishes the GitHub Release; `cargo publish` to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xZyyaP7YjHnXXNr14XjRt