### PR TITLE
pesto: give each concurrent posting run its own PAR2 temp dir

### DIFF
--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -1329,7 +1329,7 @@ async fn run_single_upload(
     // is it safe to remove the PAR2 temp dir. See `par2_temp_dir`'s doc
     // comment for why this used to happen too early.
     if !config.par2_only {
-        let _ = tokio::fs::remove_dir_all(pesto::poster::par2_temp_dir()).await;
+        let _ = tokio::fs::remove_dir_all(&outcome.par2_temp_dir).await;
     }
 
     // 26g — per-phase timing summary (only when -v is active)

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -281,6 +281,13 @@ pub struct PostOutcome {
     /// it, callers had no way to surface the actual failure and could only
     /// print a generic "interrupted" message.
     pub failure_reason: Option<String>,
+    /// This run's PAR2 temp directory (see [`par2_temp_dir`]). Always set,
+    /// even when PAR2 was never generated — removing a directory that was
+    /// never created is a harmless no-op. Callers use this instead of
+    /// calling `par2_temp_dir` themselves, so each concurrent `--each`/
+    /// `--season` entry (`--jobs > 1`) cleans up only its own directory
+    /// instead of a path shared by every run in the process (issue #67).
+    pub par2_temp_dir: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -361,6 +368,11 @@ struct Shared {
     /// identity instead of a fresh random sender per file. `None` in every
     /// other mode.
     release_from: Option<String>,
+    /// Unique ID for this run, used to key [`par2_temp_dir`] so concurrent
+    /// runs in the same process (`--each`/`--season` with `--jobs > 1`) each
+    /// get their own PAR2 temp directory instead of colliding on one shared
+    /// by process ID alone.
+    run_id: u64,
 }
 
 impl Shared {
@@ -586,6 +598,13 @@ pub async fn post_files_with_progress_and_cancel(
         .map(|_| vec![0u8; config.article_size])
         .collect();
 
+    // Unique per call to this function, i.e. per posting run — not per
+    // process. `--each`/`--season` with `--jobs > 1` spawn several runs
+    // concurrently in the same process; each needs its own PAR2 temp
+    // directory (see `par2_temp_dir`'s doc comment / GitHub issue #67).
+    static RUN_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let run_id = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+
     let shared = Arc::new(Shared {
         config: config.clone(),
         servers,
@@ -602,6 +621,7 @@ pub async fn post_files_with_progress_and_cancel(
         post_group: pick_post_group(&config.groups),
         release_prefix,
         release_from,
+        run_id,
     });
 
     // Announce the work plan: one `FileEntry` per source file, with the
@@ -858,17 +878,23 @@ pub async fn post_files_with_progress_and_cancel(
         still_missing,
         servers: servers_used,
         failure_reason,
+        par2_temp_dir: par2_temp_dir(shared.run_id),
     })
 }
 
-/// Per-process temp directory holding the intermediate PAR2 files written
-/// during a normal posting run. Callers should remove it (when
-/// `!config.par2_only`) once the *entire* run is done — including any
-/// `--check` repost pass or end-of-run failed-task retry — not right after
-/// the main post loop finishes, since both of those may still need to
-/// re-read a PAR2 file's bytes from disk.
-pub fn par2_temp_dir() -> PathBuf {
-    std::env::temp_dir().join(format!("parmesan_{}", std::process::id()))
+/// Per-run temp directory holding the intermediate PAR2 files written during
+/// a normal posting run. Keyed by `run_id` (unique per [`PostOutcome`]), not
+/// just the process ID: `--each`/`--season` with `--jobs > 1` run several
+/// posting tasks concurrently *in the same process*, and a PID-only path
+/// used to collide them all into one directory — one entry finishing would
+/// delete PAR2 source files a sibling entry was still reading to repost
+/// (see GitHub issue #67). Callers should remove
+/// `par2_temp_dir(outcome.run_id)` (when `!config.par2_only`) once the
+/// *entire* run is done — including any `--check` repost pass or end-of-run
+/// failed-task retry — not right after the main post loop finishes, since
+/// both of those may still need to re-read a PAR2 file's bytes from disk.
+pub fn par2_temp_dir(run_id: u64) -> PathBuf {
+    std::env::temp_dir().join(format!("parmesan_{}_{run_id}", std::process::id()))
 }
 
 /// Restrict the global Rayon pool to physical cores. The PAR2 encoder is pure
@@ -1634,7 +1660,7 @@ async fn producer(
                 if shared.config.par2_only {
                     par2_dir = Some(par2_output_dir(&metas[0]));
                 } else {
-                    par2_dir = Some(par2_temp_dir());
+                    par2_dir = Some(par2_temp_dir(shared.run_id));
                     tokio::fs::create_dir_all(par2_dir.as_ref().unwrap()).await?;
                 }
 
@@ -3169,6 +3195,7 @@ mod tests {
             post_group,
             release_prefix: None,
             release_from: None,
+            run_id: 0,
         })
     }
 

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -463,7 +463,7 @@ pub async fn run_upload(
     // See `poster::par2_temp_dir`'s doc comment for why this used to happen
     // too early.
     if !config.par2_only {
-        let _ = tokio::fs::remove_dir_all(crate::poster::par2_temp_dir()).await;
+        let _ = tokio::fs::remove_dir_all(&outcome.par2_temp_dir).await;
     }
 
     Ok(UploadOutcome {

--- a/crates/pesto/tests/each_concurrent_par2_temp_dirs.rs
+++ b/crates/pesto/tests/each_concurrent_par2_temp_dirs.rs
@@ -1,19 +1,15 @@
-//! Regression guard for a real crash: when a file's size is an exact
-//! multiple of the PAR2 slice size, `producer`'s per-article accumulation
-//! loop in `crates/pesto/src/poster/mod.rs` used to drain `par2_accum` to
-//! exactly zero and flush the file's true last slice with
-//! `is_last_of_file: false` (the trailing, correctly-labelled flush is
-//! skipped whenever there's nothing left over). The PAR2 worker
-//! (`crates/parmesan/src/worker.rs`) relies on that flag to finalize and
-//! push the file's MD5/CRC hash — without it, the hash silently bled into
-//! the next file, or (for the last file in the set) the worker returned
-//! fewer hashes than non-empty files and `producer` panicked with
-//! `"worker returned fewer hashes than non-empty files"`.
+//! Regression guard for GitHub issue #67: `--each`/`--season` with
+//! `--jobs > 1` runs several `post_files_with_progress_and_cancel` calls
+//! concurrently *in the same process*. `poster::par2_temp_dir()` used to be
+//! keyed only by the process ID, so every concurrent entry wrote its PAR2
+//! index/volume files into the exact same directory — and each entry's
+//! caller deletes that directory (`remove_dir_all`) as soon as its own run
+//! finishes, which could wipe out a sibling entry's still-in-flight PAR2
+//! source files (needed later for `--check`'s repost pass).
 //!
-//! This reproduces the exact condition (`article_size == par2_slice_size`,
-//! file size an exact multiple of both) against the standard posting path
-//! (not `--par2-only`, which was never affected — see the module comment on
-//! `par2_only_ingest`).
+//! This runs two `post_files` calls concurrently and checks each gets its
+//! own PAR2 temp directory (`PostOutcome::par2_temp_dir`), so finishing one
+//! and cleaning it up can never touch the other's files.
 
 use pesto::config::{Config, ObfuscateMode};
 use pesto::poster::post_files;
@@ -98,28 +94,11 @@ fn content(seed: u8, len: usize) -> Vec<u8> {
         .collect()
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn file_size_exact_multiple_of_par2_slice_size_does_not_panic() {
-    let addr = spawn_accept_all_server();
-    let dir =
-        std::env::temp_dir().join(format!("pesto_par2_exact_multiple_{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let input = dir.join("movie.bin");
-
-    // article_size == par2_slice_size, and the file is exactly 10 articles —
-    // every article boundary is also an exact PAR2 slice boundary, the
-    // precise condition that used to drain `par2_accum` to zero. 10 slices
-    // at 10% recovery rounds down to exactly 1 recovery block, so the PAR2
-    // worker (and the buggy code path) is actually exercised — too few
-    // slices makes `recovery_count` round down to 0 and skips PAR2 entirely.
+fn par2_config(port: u16) -> Config {
     const ARTICLE_SIZE: usize = 65536;
-    const ARTICLES: usize = 10;
-    std::fs::write(&input, content(0, ARTICLE_SIZE * ARTICLES)).unwrap();
-
-    let config = Config {
+    Config {
         host: "127.0.0.1".to_string(),
-        port: addr.port(),
+        port,
         ssl: false,
         connections: 1,
         username: None,
@@ -181,28 +160,95 @@ async fn file_size_exact_multiple_of_par2_slice_size_does_not_panic() {
         allow_incomplete_nzb: false,
         pipeline_depth: 1,
         keepalive_interval: 0,
-    };
+    }
+}
 
-    let inputs = expand_inputs(std::slice::from_ref(&input)).unwrap();
-    // The bug manifested as a panic (`.expect("worker returned fewer hashes
-    // than non-empty files")`) inside `producer`, unwinding straight through
-    // this `.await.unwrap()` — so simply completing without panicking is the
-    // regression check.
-    let outcome = post_files(&config, &inputs).await.unwrap();
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_each_entries_get_distinct_par2_temp_dirs() {
+    let addr = spawn_accept_all_server();
+    let dir =
+        std::env::temp_dir().join(format!("pesto_each_concurrent_par2_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    const ARTICLE_SIZE: usize = 65536;
+    const ARTICLES: usize = 10;
+
+    let input_a = dir.join("entry_a").join("movie.bin");
+    let input_b = dir.join("entry_b").join("movie.bin");
+    std::fs::create_dir_all(input_a.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(input_b.parent().unwrap()).unwrap();
+    std::fs::write(&input_a, content(1, ARTICLE_SIZE * ARTICLES)).unwrap();
+    std::fs::write(&input_b, content(2, ARTICLE_SIZE * ARTICLES)).unwrap();
+
+    let config_a = par2_config(addr.port());
+    let config_b = par2_config(addr.port());
+    let inputs_a = expand_inputs(std::slice::from_ref(&input_a)).unwrap();
+    let inputs_b = expand_inputs(std::slice::from_ref(&input_b)).unwrap();
+
+    // Simulate `--each --jobs 2`: two entries posted concurrently from the
+    // same process, exactly like `run_batch` in `bin/pesto.rs` does.
+    let (outcome_a, outcome_b) = tokio::join!(
+        post_files(&config_a, &inputs_a),
+        post_files(&config_b, &inputs_b),
+    );
+    let outcome_a = outcome_a.unwrap();
+    let outcome_b = outcome_b.unwrap();
 
     assert!(
-        outcome
-            .segments
-            .iter()
-            .any(|s| s.file_name.ends_with(".par2")),
-        "expected at least one PAR2 segment among: {:?}",
-        outcome
-            .segments
-            .iter()
-            .map(|s| &s.file_name)
-            .collect::<Vec<_>>()
+        outcome_a.failures.is_empty(),
+        "entry A: {:?}",
+        outcome_a.failures
+    );
+    assert!(
+        outcome_b.failures.is_empty(),
+        "entry B: {:?}",
+        outcome_b.failures
     );
 
-    let _ = std::fs::remove_dir_all(&outcome.par2_temp_dir);
+    // The actual fix: each concurrent run must get its own PAR2 temp dir.
+    assert_ne!(
+        outcome_a.par2_temp_dir, outcome_b.par2_temp_dir,
+        "concurrent entries shared one PAR2 temp dir — deleting either \
+         after it finishes would destroy the other's still-needed PAR2 files"
+    );
+
+    // Both directories must independently hold their own PAR2 output —
+    // deleting one (as a finished entry's caller would) must not have
+    // touched the other's files.
+    for outcome in [&outcome_a, &outcome_b] {
+        assert!(
+            outcome.par2_temp_dir.exists(),
+            "{} should still exist — no cleanup has run yet",
+            outcome.par2_temp_dir.display()
+        );
+        let has_par2_file = std::fs::read_dir(&outcome.par2_temp_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.path().extension().is_some_and(|ext| ext == "par2"));
+        assert!(
+            has_par2_file,
+            "{} should contain this entry's own PAR2 file(s)",
+            outcome.par2_temp_dir.display()
+        );
+    }
+
+    // Deleting entry A's directory (as its caller would once fully done)
+    // must leave entry B's directory and files completely intact.
+    std::fs::remove_dir_all(&outcome_a.par2_temp_dir).unwrap();
+    assert!(
+        outcome_b.par2_temp_dir.exists(),
+        "cleaning up entry A's temp dir destroyed entry B's"
+    );
+    let b_still_has_par2 = std::fs::read_dir(&outcome_b.par2_temp_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .any(|e| e.path().extension().is_some_and(|ext| ext == "par2"));
+    assert!(
+        b_still_has_par2,
+        "entry B's PAR2 file(s) disappeared after cleaning up entry A"
+    );
+
+    let _ = std::fs::remove_dir_all(&outcome_b.par2_temp_dir);
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/pesto/tests/full_shared_obfuscation.rs
+++ b/crates/pesto/tests/full_shared_obfuscation.rs
@@ -415,7 +415,6 @@ async fn full_shared_obfuscation_par2_set_shares_prefix_with_content() {
         );
     }
 
-    let par2_dir = pesto::poster::par2_temp_dir();
-    let _ = std::fs::remove_dir_all(&par2_dir);
+    let _ = std::fs::remove_dir_all(&outcome.par2_temp_dir);
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/pesto/tests/par2_temp_dir_survives_post.rs
+++ b/crates/pesto/tests/par2_temp_dir_survives_post.rs
@@ -198,14 +198,14 @@ async fn par2_temp_dir_is_not_deleted_by_post_files() {
     // must still exist immediately after post_files returns, so a caller
     // running --check afterward can still re-read them to repost a segment
     // STAT couldn't find.
-    let par2_dir = pesto::poster::par2_temp_dir();
+    let par2_dir = &outcome.par2_temp_dir;
     assert!(
         par2_dir.exists(),
-        "par2_temp_dir() ({}) must still exist right after post_files() \
+        "outcome.par2_temp_dir ({}) must still exist right after post_files() \
          returns — --check's repost pass runs after this and needs it",
         par2_dir.display()
     );
 
-    let _ = std::fs::remove_dir_all(&par2_dir);
+    let _ = std::fs::remove_dir_all(par2_dir);
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- `par2_temp_dir()` was keyed only by process ID, so `--each`/`--season` with `--jobs > 1` shared one PAR2 temp directory across every concurrently-running entry in the same process.
- An entry finishing first would `remove_dir_all` that shared directory, destroying PAR2 source files a sibling entry still needed for posting or a `--check` repost.
- Now keyed by a per-run counter, exposed as `PostOutcome::par2_temp_dir`, so each entry cleans up only its own directory.

Found while investigating #67. Not confirmed yet whether it's the exact symptom reported there (that may instead require `--watch` combined with `--each`/`--season`, which intentionally re-splits a detected top-level entry) — still awaiting feedback from the reporter on that. This is a real, independently-reproducible bug either way.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p pesto-poster` (full suite, including the 3 existing PAR2-temp-dir tests updated for the new API)
- [x] New regression test `each_concurrent_par2_temp_dirs.rs`: runs two `post_files` calls concurrently against a mock NNTP server with PAR2 enabled (mirroring `--each --jobs 2`), asserts each gets a distinct `par2_temp_dir`, and that cleaning up one leaves the other's PAR2 files intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAqWnaTiLrMAZ7yUGenseA