### PR TITLE
pesto: formalize newsgroup cross-posting via '+'

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -8,6 +8,13 @@
 #
 # Every field is optional and can be overridden by the matching CLI flag.
 # Commented-out fields show their built-in default.
+#
+# Windows paths: a single backslash inside a "..." string is a TOML escape
+# sequence, not a literal character (e.g. "C:\nzb" is "C:" + a newline, and
+# some paths simply fail to parse). Either double every backslash
+# ("C:\\nzb\\arquivo"), use forward slashes instead ("C:/nzb/arquivo" — both
+# Windows and pesto accept these fine), or use single-quoted 'literal'
+# strings, which TOML never escapes.
 
 # ── Single-server configuration ─────────────────────────────────────────────
 #
@@ -72,6 +79,12 @@ password = "your_password"
 # from = "poster <poster@example.com>"
 
 # Newsgroups to post to. At least one is required (unless --par2-only).
+# With more than one entry, one is picked at random per run to spread posts
+# across the pool — it does not cross-post. To post to several groups at
+# once instead, join their names with '+' in a single entry:
+#   groups = ["alt.binaries.a+alt.binaries.b"]
+# The two can be mixed: ["alt.binaries.a+alt.binaries.b", "alt.binaries.c"]
+# picks between cross-posting a+b, or posting to c alone, each run.
 groups = ["alt.binaries.test"]
 
 # article_size — target size of each posted segment, in bytes. Default: 768000.
@@ -170,6 +183,9 @@ groups = ["alt.binaries.test"]
 # nzb_dir — directory where .nzb hardlinks/copies are placed after each upload.
 # Every upload is also archived to ~/.config/pesto/nzb/TIMESTAMP_stem.nzb so
 # the canonical copy is never lost. Overridden by --out or output.nzb.
+# On Windows, write this as "C:/nzb" or "C:\\nzb" — a single backslash is a
+# TOML escape sequence, not a literal one (see the note at the top of this
+# file).
 # nzb_dir = "/home/user/nzbs"
 
 # nzb — fixed path for the generated .nzb hardlink/copy. Overrides nzb_dir.

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,21 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Added
+- **Cross-posting via `+`**: a `groups`/`--groups` entry can now join several
+  newsgroup names with `+` (e.g. `"alt.a+alt.b"`) to post to all of them in
+  the same run, instead of only picking one at random from the pool. Entries
+  can be mixed, e.g. `["alt.a+alt.b", "alt.c"]` picks between cross-posting
+  a+b or posting to c alone, each run. The config wizard (`pesto --config`)
+  now asks whether to cross-post when more than one group is entered.
+  A `groups` entry with an embedded `,` (only reachable via a hand-edited
+  TOML config — `--groups` on the CLI already splits on `,`) was previously
+  treated as a single literal group name that happened to cross-post once
+  it reached the `Newsgroups:` header, purely as a parsing accident; `,` is
+  now an explicit, documented (deprecated) alias for `+` with the same
+  effect, so existing configs relying on it keep working and print a
+  one-line warning nudging towards `+`. See #66.
+
 ## [0.4.7] — 2026-08-02
 
 ### Added

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -157,6 +157,15 @@ nzb_dir = "/home/user/nzbs"   # where .nzb files are saved
 
 Any config field can be overridden by a CLI flag for a single run.
 
