### PR TITLE
Default the --config wizard's NFO question to yes

### DIFF
--- a/crates/pesto/src/ui/wizard.rs
+++ b/crates/pesto/src/ui/wizard.rs
@@ -38,7 +38,7 @@ pub fn run() -> Result<()> {
     println!("Leave blank to keep that default, or enter a directory path to always");
     println!("save .nzb files there (e.g. ~/nzbs).");
     let nzb_dir = ask("NZB output directory (blank = next to uploaded file)", "")?;
-    let nfo = ask("Generate .nfo file alongside the .nzb? (y/N)", "n")?;
+    let nfo = ask("Generate .nfo file alongside the .nzb? (Y/n)", "y")?;
     let nfo = nfo.eq_ignore_ascii_case("y");
 
     let mut toml = String::new();


### PR DESCRIPTION
## Summary
The interactive `pesto --config` wizard defaulted "Generate .nfo file alongside the .nzb?" to no. Requested change: flip just the wizard's default answer to yes (leaving pesto's own behavior when the flag/config key is simply absent untouched — this only affects what pressing Enter with no input writes into a freshly generated config.toml).

Rationale: most people running the wizard don't have a strong reason to say no, and an NFO improves automatic categorization on indexers that read it. Users installing via `scripts/install.sh`/`install.ps1` who just mash Enter through the wizard now get `nfo = true` by default.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy -p pesto-poster --all-targets -- -D warnings`, `cargo test -p pesto-poster`
- [x] Manually ran the wizard end to end (`HOME=<tmp> pesto --config`, blank answers): confirmed prompt now reads `(Y/n) [y]` and the written config.toml has `nfo = true`