### PR TITLE
Add pesto --update: self-update from the latest GitHub release

### DIFF
--- a/.github/workflows/release-pesto.yml
+++ b/.github/workflows/release-pesto.yml
@@ -80,6 +80,11 @@ jobs:
           mv x86_64-unknown-linux-musl/pesto pesto-linux-x86_64-musl
           mv x86_64-pc-windows-msvc/pesto.exe pesto-windows-x86_64.exe
 
+      # `pesto --update` refuses to install a binary whose SHA256 doesn't
+      # match this file, so it must exist for every release from now on.
+      - name: Generate checksums
+        run: sha256sum pesto-linux-x86_64 pesto-linux-x86_64-musl pesto-windows-x86_64.exe > SHA256SUMS
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
@@ -87,6 +92,7 @@ jobs:
             pesto-linux-x86_64
             pesto-linux-x86_64-musl
             pesto-windows-x86_64.exe
+            SHA256SUMS
           # Not `generate_release_notes: true` — GitHub's auto-generated notes
           # pick the previous *tag by creation time* across the whole repo,
           # which would pull in unrelated `parmesan-v*`/`penne-v*` tags

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,8 @@ dependencies = [
  "parmesan-par2",
  "rayon",
  "reqwest",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -2152,6 +2154,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "semver"

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,17 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Added
+- **`pesto --update`**: downloads the latest `pesto-v*` GitHub release for
+  the current platform, verifies its SHA256 against the `SHA256SUMS` file
+  now published alongside every release, and replaces the running binary in
+  place. Intended for prebuilt-binary installs (`scripts/install.sh`/
+  `install.ps1`); `cargo install` users should keep using `cargo install
+  pesto-poster`. Note: this only works against releases cut *after* this
+  change ships, since `SHA256SUMS` is a new release asset — running
+  `--update` against an older release without one fails with a clear error
+  instead of installing an unverified binary.
+
 ### Fixed
 - **`PESTO_INPUT_PATHS` sent to post-upload hooks now lists the original
   input filenames even when `--compress` is active.** The `pesto` CLI was

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -34,7 +34,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 webpki-roots = "0.26"
 rayon = "1.12.0"
 crc32fast = "1.4"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "multipart"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "multipart", "json"] }
 sha2 = "0.10"
 tempfile = "3"
 sysinfo = { version = "0.36.1", default-features = false, features = ["system"] }
@@ -44,6 +44,8 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 lexical-sort = "0.3"
 unicode-width = "0.2"
 bdinfo-rs-core = { version = "=1.0.1", git = "https://github.com/agentjp/bdinfo-rs", tag = "v1.0.1" }
+self-replace = "1.5.0"
+semver = "1.0.28"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_System_Console", "Win32_Foundation"] }

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -49,12 +49,16 @@ Download the latest binary for your platform from the
 
 | Platform | File |
 |----------|------|
-| Linux x86-64 (glibc) | `pesto-x86_64-unknown-linux-gnu.tar.gz` |
-| Linux x86-64 (musl / Alpine) | `pesto-x86_64-unknown-linux-musl.tar.gz` |
-| Windows x86-64 | `pesto-x86_64-pc-windows-msvc.zip` |
+| Linux x86-64 (glibc) | `pesto-linux-x86_64` |
+| Linux x86-64 (musl / Alpine) | `pesto-linux-x86_64-musl` |
+| Windows x86-64 | `pesto-windows-x86_64.exe` |
 
-Extract the archive and copy the binary to a directory on your `PATH`
-(e.g. `/usr/local/bin` on Linux/macOS, `C:\Windows\System32` on Windows).
+These are plain binaries, not archives — download and copy the file to a
+directory on your `PATH` (e.g. `/usr/local/bin` on Linux, `C:\Windows\System32`
+on Windows), renaming it to `pesto`/`pesto.exe` if you want the short name.
+[`scripts/install.sh`](../../scripts/install.sh)/[`install.ps1`](../../scripts/install.ps1)
+do this for you (`curl ... | bash` / `irm ... | iex` — see each script's header
+for the one-liner).
 
 ### Via cargo
 
