### PR TITLE
Revert exec-based #61 fix, redirect only the wizard call

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,19 +60,6 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# `curl URL | bash` means bash reads this very script's source from stdin
-# (fd 0) as it executes it. Any later command that reads stdin without an
-# explicit redirect - `pesto --config`'s prompts included - inherits that
-# same fd and can read leftover, not-yet-consumed bytes of this script's own
-# source instead of the terminal (confirmed in practice: the config wizard's
-# first prompt came back containing a line of this file's own code). Reattach
-# stdin to the real terminal once, up front, so every interactive read below
-# just works. Guarded: without a tty (e.g. a non-interactive CI run), this is
-# a no-op and those reads degrade the same way they already did before.
-if [ -r /dev/tty ]; then
-    exec < /dev/tty
-fi
-
 command -v curl >/dev/null 2>&1 || die "curl is required but not found."
 
 case "$(uname -s)" in
@@ -206,7 +193,15 @@ log "pesto is installed."
 
 if [ -z "$HAVE_CONFIG" ] && [ -z "$NO_CONFIG_WIZARD" ] && [ -r /dev/tty ]; then
     log "Running the setup wizard to configure your Usenet server..."
-    "$EXE_PATH" --config
+    # Explicit redirect, not a script-wide `exec <`: this script is normally
+    # invoked as `curl ... | bash`, so bash itself is still reading the rest
+    # of *this file* from fd 0 at this point. A bare `exec < /dev/tty` here
+    # was tried and reassigns fd 0 for bash's own script-reading too, not
+    # just this command - bash then reads its next commands from the
+    # terminal instead of the remaining script, and anything typed at the
+    # prompts below gets executed as shell commands. A per-command redirect
+    # only changes stdin for this one child process.
+    "$EXE_PATH" --config < /dev/tty
 elif [ -z "$HAVE_CONFIG" ]; then
     log "No config.toml yet - run 'pesto --config' to set up your Usenet server."
 fi


### PR DESCRIPTION
## Summary
#61 fixed the reported bug (config wizard reading garbled input from the piped script source) with a script-wide `exec < /dev/tty` after argument parsing. That fix was validated locally against `bash script.sh` (file argument), which never exercises the actual failure mode — I re-tested it against a real `curl | bash` invocation (over an actual pty via SSH to a real box) and it broke catastrophically: after the `exec`, bash itself started reading its *own remaining script commands* from the terminal instead of from the piped source, so typed answers got executed as shell commands (`bash: line 75: TESTE_API_KEY_9999: command not found`).

Root cause of why: `curl URL | bash` has bash reading its own source from fd 0 throughout execution (not just once at the start). A mid-script `exec < /dev/tty` reassigns that same fd 0, which bash's own parser also uses to fetch its next command — so it stops reading the rest of *this script* from the pipe and starts reading unexecuted "commands" from the terminal.

## Fix
Drop the script-wide `exec` entirely. Redirect stdin only on the specific command that needs it: `"$EXE_PATH" --config < /dev/tty`, the same per-command pattern already used correctly for the API-key prompt (a `cmd < file` redirect only affects that command's child process, never the parent shell's own fd 0).

## Test plan
- [x] `cargo fmt --check`, `bash -n scripts/install.sh`
- [x] Reproduced #61's regression with a real `cat script.sh | bash -s -- ...` over an SSH pty (faithful to `curl | bash`, unlike the file-argument test used to validate #61)
- [x] Confirmed this fix resolves it: `host = "news.example.org"` and the API key both land correctly, full wizard answered right