### PR TITLE
Fix install.sh corrupting config.toml when run via curl | bash

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,19 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# `curl URL | bash` means bash reads this very script's source from stdin
+# (fd 0) as it executes it. Any later command that reads stdin without an
+# explicit redirect - `pesto --config`'s prompts included - inherits that
+# same fd and can read leftover, not-yet-consumed bytes of this script's own
+# source instead of the terminal (confirmed in practice: the config wizard's
+# first prompt came back containing a line of this file's own code). Reattach
+# stdin to the real terminal once, up front, so every interactive read below
+# just works. Guarded: without a tty (e.g. a non-interactive CI run), this is
+# a no-op and those reads degrade the same way they already did before.
+if [ -r /dev/tty ]; then
+    exec < /dev/tty
+fi
+
 command -v curl >/dev/null 2>&1 || die "curl is required but not found."
 
 case "$(uname -s)" in
@@ -191,7 +204,7 @@ fi
 
 log "pesto is installed."
 
-if [ -z "$HAVE_CONFIG" ] && [ -z "$NO_CONFIG_WIZARD" ]; then
+if [ -z "$HAVE_CONFIG" ] && [ -z "$NO_CONFIG_WIZARD" ] && [ -r /dev/tty ]; then
     log "Running the setup wizard to configure your Usenet server..."
     "$EXE_PATH" --config
 elif [ -z "$HAVE_CONFIG" ]; then


### PR DESCRIPTION
## Summary
Reported live by a user running `curl -fsSL https://curupira.cc/downloads/pesto/install.sh | bash`: after entering an API key at the hook prompt, every `pesto --config` wizard answer landed in the wrong field, and the NNTP `host` ended up literally set to a line of the install script's own source code.

Root cause: `curl URL | bash` makes bash read the script's own source from stdin (fd 0) while executing it. `"$EXE_PATH" --config` had no stdin redirect, so it inherited that same fd and read leftover unconsumed bytes of the script source instead of the terminal. The API-key prompt earlier in the script was already protected with `< /dev/tty`; the wizard invocation wasn't.

Fix: reattach stdin to `/dev/tty` once, right after argument parsing (guarded on `[ -r /dev/tty ]`), so every interactive read after that point just works. The wizard invocation additionally requires a tty before running, so a non-interactive run degrades to the existing "run `pesto --config` manually" message instead of repeating the bug.

## Test plan
- [x] `cargo fmt --check`
- [x] `bash -n scripts/install.sh`
- [x] Reproduced the bug pre-fix and confirmed the fix with a real pty (`pty.openpty`, since this sandbox has no `/dev/tty`): API key prompt + full `pesto --config` wizard now land in the right fields (`host = "news.example.org"` etc.), matching the user's exact repro