### PR TITLE
pesto: surface the real reason when a producer error stops an upload

### DIFF
--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,18 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Fixed
+- A `producer` error (bad PAR2 geometry, a memory-budget check, file I/O, …)
+  set the same `cancelled` flag as a real Ctrl-C, so both the CLI and the
+  human-readable renderer printed a generic "interrupted" message — the TTY
+  summary even showed a green `✓`, as if the run had succeeded — with no way
+  to tell a genuine failure apart from a user cancellation or see *why* it
+  failed. Since the failure is a deterministic function of the file and the
+  config, retrying the same file failed identically every time with no
+  indication that retrying wouldn't help. `PostOutcome`/`UploadOutcome` now
+  carry `failure_reason`, and the CLI and both renderers (TTY summary and
+  `--quiet`) surface it instead of a bare "interrupted" (fixes #57).
+
 ## [0.4.3] — 2026-07-31
 
 ### Added

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -973,7 +973,15 @@ async fn run_single_upload(
     }
 
     if cancelled {
-        if config.par2_only {
+        // `outcome.cancelled` is set both by a real user cancellation and by a
+        // producer error (bad PAR2 geometry, a memory-budget check, file I/O,
+        // …) — see `PostOutcome::failure_reason`. Printing the same generic
+        // "interrupted" text for both left a run that actually failed with no
+        // indication of why, and the same file would then fail identically on
+        // every retry with no clue that retrying wouldn't help (issue #57).
+        if let Some(reason) = &outcome.failure_reason {
+            eprintln!("upload failed: {reason}");
+        } else if config.par2_only {
             eprintln!("interrupted — stopped before finishing PAR2 generation");
         } else {
             eprintln!("interrupted — upload incomplete");
@@ -1077,7 +1085,11 @@ async fn run_single_upload(
         if !cancelled || config.resume {
             Some(nzb_archive_path(&stem).await)
         } else {
-            eprintln!("interrupted — skipping nzb output");
+            if outcome.failure_reason.is_some() {
+                eprintln!("upload failed — skipping nzb output");
+            } else {
+                eprintln!("interrupted — skipping nzb output");
+            }
             None
         }
     } else {

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -273,6 +273,14 @@ pub struct PostOutcome {
     /// when `config.check` is disabled. A non-empty list means the run
     /// produced content that is not fully confirmed on the server.
     pub still_missing: Vec<String>,
+    /// Set when the run stopped because `producer` returned an error (bad
+    /// PAR2 geometry, a memory-budget check, file I/O, …) rather than because
+    /// the user cancelled it. `cancelled` is `true` in both cases — callers
+    /// that want to tell "the user pressed Ctrl-C" apart from "the run failed
+    /// and here's why" should check this field first. See issue #57: without
+    /// it, callers had no way to surface the actual failure and could only
+    /// print a generic "interrupted" message.
+    pub failure_reason: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -730,6 +738,7 @@ pub async fn post_files_with_progress_and_cancel(
     };
 
     // Producer runs in this thread
+    let mut failure_reason: Option<String> = None;
     if let Err(e) = producer(metas, tx_opt, shared.clone()).await {
         let description = format!("producer error: {e:#}");
         // `Failed` alone only reaches `--output-format json` consumers; log
@@ -738,7 +747,10 @@ pub async fn post_files_with_progress_and_cancel(
         // see `ui::terminal`) is what's on screen.
         error!(error = %e, "producer error");
         shared.cancelled.store(true, Ordering::Relaxed);
-        shared.emit(ProgressEvent::Failed { description });
+        shared.emit(ProgressEvent::Failed {
+            description: description.clone(),
+        });
+        failure_reason = Some(description);
     }
 
     for handle in handles {
@@ -845,6 +857,7 @@ pub async fn post_files_with_progress_and_cancel(
         groups: shared.post_group.clone(),
         still_missing,
         servers: servers_used,
+        failure_reason,
     })
 }
 

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -790,7 +790,14 @@ impl RenderState {
         }
         const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
         let spinner = if final_draw {
-            '✓'
+            // A run that failed before posting anything (producer error) or
+            // was cancelled still set `final_draw`, so a bare '✓' here would
+            // claim success even when it isn't — see issue #57.
+            if self.interrupted || self.failed_description.is_some() || self.failures > 0 {
+                '⚠'
+            } else {
+                '✓'
+            }
         } else {
             let ch = SPINNER[self.spinner_frame % SPINNER.len()];
             self.spinner_frame += 1;
@@ -956,8 +963,11 @@ impl RenderState {
     /// nzb`/`wrote nfo` paths, so this covers only what the renderer itself
     /// knows — outcome, throughput and verification.
     fn summary_lines(&self, width: usize) -> Vec<String> {
-        let ok = self.failures == 0 && self.check_failed == 0 && !self.interrupted;
-        let glyph = if self.interrupted {
+        let ok = self.failures == 0
+            && self.check_failed == 0
+            && !self.interrupted
+            && self.failed_description.is_none();
+        let glyph = if self.interrupted || self.failed_description.is_some() {
             ansi("⚠", "33")
         } else if ok {
             ansi("✓", "32")
@@ -996,10 +1006,18 @@ impl RenderState {
         }
         let line2 = format!("  {}", parts.join(" · "));
 
-        vec![line1, line2]
-            .into_iter()
-            .map(|l| truncate(&l, width))
-            .collect()
+        let mut lines = vec![line1, line2];
+        // Surface *why* a run stopped early — without this, a run that fails
+        // before posting anything (e.g. a PAR2 geometry or memory-budget
+        // error in `producer`) printed a bare green checkmark here, because
+        // `ok`/`glyph` above were the only signal and `failed_description`
+        // was otherwise only ever shown in the live panel, which this summary
+        // replaces once the run ends (issue #57).
+        if let Some(desc) = &self.failed_description {
+            lines.push(format!("  {}", ansi(&format!("⚠ {desc}"), "33")));
+        }
+
+        lines.into_iter().map(|l| truncate(&l, width)).collect()
     }
 
     /// Erase the live panel and print the compact final summary in its place.
@@ -2068,6 +2086,32 @@ mod tests {
         let summary = state.summary_lines(100);
         assert!(summary[0].contains('✗'), "a failed run gets a cross glyph");
         assert!(summary[1].contains("failed"));
+    }
+
+    // Issue #57: a run that dies to a `producer` error (bad PAR2 geometry, a
+    // memory-budget check, …) before posting anything used to print a bare
+    // green `✓` here, because `summary_lines` only looked at `interrupted`
+    // (set solely by a real Ctrl-C) and never at `failed_description` (set by
+    // `ProgressEvent::Failed`) — indistinguishable from a clean run.
+    #[test]
+    fn final_summary_flags_producer_failure_instead_of_a_bare_checkmark() {
+        let mut state = started_state(false);
+        state.apply(ProgressEvent::Failed {
+            description: "producer error: too many input slices: 46875 (max 32768)".to_string(),
+        });
+        let summary = state.summary_lines(100);
+        assert!(
+            !summary.iter().any(|l| l.contains('✓')),
+            "a run that failed in producer must not show a green checkmark: {summary:?}"
+        );
+        assert!(
+            summary.iter().any(|l| l.contains('⚠')),
+            "a producer failure should get the same warning glyph as a cancellation: {summary:?}"
+        );
+        assert!(
+            summary.iter().any(|l| l.contains("too many input slices")),
+            "the actual failure reason should be visible in the final summary: {summary:?}"
+        );
     }
 
     #[test]

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -24,6 +24,11 @@ pub struct UploadOutcome {
     pub had_failures: bool,
     pub nzb_path: Option<PathBuf>,
     pub total_bytes: u64,
+    /// See [`crate::poster::PostOutcome::failure_reason`]: set when
+    /// `cancelled` is true because the run failed (not because the user
+    /// cancelled it), so callers can tell the two apart instead of showing a
+    /// generic "cancelled" state for an actual failure (issue #57).
+    pub failure_reason: Option<String>,
 }
 
 /// Run the complete upload pipeline.
@@ -471,6 +476,7 @@ pub async fn run_upload(
         had_failures: has_post_failures || has_confirmed_missing,
         nzb_path,
         total_bytes,
+        failure_reason: outcome.failure_reason,
     })
 }
 

--- a/crates/pesto/tests/producer_error_surfaces_reason.rs
+++ b/crates/pesto/tests/producer_error_surfaces_reason.rs
@@ -1,0 +1,116 @@
+//! Issue #57: a `producer` error (bad PAR2 geometry, a memory-budget check,
+//! file I/O, …) used to be indistinguishable from a real user cancellation —
+//! both just set `PostOutcome::cancelled = true`, so a caller had no way to
+//! tell "the user pressed Ctrl-C" apart from "the run failed, and here's
+//! why". Since the failure is a deterministic function of the file and the
+//! config, the same file then fails identically on every retry, with no clue
+//! that retrying won't help. `PostOutcome::failure_reason` fixes that by
+//! carrying the actual error message through.
+
+use pesto::config::{Config, ObfuscateMode};
+use pesto::poster::post_files;
+use pesto::walk::expand_inputs;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn producer_error_is_reported_via_failure_reason_not_a_bare_cancellation() {
+    let dir = std::env::temp_dir().join(format!("pesto_producer_error_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let input = dir.join("movie.bin");
+
+    // A tiny PAR2 slice size relative to the file size pushes the input slice
+    // count past the PAR2 spec's 32768 limit (see `producer`'s
+    // `total_slices > 32768` check), which is a deterministic function of
+    // the file size and this config — exactly the "same file fails every
+    // time" pattern from the issue.
+    const FILE_SIZE: usize = 3_000_000;
+    std::fs::write(&input, vec![0u8; FILE_SIZE]).unwrap();
+
+    let config = Config {
+        host: "unused".to_string(),
+        port: 563,
+        ssl: false,
+        connections: 1,
+        username: None,
+        password: None,
+        from: "tester <t@pesto.test>".to_string(),
+        groups: vec!["alt.binaries.test".to_string()],
+        article_size: 65536,
+        line_length: 128,
+        retries: 1,
+        retry_delay: 1,
+        timeout: pesto::config::DEFAULT_TIMEOUT_SECS,
+        obfuscate: ObfuscateMode::None,
+        dry_run: false,
+        par2: 10,
+        par2_slice_size: Some(64),
+        par2_slice_count: None,
+        par2_recovery_count: None,
+        par2_memory_limit: Some(1_000_000_000),
+        par2_only: false,
+        threads: 0,
+        simd: pesto::par2::SimdPath::Auto,
+        extra_servers: vec![],
+        resume: false,
+        upload_rate: 0,
+        compress_format: None,
+        compress_password: None,
+        nzb_name: None,
+        nzb_password: None,
+        nzb_category: None,
+        nzb_tags: vec![],
+        tmdb_id: None,
+        tmdb_kind: None,
+        imdb_id: None,
+        tvdb_id: None,
+        mal_id: None,
+        indexer_url: None,
+        indexer_api_key: None,
+        notify_webhook: None,
+        notify_ntfy: None,
+        notify: None,
+        history: true,
+        history_dir: None,
+        nzb_dir: None,
+        date: None,
+        no_archive: false,
+        message_id_domain: None,
+        pre_hooks: vec![],
+        post_hooks: vec![],
+        no_hooks: false,
+        nfo: false,
+        nzb_conflict: pesto::config::NzbConflict::Overwrite,
+        quiet: false,
+        bell: false,
+        check: false,
+        check_delay_secs: 5,
+        check_retries: 2,
+        check_connections: 1,
+        check_post_retries: 1,
+        allow_incomplete_nzb: false,
+        pipeline_depth: 1,
+        keepalive_interval: 0,
+    };
+
+    let inputs = expand_inputs(std::slice::from_ref(&input)).unwrap();
+    let outcome = post_files(&config, &inputs).await.unwrap();
+
+    assert!(
+        outcome.cancelled,
+        "a producer error should still set `cancelled` (existing callers rely on it)"
+    );
+    assert!(
+        outcome.segments.is_empty(),
+        "nothing should have been posted when producer fails before queuing any article"
+    );
+    let reason = outcome
+        .failure_reason
+        .as_deref()
+        .expect("producer error should populate failure_reason");
+    assert!(
+        reason.contains("too many input slices"),
+        "failure_reason should carry the actual producer error, got: {reason}"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary
- A `producer` error (bad PAR2 geometry, a memory-budget check, file I/O, …) set the same `cancelled` flag as a real Ctrl-C, so both the CLI and the human-readable renderer printed a generic "interrupted" message — the TTY summary even showed a green `✓`, as if the run had succeeded — with no way to tell a genuine failure apart from a user cancellation, or see *why* it failed.
- Since the failure is a deterministic function of the file and the config, retrying the same file failed identically every time, with no indication that retrying wouldn't help.
- `PostOutcome`/`UploadOutcome` now carry `failure_reason`, and the CLI plus both renderers (TTY summary and `--quiet`) surface it instead of a bare "interrupted".

Fixes #57.

## Test plan
- [x] New integration test `producer_error_surfaces_reason.rs`: forces the PAR2 "too many input slices" bail and asserts `failure_reason` carries it.
- [x] New unit test in `ui/terminal.rs`: a producer failure no longer shows a green `✓` in the final TTY summary.
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` all pass.
- [x] Manually reproduced against the real binary: before → generic "interrupted"; after → `upload failed: producer error: too many input slices: ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aY6DkMtbRQwdPfgv77vDf