+With more than one entry, `groups` is a pool of alternatives: one is picked
+at random each run to spread posts across the pool over time — it does not
+cross-post. To post the same article to several groups at once instead, join
+their names with `+` in a single entry, e.g. `groups = ["alt.a+alt.b"]`. The
+two can be mixed, e.g. `groups = ["alt.a+alt.b", "alt.c"]` picks between
+"cross-post to a and b" or "post to c alone" each run. (`,` is accepted as a
+deprecated alias for `+` within a `groups` array entry, with a warning —
+prefer `+` in new configs.)
+
 ### Multiple servers with automatic failover
 
 ```toml
@@ -808,7 +817,7 @@ picked up automatically — no config change needed.
 | `--auth-password <PASS>` | `auth.password` | — | NNTP password |
 | **Posting** | | | |
 | `--from <ADDRESS>` | `posting.from` | random | `From` header (omit = random per run) |
-| `--groups <G,...>` | `posting.groups` | — | Newsgroups, comma-separated |
+| `--groups <G,...>` | `posting.groups` | — | Newsgroups; a pool to pick one from at random per run, or join with `+` in one entry to cross-post to all of them |
 | `--article-size <BYTES>` | `posting.article_size` | `768000` | Target segment size in bytes |
 | `--line-length <CHARS>` | `posting.line_length` | `128` | yEnc encoded line length |
 | `--retries <N>` | `posting.retries` | `3` | Post attempts per segment |

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -108,6 +108,9 @@ struct Cli {
     from: Option<String>,
 
     /// Newsgroups to post to (repeat or comma-separate) [config: posting.groups].
+    /// With more than one, one is chosen at random per run to spread posts
+    /// across the pool; join names with '+' in a single value to cross-post
+    /// to all of them at once instead, e.g. `-g alt.a+alt.b`.
     #[arg(short = 'g', long, value_name = "GROUP", value_delimiter = ',')]
     groups: Vec<String>,
 

--- a/crates/pesto/src/config/mod.rs
+++ b/crates/pesto/src/config/mod.rs
@@ -4,6 +4,7 @@ pub mod validation;
 
 pub use parse::{config_dir, default_config_path};
 pub use types::*;
+pub use validation::validate_groups;
 
 #[cfg(test)]
 mod tests;

--- a/crates/pesto/src/config/parse.rs
+++ b/crates/pesto/src/config/parse.rs
@@ -160,6 +160,7 @@ impl Config {
                 .filter(|g| !g.is_empty())
                 .context("no `groups` set: provide [posting].groups or --groups")?
         };
+        super::validation::validate_groups(&groups)?;
 
         Ok(Config {
             host,

--- a/crates/pesto/src/config/validation.rs
+++ b/crates/pesto/src/config/validation.rs
@@ -1,1 +1,86 @@
+use anyhow::{bail, Result};
 
+/// Validate the raw `groups` entries resolved from CLI/config, before
+/// [`crate::poster`]'s `pick_post_group` ever sees them.
+///
+/// Each entry is either a single newsgroup name, or several names joined
+/// with `+` for a simultaneous cross-post (e.g. `"a.b.c+d.e.f"`). `,` is
+/// accepted as a deprecated alias for `+` — before this was formalized, a
+/// TOML array element with an embedded `,` (unlike `--groups` on the CLI,
+/// which already splits on `,`) passed straight through to the `Newsgroups:`
+/// header and happened to cross-post, purely as a parsing accident. Existing
+/// configs relying on that keep working, with a nudge towards `+`, rather
+/// than a hard break on upgrade.
+pub fn validate_groups(groups: &[String]) -> Result<()> {
+    for entry in groups {
+        if entry.contains(',') {
+            eprintln!(
+                "warning: newsgroup entry `{entry}` uses ',' to cross-post — ',' is \
+                 deprecated for this, use '+' instead (e.g. \"a.b.c+d.e.f\"); ',' will stop \
+                 being treated as a cross-post separator in a future release"
+            );
+        }
+        for part in entry.split(['+', ',']) {
+            if part.trim().is_empty() {
+                bail!("newsgroup entry `{entry}` has an empty name around '+'/','");
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_group_is_valid() {
+        assert!(validate_groups(&["alt.binaries.test".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn cross_post_target_is_valid() {
+        assert!(validate_groups(&["alt.binaries.a+alt.binaries.b".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn pool_of_targets_is_valid() {
+        let groups = vec![
+            "alt.binaries.a+alt.binaries.b".to_string(),
+            "alt.binaries.c".to_string(),
+        ];
+        assert!(validate_groups(&groups).is_ok());
+    }
+
+    #[test]
+    fn comma_is_accepted_as_deprecated_alias() {
+        // Warns on stderr (not asserted here, matching this crate's other
+        // eprintln!-based warnings, e.g. walk.rs) but does not error.
+        assert!(validate_groups(&["alt.binaries.a,alt.binaries.b".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn trailing_plus_is_rejected() {
+        assert!(validate_groups(&["alt.binaries.a+".to_string()]).is_err());
+    }
+
+    #[test]
+    fn leading_plus_is_rejected() {
+        assert!(validate_groups(&["+alt.binaries.a".to_string()]).is_err());
+    }
+
+    #[test]
+    fn double_plus_is_rejected() {
+        assert!(validate_groups(&["alt.binaries.a++alt.binaries.b".to_string()]).is_err());
+    }
+
+    #[test]
+    fn trailing_comma_is_rejected() {
+        assert!(validate_groups(&["alt.binaries.a,".to_string()]).is_err());
+    }
+
+    #[test]
+    fn whitespace_only_part_is_rejected() {
+        assert!(validate_groups(&["alt.binaries.a+   ".to_string()]).is_err());
+    }
+}

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -2331,16 +2331,26 @@ fn make_task(
     }
 }
 
-/// across the configured groups over many runs. With zero or one configured
-/// group the slice is returned as-is.
+/// across the configured groups over many runs. Each entry in `groups` is a
+/// "target" that may itself be several newsgroup names joined with `+` (or
+/// the deprecated `,` alias) for a simultaneous cross-post (see
+/// [`crate::config::validation::validate_groups`] for the syntax this
+/// assumes has already been validated); the chosen target is split into the
+/// flat list every caller expects. With zero or one configured entry
+/// there's nothing to pick between, but the split still applies.
 fn pick_post_group(groups: &[String]) -> Vec<String> {
-    match groups {
-        [] | [_] => groups.to_vec(),
-        _ => {
-            let idx = (rand_u64() % groups.len() as u64) as usize;
-            vec![groups[idx].clone()]
+    let target = match groups {
+        [] => return Vec::new(),
+        [one] => one.as_str(),
+        many => {
+            let idx = (rand_u64() % many.len() as u64) as usize;
+            many[idx].as_str()
         }
-    }
+    };
+    target
+        .split(['+', ','])
+        .map(|s| s.trim().to_string())
+        .collect()
 }
 
 /// Compute the `Date:` header value and its Unix timestamp from the config
@@ -3164,6 +3174,41 @@ mod tests {
             let picked = pick_post_group(&groups);
             assert_eq!(picked.len(), 1);
             assert!(groups.contains(&picked[0]));
+        }
+    }
+
+    #[test]
+    fn pick_post_group_splits_single_entry_cross_post_target() {
+        let groups = vec!["alt.binaries.a+alt.binaries.b".to_string()];
+        assert_eq!(
+            pick_post_group(&groups),
+            vec!["alt.binaries.a".to_string(), "alt.binaries.b".to_string()]
+        );
+    }
+
+    #[test]
+    fn pick_post_group_trims_whitespace_around_plus() {
+        let groups = vec!["alt.binaries.a  +  alt.binaries.b".to_string()];
+        assert_eq!(
+            pick_post_group(&groups),
+            vec!["alt.binaries.a".to_string(), "alt.binaries.b".to_string()]
+        );
+    }
+
+    #[test]
+    fn pick_post_group_splits_the_chosen_target_from_a_pool() {
+        let groups = vec![
+            "alt.binaries.a+alt.binaries.b".to_string(),
+            "alt.binaries.c".to_string(),
+        ];
+        for _ in 0..100 {
+            let picked = pick_post_group(&groups);
+            let picked_set: Vec<&str> = picked.iter().map(String::as_str).collect();
+            assert!(
+                picked_set == ["alt.binaries.a", "alt.binaries.b"]
+                    || picked_set == ["alt.binaries.c"],
+                "unexpected pick: {picked:?}"
+            );
         }
     }
 

--- a/crates/pesto/src/ui/wizard.rs
+++ b/crates/pesto/src/ui/wizard.rs
@@ -30,6 +30,17 @@ pub fn run() -> Result<()> {
         ask("Password", "")?
     };
     let groups = ask("Newsgroups (comma-separated)", "alt.binaries.test")?;
+    let group_count = groups.split(',').filter(|g| !g.trim().is_empty()).count();
+    let cross_post = if group_count > 1 {
+        let ans = ask(
+            "Cross-post to all of them together on every run, instead of rotating \
+             through them at random? (y/N)",
+            "n",
+        )?;
+        ans.eq_ignore_ascii_case("y")
+    } else {
+        false
+    };
     let from = ask("From header (blank = random identity per run)", "")?;
     let par2 = ask("PAR2 recovery percentage (0 disables)", "10")?;
 
@@ -57,11 +68,21 @@ pub fn run() -> Result<()> {
     }
 
     toml.push_str("[posting]\n");
-    let group_list = groups
-        .split(',')
-        .map(|g| format!("\"{}\"", esc(g.trim())))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let group_list = if cross_post {
+        let target = groups
+            .split(',')
+            .map(str::trim)
+            .filter(|g| !g.is_empty())
+            .collect::<Vec<_>>()
+            .join("+");
+        format!("\"{}\"", esc(&target))
+    } else {
+        groups
+            .split(',')
+            .map(|g| format!("\"{}\"", esc(g.trim())))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
     toml.push_str(&format!("groups = [{group_list}]\n"));
     if from.is_empty() {
         toml.push_str("# from omitted: each run posts under a random identity.\n");


### PR DESCRIPTION
## Summary
- `groups`/`--groups` entries can now join newsgroup names with `+` (e.g. `"a.b.c+d.e.f"`) to cross-post to all of them every run, instead of only rotating through the pool at random. Entries can be mixed, e.g. `["a+b", "c"]` picks between cross-posting a+b or posting to c alone each run.
- `,` keeps working as a deprecated alias for `+` (with a one-line warning) so existing hand-edited configs relying on the old parsing-accident behavior aren't broken on upgrade — only genuinely malformed entries (empty parts around `+`/`,`) are a hard error.
- The config wizard (`pesto --config`) now asks whether to cross-post when more than one group is entered.
- Documents a TOML gotcha reported against `nzb_dir` on Windows: a single backslash in a `"..."` string is a TOML escape sequence, not literal — `config.example.toml` now explains using `"C:/nzb"`, `"C:\\nzb"`, or `'C:\nzb'`.

Closes #66.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all suites, including `upapasta`/`penne`/`sugo` which consume `pesto` as a library)
- [x] Manual `--dry-run` check: `--groups "a+b"` produces an NZB listing both groups
- [x] Manual check: a TOML config with `groups = ["a,b"]` prints the deprecation warning and still cross-posts to both groups (no breaking change)
- [x] Manual check: malformed entries (`"a+"`, `"a,"`) are rejected with an actionable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWqSigDirSuT2qBMNSGrJ1