@@ -63,6 +67,20 @@ cargo install pesto-poster
 ```
 
 The installed binary is named `pesto`.
+
+### Updating
+
+If you installed a prebuilt binary (not via `cargo install`), run:
+
+```bash
+pesto --update
+```
+
+This downloads the latest `pesto-v*` release for your platform, verifies its
+SHA256 against the `SHA256SUMS` file published alongside it, and replaces the
+running binary in place. It touches nothing else — no config, no NZBs.
+`cargo install pesto-poster` installs are unaffected; update those the same
+way you installed them (`cargo install pesto-poster` again).
 
 ### Build from source
 
@@ -779,6 +797,7 @@ picked up automatically — no config change needed.
 | Flag | Config key | Default | Description |
 |------|-----------|---------|-------------|
 | `-c`, `--config [PATH]` | — | auto | Load a TOML config; with no value, run the setup wizard |
+| `--update` | — | — | Download and install the latest release binary for this platform, then exit |
 | **Connection** | | | |
 | `--host <HOST>` | `server.host` | — | NNTP server hostname |
 | `--port <PORT>` | `server.port` | `563` | NNTP server port |

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -72,6 +72,12 @@ struct Cli {
     #[arg(short, long, value_name = "PATH", num_args = 0..=1)]
     config: Option<Option<PathBuf>>,
 
+    /// Download the latest pesto-v* release from GitHub for this platform,
+    /// verify its checksum, and replace the running binary with it. Exits
+    /// without touching anything else (no upload, no config load).
+    #[arg(long)]
+    update: bool,
+
     /// NNTP server hostname [config: server.host].
     #[arg(short = 's', long, value_name = "HOST")]
     host: Option<String>,
@@ -2161,6 +2167,10 @@ async fn main() -> Result<()> {
     // `pesto --config` with no value: launch the interactive setup wizard.
     if matches!(cli.config, Some(None)) {
         return pesto::ui::wizard::run();
+    }
+
+    if cli.update {
+        return pesto::update::run().await;
     }
 
     // Handle `-` (stdin) in the file list.

--- a/crates/pesto/src/lib.rs
+++ b/crates/pesto/src/lib.rs
@@ -40,6 +40,7 @@ pub mod poster;
 pub mod progress;
 pub mod resume;
 pub mod ui;
+pub mod update;
 pub mod upload;
 pub mod walk;
 pub mod yenc;

--- a/crates/pesto/src/update.rs
+++ b/crates/pesto/src/update.rs
@@ -1,0 +1,232 @@
+//! `pesto --update`: fetch the latest `pesto-v*` GitHub release for the
+//! platform pesto is currently running on, verify its SHA256 against the
+//! `SHA256SUMS` file published alongside it, and replace the running binary
+//! in place.
+//!
+//! This is deliberately independent of `cargo install`/`cargo publish` (see
+//! RELEASING.md) — it targets users who installed a prebuilt binary via
+//! `scripts/install.sh`/`install.ps1` and have no Rust toolchain to
+//! `cargo install` a new version with.
+
+use std::io::Write;
+
+use anyhow::{ensure, Context, Result};
+use serde::Deserialize;
+
+const REPO: &str = "franzopl/pesto";
+
+#[derive(Debug, Deserialize)]
+struct GhRelease {
+    tag_name: String,
+    assets: Vec<GhAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+/// Name of the release asset matching the platform this binary was built
+/// for. Must match the names `.github/workflows/release-pesto.yml` uploads.
+fn asset_name() -> &'static str {
+    #[cfg(all(target_os = "linux", target_env = "musl"))]
+    {
+        "pesto-linux-x86_64-musl"
+    }
+    #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+    {
+        "pesto-linux-x86_64"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "pesto-windows-x86_64.exe"
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        compile_error!("pesto --update has no published release binary for this platform");
+    }
+}
+
+/// Find the hex SHA256 for `want` inside a `sha256sum`-formatted checksums
+/// file (`<hash>  <filename>` or `<hash> *<filename>`, one entry per line).
+fn find_checksum(sums_text: &str, want: &str) -> Option<String> {
+    for line in sums_text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(2, char::is_whitespace);
+        let hash = parts.next()?;
+        let name = parts.next()?.trim().trim_start_matches('*');
+        if name == want {
+            return Some(hash.to_lowercase());
+        }
+    }
+    None
+}
+
+/// Run `pesto --update`: check the latest release, download it if newer,
+/// verify its checksum, and replace the running binary.
+pub async fn run() -> Result<()> {
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("pesto-update/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("building HTTP client")?;
+
+    println!("Checking for updates...");
+    let releases: Vec<GhRelease> = client
+        .get(format!("https://api.github.com/repos/{REPO}/releases"))
+        .send()
+        .await
+        .context("fetching release list from GitHub")?
+        .error_for_status()
+        .context("GitHub API returned an error")?
+        .json()
+        .await
+        .context("parsing GitHub release list")?;
+
+    // GitHub lists releases newest-first, and pesto is tagged/released
+    // independently of parmesan/penne (see RELEASING.md) — the first
+    // `pesto-v*` tag encountered here is the latest pesto release.
+    let latest = releases
+        .into_iter()
+        .find(|r| r.tag_name.starts_with("pesto-v"))
+        .context("no pesto-v* release found on GitHub")?;
+
+    let latest_version_str = latest.tag_name.trim_start_matches("pesto-v");
+    let latest_version: semver::Version = latest_version_str
+        .parse()
+        .with_context(|| format!("release tag `{}` is not valid semver", latest.tag_name))?;
+    let current_version: semver::Version = env!("CARGO_PKG_VERSION")
+        .parse()
+        .context("current CARGO_PKG_VERSION is not valid semver")?;
+
+    if latest_version <= current_version {
+        println!(
+            "pesto {current_version} is already up to date (latest release: {latest_version})."
+        );
+        return Ok(());
+    }
+
+    println!("Updating pesto {current_version} -> {latest_version}...");
+
+    let want = asset_name();
+    let asset = latest
+        .assets
+        .iter()
+        .find(|a| a.name == want)
+        .with_context(|| format!("release {} has no asset named {want}", latest.tag_name))?;
+    let sums_asset = latest
+        .assets
+        .iter()
+        .find(|a| a.name == "SHA256SUMS")
+        .with_context(|| {
+            format!(
+                "release {} is missing SHA256SUMS; refusing to update without checksum verification",
+                latest.tag_name
+            )
+        })?;
+
+    let sums_text = client
+        .get(&sums_asset.browser_download_url)
+        .send()
+        .await
+        .context("downloading SHA256SUMS")?
+        .error_for_status()
+        .context("GitHub returned an error downloading SHA256SUMS")?
+        .text()
+        .await
+        .context("reading SHA256SUMS")?;
+    let expected_sha256 = find_checksum(&sums_text, want)
+        .with_context(|| format!("SHA256SUMS has no entry for {want}"))?;
+
+    println!("Downloading {want}...");
+    let bytes = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .context("downloading the update")?
+        .error_for_status()
+        .context("GitHub returned an error downloading the update")?
+        .bytes()
+        .await
+        .context("reading the downloaded update")?;
+
+    let actual_sha256 = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        format!("{:x}", hasher.finalize())
+    };
+    ensure!(
+        actual_sha256 == expected_sha256,
+        "checksum mismatch for {want}: expected {expected_sha256}, got {actual_sha256} — \
+         refusing to install a corrupted or tampered binary"
+    );
+
+    let mut tmp = tempfile::NamedTempFile::new().context("creating a temp file for the update")?;
+    tmp.write_all(&bytes)
+        .context("writing the downloaded update to disk")?;
+    tmp.flush().context("flushing the downloaded update")?;
+
+    self_replace::self_replace(tmp.path()).context(
+        "replacing the running pesto binary (check you have write permission to its directory)",
+    )?;
+
+    println!("Updated to pesto {latest_version}. Restart any running pesto process to use it.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_name_is_one_of_the_release_pesto_workflow_assets() {
+        // Must stay in lockstep with the `mv`/`sha256sum` filenames in
+        // .github/workflows/release-pesto.yml — a mismatch here means
+        // `--update` can never find its own platform's asset.
+        assert!(matches!(
+            asset_name(),
+            "pesto-linux-x86_64" | "pesto-linux-x86_64-musl" | "pesto-windows-x86_64.exe"
+        ));
+    }
+
+    #[test]
+    fn find_checksum_matches_two_space_gnu_format() {
+        let sums = "abc123  pesto-linux-x86_64\ndef456  pesto-windows-x86_64.exe\n";
+        assert_eq!(
+            find_checksum(sums, "pesto-linux-x86_64"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            find_checksum(sums, "pesto-windows-x86_64.exe"),
+            Some("def456".to_string())
+        );
+    }
+
+    #[test]
+    fn find_checksum_matches_binary_mode_asterisk_format() {
+        let sums = "ABC123 *pesto-linux-x86_64-musl\n";
+        assert_eq!(
+            find_checksum(sums, "pesto-linux-x86_64-musl"),
+            Some("abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn find_checksum_returns_none_for_unknown_asset() {
+        let sums = "abc123  pesto-linux-x86_64\n";
+        assert_eq!(find_checksum(sums, "pesto-windows-x86_64.exe"), None);
+    }
+
+    #[test]
+    fn find_checksum_ignores_blank_lines() {
+        let sums = "\nabc123  pesto-linux-x86_64\n\n";
+        assert_eq!(
+            find_checksum(sums, "pesto-linux-x86_64"),
+            Some("abc123".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- New `pesto --update` flag: downloads the platform-matching `pesto-v*` release asset from GitHub, verifies its SHA256 against a new `SHA256SUMS` file, and replaces the running binary in place using the `self-replace` crate (handles Windows' running-executable-replace restrictions safely).
- `release-pesto.yml` now generates `SHA256SUMS` for the three binaries and uploads it as a release asset.
- Refuses to install if the checksum doesn't match, or if the release has no `SHA256SUMS` yet (older releases cut before this change) — never installs an unverified binary.
- README: new "Updating" section, plus a correction to the pre-built-binary asset table, which listed `.tar.gz`/`.zip` names that don't match what the workflow actually produces (plain binaries, not archives).
- Targets prebuilt-binary installs (`scripts/install.sh`/`install.ps1`); `cargo install` users should keep using `cargo install pesto-poster`.

**Note:** `--update` only works against releases cut *after* this merges, since `SHA256SUMS` is a new release asset. Running it against pesto-v0.4.5 (today's latest) correctly fails with "release pesto-v0.4.5 is missing SHA256SUMS" instead of installing something unverified — verified manually below.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p pesto-poster` all pass (404 tests).
- [x] Unit tests for `find_checksum` (both `sha256sum` output formats: two-space and `*binary-mode`) and `asset_name()` (kept in lockstep with the workflow's asset filenames).
- [x] Manual live smoke test against the real GitHub API: `pesto --update` on the current 0.4.5 binary correctly reports "already up to date".
- [x] Manual live smoke test simulating an older version (temporarily set `Cargo.toml` version to 0.4.4, reverted after): correctly detects 0.4.5 as newer, then cleanly refuses with "release pesto-v0.4.5 is missing SHA256SUMS" — confirms the checksum guard fires before any binary replacement is attempted, with no live release having `SHA256SUMS` yet.
- [ ] Manual end-to-end verification of the full download+verify+replace path against a real release with `SHA256SUMS` — only possible once the next `pesto-v*` release is cut with this workflow change live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145LZGvCiPYnDt1TnyTy2md