### PR TITLE
Fix install.ps1 shadowing itself; warn on hook-folder collisions

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -105,14 +105,17 @@ if (-not $NoPathUpdate) {
     if ($userPath) { $pathEntries = $userPath -split ";" }
 
     if ($pathEntries -notcontains $InstallDir) {
-        $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+        # Prepend, not append: an older pesto.exe elsewhere on PATH (a prior
+        # manual install, common per pesto's own README before this script
+        # existed) would otherwise keep shadowing the one just installed here
+        # in every new terminal, silently running stale code.
+        $newPath = if ($userPath) { "$InstallDir;$userPath" } else { $InstallDir }
         [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
-        Log "Added $InstallDir to your user PATH (open a new terminal to pick it up)."
+        Log "Added $InstallDir to the front of your user PATH (open a new terminal to pick it up)."
     }
 
-    if (($env:Path -split ";") -notcontains $InstallDir) {
-        $env:Path = "$env:Path;$InstallDir"
-    }
+    $sessionEntries = $env:Path -split ";" | Where-Object { $_ -and ($_ -ne $InstallDir) }
+    $env:Path = (@($InstallDir) + $sessionEntries) -join ";"
 }
 
 # ── hooks folder ─────────────────────────────────────────────────────────────
@@ -124,6 +127,20 @@ if ($HookUrl) {
     $hookName = [IO.Path]::GetFileName(([Uri]$HookUrl).LocalPath)
     if (-not $hookName) { $hookName = "hook.ps1" }
     $hookPath = Join-Path $hooksDir $hookName
+
+    # pesto runs every executable file in this folder on every upload -
+    # a pre-existing hook here (from a manual install before this script
+    # existed, or from a previous run with a different -HookUrl filename)
+    # would now ALSO run alongside the new one, e.g. double-posting the
+    # same release to an indexer twice. Can't tell if they're duplicates
+    # (that requires reading what each one does), so just surface it.
+    $existingHooks = Get-ChildItem -Path $hooksDir -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne $hookName }
+    if ($existingHooks) {
+        Warn "The hooks folder already has other file(s): $(($existingHooks.Name) -join ', ')"
+        Warn "pesto runs every file in $hooksDir on every upload - check none of them duplicate what the new hook does (e.g. posting to the same indexer twice)."
+    }
+
     Invoke-WebRequest -Uri $HookUrl -OutFile $hookPath
     Log "Hook script installed to $hookPath"
 
@@ -178,6 +195,34 @@ try {
 }
 
 Log "pesto is installed."
+
+# A prior manual install (System PATH, e.g. C:\Windows\System32 - pesto's
+# own README used to suggest that location) can still shadow this one: on
+# Windows, new sessions build PATH as Machine entries followed by User
+# entries, and prepending only within the User half can't override that.
+# Reconstruct what a brand-new terminal's PATH would resolve `pesto` to and
+# warn loudly if it would find a *different* pesto.exe than the one just
+# installed - better than a leigo user quietly running stale code forever.
+$machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+$freshUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$freshPath = @($machinePath, $freshUserPath) -join ";"
+$shadowingPesto = $null
+foreach ($dir in ($freshPath -split ";" | Where-Object { $_ })) {
+    $candidate = Join-Path $dir "pesto.exe"
+    if (Test-Path $candidate) {
+        $shadowingPesto = $candidate
+        break
+    }
+}
+if ($shadowingPesto -and ((Resolve-Path $shadowingPesto).Path -ne (Resolve-Path $exePath).Path)) {
+    Warn "A different pesto.exe was found earlier on PATH: $shadowingPesto"
+    Warn "New terminals will run THAT one instead of the one just installed at $exePath."
+    try {
+        $oldVersion = (& $shadowingPesto --version 2>$null)
+        if ($oldVersion) { Warn "That one reports: $oldVersion" }
+    } catch {}
+    Warn "Remove or update it (or move $InstallDir earlier in PATH) so 'pesto' resolves to the version just installed."
+}
 
 if (-not $haveConfig -and -not $NoConfigWizard) {
     Log "Running the setup wizard to configure your Usenet server..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,6 +136,20 @@ if [ -n "$HOOK_URL" ]; then
     HOOK_NAME="$(basename "${HOOK_URL%%\?*}")"
     [ -n "$HOOK_NAME" ] || HOOK_NAME="hook.sh"
     HOOK_PATH="${HOOKS_DIR}/${HOOK_NAME}"
+
+    # pesto runs every executable file in this folder on every upload - a
+    # pre-existing hook here (from a manual install before this script
+    # existed, or a previous run with a different --hook-url filename) would
+    # now ALSO run alongside the new one, e.g. double-posting the same
+    # release to an indexer twice. Can't tell if they're duplicates (that
+    # requires reading what each one does), so just surface it.
+    existing_hooks="$(find "$HOOKS_DIR" -maxdepth 1 -type f ! -name "$HOOK_NAME" 2>/dev/null)"
+    if [ -n "$existing_hooks" ]; then
+        warn "The hooks folder already has other file(s):"
+        printf '%s\n' "$existing_hooks" | while IFS= read -r f; do warn "  - $f"; done
+        warn "pesto runs every file in ${HOOKS_DIR} on every upload - check none of them duplicate what the new hook does (e.g. posting to the same indexer twice)."
+    fi
+
     curl -fsSL "$HOOK_URL" -o "$HOOK_PATH"
     chmod +x "$HOOK_PATH"
     log "Hook script installed to ${HOOK_PATH}"


### PR DESCRIPTION
## Summary
Reported live by a user: after installing via `install.ps1` and running a real upload, the newly-installed hook (`hook.ps1`) failed with `os error 193` ("%1 is not a valid Win32 application"). Their transcript showed `pesto v0.3.13` running — a much older version that predates the `.ps1`-via-`powershell.exe` wrapping fix (added around v0.3.36-0.3.42, see CHANGELOG). Current is v0.4.4.

Root cause: they had an old `pesto.exe` already on PATH from a prior manual install (pesto's README used to point people at `C:\Windows\System32`). `install.ps1` appended the new install dir to the *end* of the user PATH, so the stale binary kept winning PATH resolution in every new terminal — the installer reported success while the user kept running months-old code with none of the fixes since.

Their transcript also showed a second, related issue: pesto ran their pre-existing `curupira_send_nzb.bat` hook *and* the newly installed `hook.ps1` on the same upload — pesto runs every file in the hooks folder, so once `hook.ps1` also started working (after this fix), every future release would double-post to the indexer.

## Fixes
- `install.ps1`: prepend the install dir to PATH (persisted + live session) instead of appending.
- `install.ps1`: after install, reconstruct what a brand-new terminal's PATH would resolve `pesto` to (Machine entries then User entries — Windows' own build order, which prepending only within the User half can't override) and warn loudly, naming the exact conflicting binary and its version, if it differs from what was just installed.
- `install.ps1` + `install.sh`: warn and list existing files in the hooks folder before adding a new one, since pesto can't tell if two hooks do the same thing.

## Test plan
- [x] `cargo fmt --check`, `bash -n scripts/install.sh`
- [x] `install.sh`: verified end to end with a real pty (pre-existing hook file present) — collision warning fires, API key prompt + full `pesto --config` wizard still land correctly, no regression
- [ ] `install.ps1`: reviewed by hand, not executed (no Windows/pwsh available in this environment)