### PR TITLE
DIAG: CPU feature probe (throwaway, do not merge)

### DIFF
--- a/crates/parmesan/tests/cpu_diag.rs
+++ b/crates/parmesan/tests/cpu_diag.rs
@@ -1,0 +1,17 @@
+// Throwaway diagnostic: print which SIMD dispatch path the CI runner's CPU
+// actually takes, to debug the flaky decoder proptest failure. Not meant to
+// be merged.
+#[test]
+#[cfg(target_arch = "x86_64")]
+fn print_cpu_features() {
+    panic!(
+        "CPU_DIAG avx2={} ssse3={} avx512f={} avx512bw={} gfni={} avx512vbmi={} nproc={}",
+        std::is_x86_feature_detected!("avx2"),
+        std::is_x86_feature_detected!("ssse3"),
+        std::is_x86_feature_detected!("avx512f"),
+        std::is_x86_feature_detected!("avx512bw"),
+        std::is_x86_feature_detected!("gfni"),
+        std::is_x86_feature_detected!("avx512vbmi"),
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(0),
+    );
+}

--- a/crates/parmesan/tests/cpu_diag.rs
+++ b/crates/parmesan/tests/cpu_diag.rs
@@ -12,6 +12,8 @@ fn print_cpu_features() {
         std::is_x86_feature_detected!("avx512bw"),
         std::is_x86_feature_detected!("gfni"),
         std::is_x86_feature_detected!("avx512vbmi"),
-        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(0),
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(0),
     );
 }


### PR DESCRIPTION
Temporary diagnostic to see what SIMD features the CI runner's CPU has, investigating the flaky decoder proptest. Will close without merging.