### PR TITLE
Fix PESTO_INPUT_PATHS losing original filenames after --compress

### DIFF
--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,16 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Fixed
+- **`PESTO_INPUT_PATHS` sent to post-upload hooks now lists the original
+  input filenames even when `--compress` is active.** The `pesto` CLI was
+  overwriting its internal file list with the single compressed archive
+  before building the hook environment, so any hook that detects a video
+  file by extension (e.g. to capture thumbnails) never saw a `.mkv`/`.mp4`
+  path and silently skipped that step whenever compression was used. The
+  `pesto` library (used by `upapasta`/`sugo`) was unaffected — it already
+  reported the pre-compression paths.
+
 ## [0.4.5] — 2026-08-01
 
 ### Added

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -631,6 +631,11 @@ async fn run_single_upload(
 
     let mut inputs = pesto::walk::expand_inputs(entry_paths)?;
     let (_file_count, _folder_count, total_bytes) = upload_summary(&inputs);
+    // Snapshot the pre-compression file list: `inputs` gets overwritten below
+    // with the single archive file when --compress is active, but hooks still
+    // need the original filenames (e.g. to detect a video file by extension
+    // for thumbnail generation) regardless of what was actually posted.
+    let original_inputs = inputs.clone();
 
     // Run pre-hook(s) before anything else (before compression, PAR2, or NNTP).
     // Non-zero exit from any hook aborts the upload immediately.
@@ -1274,7 +1279,11 @@ async fn run_single_upload(
 
     // Run post-upload hooks only when the upload actually succeeded.
     if upload_ok && !config.par2_only && !config.dry_run {
-        let post_input_paths = inputs
+        // Use `original_inputs`, not `inputs`: when --compress is active
+        // `inputs` was replaced with the single compressed archive, which
+        // would otherwise hide every original filename (and its extension)
+        // from post-upload hooks — see the `original_inputs` snapshot above.
+        let post_input_paths = original_inputs
             .iter()
             .map(|f| f.path.to_string_lossy().into_owned())
             .collect::<Vec<_>>()

--- a/crates/pesto/tests/compress_hook_input_paths.rs
+++ b/crates/pesto/tests/compress_hook_input_paths.rs
@@ -1,0 +1,151 @@
+//! Regression test: `PESTO_INPUT_PATHS` must still list the original input
+//! filenames after `--compress`, not just the compressed archive.
+//!
+//! Post-upload hooks (e.g. a hook that screenshots a video file) detect a
+//! video by checking the extension of each path in `PESTO_INPUT_PATHS`. When
+//! `--compress` replaces the upload payload with a single `.7z`/`.zip`/`.rar`
+//! archive, a hook that only sees the archive path can never find a `.mkv`/
+//! `.mp4` extension to trigger on — so screenshots would silently never run.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::process::Command;
+
+fn spawn_accepting_server() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            std::thread::spawn(move || handle_connection(stream));
+        }
+    });
+
+    addr
+}
+
+fn handle_connection(stream: TcpStream) {
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+    let mut reader = BufReader::new(stream);
+    if writer.write_all(b"200 pesto mock ready\r\n").is_err() {
+        return;
+    }
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+        let command = line.trim_end().to_string();
+
+        if command == "POST" {
+            if writer.write_all(b"340 send article\r\n").is_err() {
+                return;
+            }
+            let mut raw = Vec::new();
+            loop {
+                raw.clear();
+                match reader.read_until(b'\n', &mut raw) {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+                if raw == b".\r\n" {
+                    break;
+                }
+            }
+            if writer
+                .write_all(b"240 <article@test> Article received OK\r\n")
+                .is_err()
+            {
+                return;
+            }
+        } else if command.starts_with("MODE READER") {
+            if writer.write_all(b"200 reader mode\r\n").is_err() {
+                return;
+            }
+        } else if command == "QUIT" {
+            let _ = writer.write_all(b"205 bye\r\n");
+            return;
+        } else if writer.write_all(b"500 unknown command\r\n").is_err() {
+            return;
+        }
+    }
+}
+
+#[test]
+fn compress_preserves_original_filenames_in_hook_input_paths() {
+    if which_7z_missing() {
+        eprintln!("skipping: 7z not found in PATH");
+        return;
+    }
+
+    let addr = spawn_accepting_server();
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("movie.mkv");
+    std::fs::write(&input, vec![0xABu8; 64]).unwrap();
+    let out = dir.path().join("out.nzb");
+
+    let xdg_home = tempfile::tempdir().unwrap();
+    let hooks_dir = xdg_home.path().join("pesto").join("hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    let captured = dir.path().join("captured_input_paths.txt");
+    let hook_path = hooks_dir.join("capture.sh");
+    std::fs::write(
+        &hook_path,
+        format!(
+            "#!/bin/sh\necho \"$PESTO_INPUT_PATHS\" > {}\n",
+            captured.to_str().unwrap()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&hook_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pesto"))
+        .env("XDG_CONFIG_HOME", xdg_home.path())
+        .arg("--no-ssl")
+        .args(["-s", "127.0.0.1"])
+        .args(["-P", &addr.port().to_string()])
+        .args(["-g", "alt.binaries.test"])
+        .args(["-n", "1"])
+        .args(["--par2", "0"])
+        .arg("--compress")
+        .args(["-o", out.to_str().unwrap()])
+        .arg(&input)
+        .output()
+        .expect("failed to run pesto");
+
+    assert!(
+        output.status.success(),
+        "pesto exited with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let captured_paths = std::fs::read_to_string(&captured)
+        .unwrap_or_else(|e| panic!("hook never ran / wrote {}: {e}", captured.display()));
+
+    assert!(
+        captured_paths.contains("movie.mkv"),
+        "PESTO_INPUT_PATHS should still list the original movie.mkv filename \
+         after --compress, so hooks can detect it by extension; got: {captured_paths:?}"
+    );
+    assert!(
+        !captured_paths.trim().ends_with(".7z"),
+        "PESTO_INPUT_PATHS should not resolve to the compressed archive only; got: {captured_paths:?}"
+    );
+}
+
+fn which_7z_missing() -> bool {
+    pesto::compress::find_binary("7z").is_none()
+}


### PR DESCRIPTION
## Summary
- The `pesto` CLI overwrote its internal file list with the single compressed archive before building the post-upload hook environment, so `PESTO_INPUT_PATHS` only contained the `.7z`/`.zip`/`.rar` path whenever `--compress` (or `--password`, which implies it) was active.
- Hooks that detect a video file by extension (e.g. to capture ffmpeg thumbnails, as curupira.cc's hook does) never matched a video extension in that case, so screenshot generation silently stopped working for compressed uploads.
- Snapshot the pre-compression input list and use that for the post-hook env instead — matching what `pesto`'s library path (`upload.rs`, used by `upapasta`/`sugo`) already did.

## Test plan
- [x] Added `crates/pesto/tests/compress_hook_input_paths.rs`: spins up a mock NNTP server, runs the real `pesto` binary with `--compress`, and asserts a post-hook still receives the original `movie.mkv` filename in `PESTO_INPUT_PATHS` (not just the archive).
- [x] Verified the new test fails without the fix (reverted the fix locally, confirmed the assertion catches the regression) and passes with it.
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p pesto-poster` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145LZGvCiPYnDt1TnyTy2md