### PR TITLE
Also prompt for the ImgBB API key during hook install

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -35,8 +35,9 @@
     Skip running `pesto --config` at the end when no config.toml exists yet.
 
 .PARAMETER NoApiKeyPrompt
-    Skip the interactive prompt for an indexer API key, even if the
-    downloaded hook (-HookUrl) contains the YOUR_API_KEY placeholder.
+    Skip the interactive prompts for an indexer/ImgBB API key, even if the
+    downloaded hook (-HookUrl) contains the YOUR_API_KEY / YOUR_IMGBB_API_KEY
+    placeholders.
 
 .EXAMPLE
     Plain install, run interactively:
@@ -63,6 +64,36 @@ $Repo = "franzopl/pesto"
 
 function Log  { param($msg) Write-Host "[pesto-install] $msg" }
 function Warn { param($msg) Write-Host "[pesto-install] WARNING: $msg" -ForegroundColor Yellow }
+
+# Hooks that need a per-user credential use a literal placeholder - e.g.
+# YOUR_API_KEY / YOUR_IMGBB_API_KEY in examples/hooks/generic-indexer.* -
+# since a distributor can bake in their own indexer URL but not a key that
+# belongs to each individual user. Prompt for it and substitute it in place,
+# so installs need no manual editing.
+function Set-HookPlaceholder {
+    param([string]$HookPath, [string]$Placeholder, [string]$PromptText)
+
+    $hookContent = Get-Content -Raw -Path $HookPath
+    if ($hookContent -notmatch [regex]::Escape($Placeholder)) { return }
+
+    $value = Read-Host $PromptText
+    if ($value) {
+        # Replace only the FIRST occurrence (via IndexOf/Substring, not
+        # .Replace(), which rewrites every occurrence). The placeholder can
+        # appear a second time in the hook's own "is this still unset" check
+        # (e.g. generic-indexer.ps1's
+        # `elseif ($ImgbbApiKey -eq "YOUR_IMGBB_API_KEY")`) - replacing every
+        # occurrence would rewrite that check into comparing the key against
+        # itself, always true, permanently "detecting" a freshly-filled key
+        # as still unset.
+        $idx = $hookContent.IndexOf($Placeholder)
+        $hookContent = $hookContent.Substring(0, $idx) + $value + $hookContent.Substring($idx + $Placeholder.Length)
+        Set-Content -Path $HookPath -Value $hookContent
+        Log "Value written to $HookPath (replaced $Placeholder)"
+    } else {
+        Warn "No value entered - edit $HookPath manually before your first upload (replace $Placeholder)."
+    }
+}
 
 # Windows PowerShell 5.1 (the default on Windows 10/11) only speaks TLS 1.0
 # by default on some configurations; force 1.2 or GitHub's API/CDN will
@@ -149,22 +180,9 @@ if ($HookUrl) {
         Warn "$hookName does not have a recognized extension (.exe/.cmd/.bat/.ps1/.py) - pesto will not run it automatically."
     }
 
-    # Hooks that need a per-user credential use the literal placeholder
-    # YOUR_API_KEY (see examples/hooks/generic-indexer.*) since a distributor
-    # can bake in their own indexer URL but not a key that belongs to each
-    # individual user. Prompt for it here so installs need no manual editing.
     if (-not $NoApiKeyPrompt) {
-        $hookContent = Get-Content -Raw -Path $hookPath
-        if ($hookContent -match "YOUR_API_KEY") {
-            $apiKey = Read-Host "Enter your indexer API key (leave blank to fill in later)"
-            if ($apiKey) {
-                $hookContent = $hookContent.Replace("YOUR_API_KEY", $apiKey)
-                Set-Content -Path $hookPath -Value $hookContent
-                Log "API key written to $hookPath"
-            } else {
-                Warn "No API key entered - edit $hookPath manually before your first upload (replace YOUR_API_KEY)."
-            }
-        }
+        Set-HookPlaceholder -HookPath $hookPath -Placeholder "YOUR_API_KEY" -PromptText "Enter your indexer API key (leave blank to fill in later)"
+        Set-HookPlaceholder -HookPath $hookPath -Placeholder "YOUR_IMGBB_API_KEY" -PromptText "Enter your ImgBB API key for hook screenshots (leave blank to skip screenshots, see https://api.imgbb.com/)"
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,7 @@
 #   --musl                Force the musl build (default: auto-detected).
 #   --no-path-update      Don't touch your shell rc file.
 #   --no-config-wizard    Don't run `pesto --config` even if no config.toml exists yet.
-#   --no-api-key-prompt   Don't prompt for an indexer API key, even if the downloaded hook needs one.
+#   --no-api-key-prompt   Don't prompt for an indexer/ImgBB API key, even if the downloaded hook needs one.
 
 set -euo pipefail
 
@@ -45,6 +45,43 @@ NO_API_KEY_PROMPT=""
 log()  { printf '[pesto-install] %s\n' "$1"; }
 warn() { printf '[pesto-install] WARNING: %s\n' "$1" >&2; }
 die()  { printf '[pesto-install] ERROR: %s\n' "$1" >&2; exit 1; }
+
+# Hooks that need a per-user credential use a literal placeholder - e.g.
+# YOUR_API_KEY / YOUR_IMGBB_API_KEY in examples/hooks/generic-indexer.* -
+# since a distributor can bake in their own indexer URL but not a key that
+# belongs to each individual user. Prompt for it and substitute it in place,
+# so installs need no manual editing.
+fill_hook_placeholder() {
+    placeholder="$1"
+    prompt_text="$2"
+    grep -q "$placeholder" "$HOOK_PATH" 2>/dev/null || return 0
+
+    value=""
+    # Read from /dev/tty, not stdin: this script is normally invoked as
+    # `curl ... | bash`, so stdin is the script source, not the terminal.
+    if [ -r /dev/tty ]; then
+        read -rp "[pesto-install] ${prompt_text}: " value < /dev/tty || true
+    fi
+    if [ -n "$value" ]; then
+        # Bash's ${var//pattern/replacement} treats & and \ in the
+        # replacement specially (like sed) - escape them so a value
+        # containing either lands in the file byte-for-byte.
+        value_escaped="${value//\\/\\\\}"
+        value_escaped="${value_escaped//&/\\&}"
+        # Single-slash form: replace only the FIRST occurrence. The
+        # placeholder can appear a second time in the hook's own "is this
+        # still unset" check (e.g. generic-indexer.sh's
+        # `if [ "$IMGBB_API_KEY" = "YOUR_IMGBB_API_KEY" ]`) - replacing every
+        # occurrence would rewrite that check into comparing the key against
+        # itself, always true, permanently "detecting" a freshly-filled key
+        # as still unset.
+        hook_content="$(cat "$HOOK_PATH")"
+        printf '%s\n' "${hook_content/$placeholder/$value_escaped}" > "$HOOK_PATH"
+        log "Value written to ${HOOK_PATH} (replaced ${placeholder})"
+    else
+        warn "No value entered - edit ${HOOK_PATH} manually before your first upload (replace ${placeholder})."
+    fi
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -154,29 +191,9 @@ if [ -n "$HOOK_URL" ]; then
     chmod +x "$HOOK_PATH"
     log "Hook script installed to ${HOOK_PATH}"
 
-    # Hooks that need a per-user credential use the literal placeholder
-    # YOUR_API_KEY (see examples/hooks/generic-indexer.*) since a distributor
-    # can bake in their own indexer URL but not a key that belongs to each
-    # individual user. Prompt for it here so installs need no manual editing.
-    # Read from /dev/tty, not stdin: this script is normally invoked as
-    # `curl ... | bash`, so stdin is the script source, not the terminal.
-    if [ -z "$NO_API_KEY_PROMPT" ] && grep -q "YOUR_API_KEY" "$HOOK_PATH" 2>/dev/null; then
-        api_key=""
-        if [ -r /dev/tty ]; then
-            read -rp "[pesto-install] Enter your indexer API key (leave blank to fill in later): " api_key < /dev/tty || true
-        fi
-        if [ -n "$api_key" ]; then
-            # Bash's ${var//pattern/replacement} treats & and \ in the
-            # replacement specially (like sed) - escape them so an API key
-            # containing either lands in the file byte-for-byte.
-            api_key_escaped="${api_key//\\/\\\\}"
-            api_key_escaped="${api_key_escaped//&/\\&}"
-            hook_content="$(cat "$HOOK_PATH")"
-            printf '%s\n' "${hook_content//YOUR_API_KEY/$api_key_escaped}" > "$HOOK_PATH"
-            log "API key written to ${HOOK_PATH}"
-        else
-            warn "No API key entered - edit ${HOOK_PATH} manually before your first upload (replace YOUR_API_KEY)."
-        fi
+    if [ -z "$NO_API_KEY_PROMPT" ]; then
+        fill_hook_placeholder "YOUR_API_KEY" "Enter your indexer API key (leave blank to fill in later)"
+        fill_hook_placeholder "YOUR_IMGBB_API_KEY" "Enter your ImgBB API key for hook screenshots (leave blank to skip screenshots, see https://api.imgbb.com/)"
     fi
 fi
 


### PR DESCRIPTION
## Summary
`generic-indexer.ps1`/`.sh` has two placeholders: `YOUR_API_KEY` (indexer) and `YOUR_IMGBB_API_KEY` (optional video-screenshot feature). Only the first got an interactive prompt — this adds the second, refactoring both installers' substitution logic into a reusable helper called once per placeholder.

## Bug found and fixed while wiring this up
`YOUR_IMGBB_API_KEY` appears **twice** in the bundled hook: once as the assignment, once in the hook's own "is this still unset" check that gates whether screenshots run at all (`if [ "$IMGBB_API_KEY" = "YOUR_IMGBB_API_KEY" ]`). The existing global replace (bash `${//}`, PowerShell `.Replace()`) rewrote *both* occurrences — turning that check into comparing the freshly-filled key against itself, always true, so screenshots would stay silently "disabled" forever even with a real key in place.

Fix: replace only the first occurrence in both installers (bash `${var/pat/repl}` instead of `${var//pat/repl}`; PowerShell manual `IndexOf`/`Substring` splice instead of `.Replace()`).

## Test plan
- [x] `cargo fmt --check`, `bash -n scripts/install.sh`
- [x] Verified with a real pty: both prompts fire, both keys land in the right assignment line, and the hook's own placeholder check (line 84 of generic-indexer.sh) is left intact so it correctly treats the key as configured
- [ ] `install.ps1`: reviewed by hand, not executed (no Windows/pwsh in this environment)