### PR TITLE
Add Windows/Linux install scripts, with API-key prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,21 +62,29 @@ Copy the binary to a directory on your `PATH` (e.g. `/usr/local/bin` on
 Linux/macOS), marking it executable on Linux/macOS (`chmod +x`). On Windows,
 rename it to `pesto.exe` and place it anywhere on your `PATH`.
 
-### Windows install script
+### Install script (Windows / Linux)
 
-For a one-command setup that also creates the hooks folder, run this in
-PowerShell:
+For a one-command setup that also creates the hooks folder, run one of:
 
 ```powershell
+# Windows (PowerShell)
 irm https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.ps1 | iex
 ```
 
-This downloads the latest `pesto.exe`, installs it under
-`%LOCALAPPDATA%\pesto\bin`, adds that folder to your user `PATH`, creates
-`%APPDATA%\pesto\hooks\`, and runs the `--config` wizard if you don't have a
-config yet. See [`scripts/install.ps1`](scripts/install.ps1) for the
-`-HookUrl` / `-ConfigUrl` parameters distributors (e.g. an indexer pointing
-its users at a pre-filled hook) can use to skip manual file editing entirely.
+```bash
+# Linux
+curl -fsSL https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.sh | bash
+```
+
+This downloads the latest binary, installs it to a per-user directory
+(`%LOCALAPPDATA%\pesto\bin` / `~/.local/bin`), adds that directory to your
+`PATH`, creates the hooks folder (`%APPDATA%\pesto\hooks\` /
+`~/.config/pesto/hooks/`), and runs the `--config` wizard if you don't have a
+config yet. See [`scripts/install.ps1`](scripts/install.ps1) /
+[`scripts/install.sh`](scripts/install.sh) for the `-HookUrl`/`--hook-url`
+and `-ConfigUrl`/`--config-url` parameters distributors (e.g. an indexer
+pointing its users at a pre-filled hook) can use to skip manual file editing
+entirely.
 
 ### Via cargo
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ config yet. See [`scripts/install.ps1`](scripts/install.ps1) /
 [`scripts/install.sh`](scripts/install.sh) for the `-HookUrl`/`--hook-url`
 and `-ConfigUrl`/`--config-url` parameters distributors (e.g. an indexer
 pointing its users at a pre-filled hook) can use to skip manual file editing
-entirely.
+entirely. If the downloaded hook still contains the `YOUR_API_KEY`
+placeholder (see [`examples/hooks/`](examples/hooks/)), the installer prompts
+for it interactively and writes it into the hook file — pass
+`-NoApiKeyPrompt`/`--no-api-key-prompt` to skip that.
 
 ### Via cargo
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,29 @@ Download the latest binary for your platform from the
 
 | Platform | File |
 |----------|------|
-| Linux x86-64 (glibc) | `pesto-x86_64-unknown-linux-gnu.tar.gz` |
-| Linux x86-64 (musl / Alpine) | `pesto-x86_64-unknown-linux-musl.tar.gz` |
-| Windows x86-64 | `pesto-x86_64-pc-windows-msvc.zip` |
+| Linux x86-64 (glibc) | `pesto-linux-x86_64` |
+| Linux x86-64 (musl / Alpine) | `pesto-linux-x86_64-musl` |
+| Windows x86-64 | `pesto-windows-x86_64.exe` |
 
-Extract the archive and copy the binary to a directory on your `PATH`
-(e.g. `/usr/local/bin` on Linux/macOS, `C:\Windows\System32` on Windows).
+Copy the binary to a directory on your `PATH` (e.g. `/usr/local/bin` on
+Linux/macOS), marking it executable on Linux/macOS (`chmod +x`). On Windows,
+rename it to `pesto.exe` and place it anywhere on your `PATH`.
+
+### Windows install script
+
+For a one-command setup that also creates the hooks folder, run this in
+PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.ps1 | iex
+```
+
+This downloads the latest `pesto.exe`, installs it under
+`%LOCALAPPDATA%\pesto\bin`, adds that folder to your user `PATH`, creates
+`%APPDATA%\pesto\hooks\`, and runs the `--config` wizard if you don't have a
+config yet. See [`scripts/install.ps1`](scripts/install.ps1) for the
+`-HookUrl` / `-ConfigUrl` parameters distributors (e.g. an indexer pointing
+its users at a pre-filled hook) can use to skip manual file editing entirely.
 
 ### Via cargo
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,6 +34,10 @@
 .PARAMETER NoConfigWizard
     Skip running `pesto --config` at the end when no config.toml exists yet.
 
+.PARAMETER NoApiKeyPrompt
+    Skip the interactive prompt for an indexer API key, even if the
+    downloaded hook (-HookUrl) contains the YOUR_API_KEY placeholder.
+
 .EXAMPLE
     Plain install, run interactively:
         irm https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.ps1 | iex
@@ -50,7 +54,8 @@ param(
     [string]$ConfigUrl,
     [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "pesto\bin"),
     [switch]$NoPathUpdate,
-    [switch]$NoConfigWizard
+    [switch]$NoConfigWizard,
+    [switch]$NoApiKeyPrompt
 )
 
 $ErrorActionPreference = "Stop"
@@ -125,6 +130,24 @@ if ($HookUrl) {
     $recognized = @(".exe", ".cmd", ".bat", ".ps1", ".py")
     if ($recognized -notcontains [IO.Path]::GetExtension($hookName).ToLower()) {
         Warn "$hookName does not have a recognized extension (.exe/.cmd/.bat/.ps1/.py) - pesto will not run it automatically."
+    }
+
+    # Hooks that need a per-user credential use the literal placeholder
+    # YOUR_API_KEY (see examples/hooks/generic-indexer.*) since a distributor
+    # can bake in their own indexer URL but not a key that belongs to each
+    # individual user. Prompt for it here so installs need no manual editing.
+    if (-not $NoApiKeyPrompt) {
+        $hookContent = Get-Content -Raw -Path $hookPath
+        if ($hookContent -match "YOUR_API_KEY") {
+            $apiKey = Read-Host "Enter your indexer API key (leave blank to fill in later)"
+            if ($apiKey) {
+                $hookContent = $hookContent.Replace("YOUR_API_KEY", $apiKey)
+                Set-Content -Path $hookPath -Value $hookContent
+                Log "API key written to $hookPath"
+            } else {
+                Warn "No API key entered - edit $hookPath manually before your first upload (replace YOUR_API_KEY)."
+            }
+        }
     }
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+    Installs the pesto Usenet posting CLI on Windows.
+
+.DESCRIPTION
+    Downloads the latest pesto-v* release binary from GitHub, installs it to
+    a per-user directory, adds that directory to the user PATH, and creates
+    the hooks folder pesto scans on every upload (%APPDATA%\pesto\hooks).
+
+    Optionally fetches a ready-made post-upload hook script and/or a
+    pre-filled config.toml from URLs you provide, so a distributor (e.g. an
+    indexer that wants its users on pesto) can point people at a single
+    command that leaves them fully configured, with no manual file editing.
+
+    This script itself is indexer-agnostic: it has no knowledge of any
+    specific indexer, URL, or API key. Pass -HookUrl / -ConfigUrl to point
+    it at files you host yourself.
+
+.PARAMETER HookUrl
+    URL of a ready-to-use post-upload hook script (.ps1/.bat/.cmd/.exe/.py).
+    Downloaded into the pesto hooks folder under its original filename.
+
+.PARAMETER ConfigUrl
+    URL of a pre-filled config.toml. Only written when no config.toml exists
+    yet at the destination — an existing config is never overwritten.
+
+.PARAMETER InstallDir
+    Directory pesto.exe is installed into. Defaults to
+    "$env:LOCALAPPDATA\pesto\bin".
+
+.PARAMETER NoPathUpdate
+    Skip adding InstallDir to the user PATH.
+
+.PARAMETER NoConfigWizard
+    Skip running `pesto --config` at the end when no config.toml exists yet.
+
+.EXAMPLE
+    Plain install, run interactively:
+        irm https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.ps1 | iex
+
+.EXAMPLE
+    Install with a pre-filled hook and config, for distributors piping in
+    parameters (a plain `... | iex` cannot take parameters):
+        & ([scriptblock]::Create((irm https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.ps1))) -HookUrl "https://your-domain.example/pesto-hook.ps1" -ConfigUrl "https://your-domain.example/pesto-config.toml"
+#>
+
+[CmdletBinding()]
+param(
+    [string]$HookUrl,
+    [string]$ConfigUrl,
+    [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "pesto\bin"),
+    [switch]$NoPathUpdate,
+    [switch]$NoConfigWizard
+)
+
+$ErrorActionPreference = "Stop"
+$Repo = "franzopl/pesto"
+
+function Log  { param($msg) Write-Host "[pesto-install] $msg" }
+function Warn { param($msg) Write-Host "[pesto-install] WARNING: $msg" -ForegroundColor Yellow }
+
+# Windows PowerShell 5.1 (the default on Windows 10/11) only speaks TLS 1.0
+# by default on some configurations; force 1.2 or GitHub's API/CDN will
+# refuse the connection.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+# ── locate the latest pesto-v* release ──────────────────────────────────────
+# GitHub's /releases/latest is not safe here: parmesan-v* and penne-v*
+# releases share this repo and are cut independently, so "latest" by date
+# is not necessarily a pesto release. Walk the release list instead and
+# take the newest tag matching pesto-v*.
+Log "Looking up the latest pesto release..."
+$releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases" -Headers @{ "User-Agent" = "pesto-install-script" }
+$release = $releases | Where-Object { $_.tag_name -like "pesto-v*" } | Select-Object -First 1
+
+if (-not $release) {
+    throw "Could not find a pesto-v* release on GitHub. Check https://github.com/$Repo/releases manually."
+}
+
+$asset = $release.assets | Where-Object { $_.name -eq "pesto-windows-x86_64.exe" }
+if (-not $asset) {
+    throw "Release $($release.tag_name) has no pesto-windows-x86_64.exe asset."
+}
+
+Log "Installing $($release.tag_name)..."
+
+# ── download the binary ─────────────────────────────────────────────────────
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$exePath = Join-Path $InstallDir "pesto.exe"
+
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exePath
+Log "pesto.exe installed to $exePath"
+
+# ── add to PATH (per-user, persisted) ───────────────────────────────────────
+
+if (-not $NoPathUpdate) {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $pathEntries = @()
+    if ($userPath) { $pathEntries = $userPath -split ";" }
+
+    if ($pathEntries -notcontains $InstallDir) {
+        $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        Log "Added $InstallDir to your user PATH (open a new terminal to pick it up)."
+    }
+
+    if (($env:Path -split ";") -notcontains $InstallDir) {
+        $env:Path = "$env:Path;$InstallDir"
+    }
+}
+
+# ── hooks folder ─────────────────────────────────────────────────────────────
+
+$hooksDir = Join-Path $env:APPDATA "pesto\hooks"
+New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
+
+if ($HookUrl) {
+    $hookName = [IO.Path]::GetFileName(([Uri]$HookUrl).LocalPath)
+    if (-not $hookName) { $hookName = "hook.ps1" }
+    $hookPath = Join-Path $hooksDir $hookName
+    Invoke-WebRequest -Uri $HookUrl -OutFile $hookPath
+    Log "Hook script installed to $hookPath"
+
+    $recognized = @(".exe", ".cmd", ".bat", ".ps1", ".py")
+    if ($recognized -notcontains [IO.Path]::GetExtension($hookName).ToLower()) {
+        Warn "$hookName does not have a recognized extension (.exe/.cmd/.bat/.ps1/.py) - pesto will not run it automatically."
+    }
+}
+
+# ── config.toml ──────────────────────────────────────────────────────────────
+
+$configDir = Join-Path $env:APPDATA "pesto"
+$configPath = Join-Path $configDir "config.toml"
+New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+
+$haveConfig = Test-Path $configPath
+
+if ($ConfigUrl) {
+    if ($haveConfig) {
+        Warn "config.toml already exists at $configPath - not overwriting. Delete it first if you want the one from -ConfigUrl."
+    } else {
+        Invoke-WebRequest -Uri $ConfigUrl -OutFile $configPath
+        Log "config.toml installed to $configPath"
+        $haveConfig = $true
+    }
+}
+
+# ── verify ───────────────────────────────────────────────────────────────────
+
+try {
+    & $exePath --version | Out-Null
+} catch {
+    throw "pesto.exe did not run correctly after install: $_"
+}
+
+Log "pesto is installed."
+
+if (-not $haveConfig -and -not $NoConfigWizard) {
+    Log "Running the setup wizard to configure your Usenet server..."
+    & $exePath --config
+} elseif (-not $haveConfig) {
+    Log "No config.toml yet - run 'pesto --config' to set up your Usenet server."
+}
+
+Log "Done. Open a new terminal window if 'pesto' is not immediately recognized."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Installs the pesto Usenet posting CLI on Linux.
+#
+# Downloads the latest pesto-v* release binary from GitHub, installs it to
+# a per-user directory, adds that directory to PATH (by appending to your
+# shell rc file if it's not there yet), and creates the hooks folder pesto
+# scans on every upload (~/.config/pesto/hooks, or $XDG_CONFIG_HOME/pesto/hooks).
+#
+# Optionally fetches a ready-made post-upload hook script and/or a
+# pre-filled config.toml from URLs you provide, so a distributor (e.g. an
+# indexer that wants its users on pesto) can point people at a single
+# command that leaves them fully configured, with no manual file editing.
+#
+# This script itself is indexer-agnostic: it has no knowledge of any
+# specific indexer, URL, or API key. Pass --hook-url / --config-url to
+# point it at files you host yourself.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.sh | bash
+#
+#   # with a distributor-supplied hook:
+#   curl -fsSL https://raw.githubusercontent.com/franzopl/pesto/main/scripts/install.sh | bash -s -- \
+#       --hook-url "https://your-domain.example/pesto-hook.sh"
+#
+# Flags:
+#   --hook-url <URL>      Download a ready-to-use post-upload hook script into the hooks folder.
+#   --config-url <URL>    Download a pre-filled config.toml (never overwrites an existing one).
+#   --install-dir <DIR>   Where to install the pesto binary (default: ~/.local/bin).
+#   --musl                Force the musl build (default: auto-detected).
+#   --no-path-update      Don't touch your shell rc file.
+#   --no-config-wizard    Don't run `pesto --config` even if no config.toml exists yet.
+
+set -euo pipefail
+
+REPO="franzopl/pesto"
+INSTALL_DIR="${HOME}/.local/bin"
+HOOK_URL=""
+CONFIG_URL=""
+FORCE_MUSL=""
+NO_PATH_UPDATE=""
+NO_CONFIG_WIZARD=""
+
+log()  { printf '[pesto-install] %s\n' "$1"; }
+warn() { printf '[pesto-install] WARNING: %s\n' "$1" >&2; }
+die()  { printf '[pesto-install] ERROR: %s\n' "$1" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --hook-url) HOOK_URL="$2"; shift 2 ;;
+        --config-url) CONFIG_URL="$2"; shift 2 ;;
+        --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+        --musl) FORCE_MUSL=1; shift ;;
+        --no-path-update) NO_PATH_UPDATE=1; shift ;;
+        --no-config-wizard) NO_CONFIG_WIZARD=1; shift ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) die "Unknown argument: $1" ;;
+    esac
+done
+
+command -v curl >/dev/null 2>&1 || die "curl is required but not found."
+
+case "$(uname -s)" in
+    Linux) ;;
+    Darwin) die "No macOS build is published yet. Install with: cargo install pesto-poster" ;;
+    *) die "Unsupported OS: $(uname -s). Install with: cargo install pesto-poster" ;;
+esac
+
+# ── pick the right asset (glibc vs musl) ────────────────────────────────────
+
+ASSET_NAME="pesto-linux-x86_64"
+if [ -n "$FORCE_MUSL" ]; then
+    ASSET_NAME="pesto-linux-x86_64-musl"
+elif [ -f /etc/alpine-release ] || (command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl); then
+    ASSET_NAME="pesto-linux-x86_64-musl"
+fi
+
+# ── locate the latest pesto-v* release ──────────────────────────────────────
+# GitHub's /releases/latest is not safe here: parmesan-v* and penne-v*
+# releases share this repo and are cut independently, so "latest" by date
+# is not necessarily a pesto release. Walk the release list instead and
+# take the newest tag matching pesto-v*.
+log "Looking up the latest pesto release..."
+
+RELEASES_JSON="$(curl -fsSL -H "User-Agent: pesto-install-script" "https://api.github.com/repos/${REPO}/releases")"
+
+DOWNLOAD_URL="$(printf '%s' "$RELEASES_JSON" | grep -o "\"browser_download_url\": *\"[^\"]*${ASSET_NAME}\"" | head -n1 | sed -E 's/.*"(https:[^"]+)"/\1/')"
+TAG_NAME="$(printf '%s' "$RELEASES_JSON" | grep -o '"tag_name": *"pesto-v[^"]*"' | head -n1 | sed -E 's/.*"(pesto-v[^"]+)"/\1/')"
+
+[ -n "$DOWNLOAD_URL" ] || die "Could not find a pesto-v* release with asset ${ASSET_NAME}. Check https://github.com/${REPO}/releases manually."
+
+log "Installing ${TAG_NAME} (${ASSET_NAME})..."
+
+# ── download the binary ─────────────────────────────────────────────────────
+
+mkdir -p "$INSTALL_DIR"
+EXE_PATH="${INSTALL_DIR}/pesto"
+
+curl -fsSL "$DOWNLOAD_URL" -o "$EXE_PATH"
+chmod +x "$EXE_PATH"
+log "pesto installed to ${EXE_PATH}"
+
+# ── add to PATH ──────────────────────────────────────────────────────────────
+
+if [ -z "$NO_PATH_UPDATE" ]; then
+    case ":$PATH:" in
+        *":${INSTALL_DIR}:"*) ;;
+        *)
+            RC_FILE="${HOME}/.profile"
+            case "${SHELL:-}" in
+                */zsh) RC_FILE="${HOME}/.zshrc" ;;
+                */bash) RC_FILE="${HOME}/.bashrc" ;;
+            esac
+
+            EXPORT_LINE="export PATH=\"${INSTALL_DIR}:\$PATH\""
+            if [ -f "$RC_FILE" ] && grep -qF "$INSTALL_DIR" "$RC_FILE" 2>/dev/null; then
+                :
+            else
+                printf '\n# Added by the pesto installer\n%s\n' "$EXPORT_LINE" >> "$RC_FILE"
+                log "Added ${INSTALL_DIR} to PATH in ${RC_FILE} (restart your shell, or run: export PATH=\"${INSTALL_DIR}:\$PATH\")"
+            fi
+            export PATH="${INSTALL_DIR}:${PATH}"
+            ;;
+    esac
+fi
+
+# ── hooks folder ─────────────────────────────────────────────────────────────
+
+CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
+HOOKS_DIR="${CONFIG_HOME}/pesto/hooks"
+mkdir -p "$HOOKS_DIR"
+
+if [ -n "$HOOK_URL" ]; then
+    HOOK_NAME="$(basename "${HOOK_URL%%\?*}")"
+    [ -n "$HOOK_NAME" ] || HOOK_NAME="hook.sh"
+    HOOK_PATH="${HOOKS_DIR}/${HOOK_NAME}"
+    curl -fsSL "$HOOK_URL" -o "$HOOK_PATH"
+    chmod +x "$HOOK_PATH"
+    log "Hook script installed to ${HOOK_PATH}"
+fi
+
+# ── config.toml ──────────────────────────────────────────────────────────────
+
+CONFIG_DIR="${CONFIG_HOME}/pesto"
+CONFIG_PATH="${CONFIG_DIR}/config.toml"
+mkdir -p "$CONFIG_DIR"
+
+HAVE_CONFIG=""
+[ -f "$CONFIG_PATH" ] && HAVE_CONFIG=1
+
+if [ -n "$CONFIG_URL" ]; then
+    if [ -n "$HAVE_CONFIG" ]; then
+        warn "config.toml already exists at ${CONFIG_PATH} - not overwriting. Delete it first if you want the one from --config-url."
+    else
+        curl -fsSL "$CONFIG_URL" -o "$CONFIG_PATH"
+        log "config.toml installed to ${CONFIG_PATH}"
+        HAVE_CONFIG=1
+    fi
+fi
+
+# ── verify ───────────────────────────────────────────────────────────────────
+
+"$EXE_PATH" --version >/dev/null || die "pesto did not run correctly after install."
+
+log "pesto is installed."
+
+if [ -z "$HAVE_CONFIG" ] && [ -z "$NO_CONFIG_WIZARD" ]; then
+    log "Running the setup wizard to configure your Usenet server..."
+    "$EXE_PATH" --config
+elif [ -z "$HAVE_CONFIG" ]; then
+    log "No config.toml yet - run 'pesto --config' to set up your Usenet server."
+fi
+
+log "Done. Open a new terminal window if 'pesto' is not immediately recognized."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,6 +29,7 @@
 #   --musl                Force the musl build (default: auto-detected).
 #   --no-path-update      Don't touch your shell rc file.
 #   --no-config-wizard    Don't run `pesto --config` even if no config.toml exists yet.
+#   --no-api-key-prompt   Don't prompt for an indexer API key, even if the downloaded hook needs one.
 
 set -euo pipefail
 
@@ -39,6 +40,7 @@ CONFIG_URL=""
 FORCE_MUSL=""
 NO_PATH_UPDATE=""
 NO_CONFIG_WIZARD=""
+NO_API_KEY_PROMPT=""
 
 log()  { printf '[pesto-install] %s\n' "$1"; }
 warn() { printf '[pesto-install] WARNING: %s\n' "$1" >&2; }
@@ -52,6 +54,7 @@ while [ $# -gt 0 ]; do
         --musl) FORCE_MUSL=1; shift ;;
         --no-path-update) NO_PATH_UPDATE=1; shift ;;
         --no-config-wizard) NO_CONFIG_WIZARD=1; shift ;;
+        --no-api-key-prompt) NO_API_KEY_PROMPT=1; shift ;;
         -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) die "Unknown argument: $1" ;;
     esac
@@ -136,6 +139,31 @@ if [ -n "$HOOK_URL" ]; then
     curl -fsSL "$HOOK_URL" -o "$HOOK_PATH"
     chmod +x "$HOOK_PATH"
     log "Hook script installed to ${HOOK_PATH}"
+
+    # Hooks that need a per-user credential use the literal placeholder
+    # YOUR_API_KEY (see examples/hooks/generic-indexer.*) since a distributor
+    # can bake in their own indexer URL but not a key that belongs to each
+    # individual user. Prompt for it here so installs need no manual editing.
+    # Read from /dev/tty, not stdin: this script is normally invoked as
+    # `curl ... | bash`, so stdin is the script source, not the terminal.
+    if [ -z "$NO_API_KEY_PROMPT" ] && grep -q "YOUR_API_KEY" "$HOOK_PATH" 2>/dev/null; then
+        api_key=""
+        if [ -r /dev/tty ]; then
+            read -rp "[pesto-install] Enter your indexer API key (leave blank to fill in later): " api_key < /dev/tty || true
+        fi
+        if [ -n "$api_key" ]; then
+            # Bash's ${var//pattern/replacement} treats & and \ in the
+            # replacement specially (like sed) - escape them so an API key
+            # containing either lands in the file byte-for-byte.
+            api_key_escaped="${api_key//\\/\\\\}"
+            api_key_escaped="${api_key_escaped//&/\\&}"
+            hook_content="$(cat "$HOOK_PATH")"
+            printf '%s\n' "${hook_content//YOUR_API_KEY/$api_key_escaped}" > "$HOOK_PATH"
+            log "API key written to ${HOOK_PATH}"
+        else
+            warn "No API key entered - edit ${HOOK_PATH} manually before your first upload (replace YOUR_API_KEY)."
+        fi
+    fi
 fi
 
 # ── config.toml ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `scripts/install.ps1` / `scripts/install.sh`: one-liner installers (`irm ... | iex` / `curl ... | bash`) that download the latest `pesto-v*` release binary, add it to PATH, and create the hooks folder. Indexer-agnostic — no indexer name/URL/key is hardcoded anywhere in this repo.
- `-HookUrl`/`--hook-url` and `-ConfigUrl`/`--config-url` let a distributor (e.g. an indexer) point users at a hook/config they host themselves, so leigo users need zero manual file editing.
- If the downloaded hook contains the `YOUR_API_KEY` placeholder (used by `examples/hooks/generic-indexer.*`), the installer now prompts for it interactively and writes it in — `-NoApiKeyPrompt`/`--no-api-key-prompt` opts out.
- README's stale "Installing" asset table fixed (it still listed `.tar.gz`/`.zip`, but the release workflow ships raw binaries).

## Why now
curupira.cc already hosts `https://curupira.cc/downloads/pesto/install.{ps1,sh}` in production, which delegates to `scripts/install.ps1|sh` on this repo's `main` branch via raw.githubusercontent.com. Until this merges, that URL 404s and the hosted installer is broken end-to-end.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `bash -n scripts/install.sh` + manual test of the `${var//pattern/replacement}` API-key escaping (bash treats `&`/`\` specially there, like sed)
- [x] Verified end-to-end against the real curupira.cc deployment (200s, correct content, API key substitution)
- [ ] Manual run on a clean Windows box (no `pwsh` available in this environment to test directly)

Claude-Session: https://claude.ai/code/session_015aY6DkMtbRQwdPfgv77vDf