### PR TITLE
pesto: make --resume safe against stale/mismatched state, add automatic check-recovery pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,12 +487,17 @@ deleted if `--watch-done` is not set.
 
 ### Upload resume
 
-If a posting run is interrupted (Ctrl-C, network failure, etc.), `pesto` can save
-state to a `.pesto-state` sidecar file next to the `.nzb`. On the next run with
-the same output path, already-posted articles are skipped and their `Message-ID`s
-are reused, so the final `.nzb` is complete and correct.
+If a posting run is interrupted (Ctrl-C, network failure, articles still
+missing after every automatic retry, etc.), `pesto` can pick up where it left
+off instead of re-posting everything from scratch.
 
-Resume is **off by default**. Enable it for a single run:
+Progress is tracked automatically for every run. If a run ends incomplete, that
+progress is saved to a `.pesto-state` sidecar file next to the `.nzb`; if it
+completes successfully, any state file is deleted — there is nothing left to
+resume from a finished upload. `--resume` controls the other half: whether a
+*prior* run's saved state is actually loaded and its already-posted segments
+skipped. Without it, `pesto` always starts fresh, even if a `.pesto-state` file
+is sitting right there.
 
 ```bash
 pesto --resume movie.mkv
@@ -504,8 +509,41 @@ Or enable it permanently in config.toml:
 resume = true
 ```
 
-State files are created beside the `.nzb` and are not automatically cleaned up.
-You can delete them manually when you no longer need them.
+When posting finishes but only a handful of articles fail the post-check,
+`pesto` already retries them automatically in the same run before giving up
+(see `--check-post-retries` and `--check-recover-max` below) — `--resume` is
+for what that can't cover: a run interrupted outright, or one where too many
+articles failed to justify an automatic retry. When a run does end that way,
+the printed error includes a ready-to-run retry command with the original
+`--article-size`/`--obfuscate`/`--par2`/`--compress` values already filled in.
+
+**Safety.** A saved state is only trusted if it was recorded under the same
+posting parameters (`--article-size`, `--obfuscate`, `--compress`, `--par2`)
+and, per file, the same size and modification time as what `--resume` sees
+now. Any mismatch — different parameters, or a file that changed since the
+state was recorded — is discarded rather than partially trusted, so a
+mismatched retry never corrupts the `.nzb`; it just re-posts as if `--resume`
+had not found anything.
+
+**Compressed uploads (`--compress`).** The archive is rebuilt from scratch on
+every run, so it always looks "changed" to the per-file check above and its
+segments can't be skipped on `--resume` — the archive's *content* is not
+resumable today. What does carry over: the obfuscated name/identity used to
+build it (reused instead of regenerated, so at least the file doesn't change
+identity every retry), and any article that was sent but never got a
+confirmed response (see below). The same applies to PAR2 recovery volumes for
+segments an interrupted run never reached — they're regenerated, not resumed.
+A plain, uncompressed upload gets full data-level resume; a compressed one
+mainly gets a safe, fast "no" instead of a slow re-post pretending to be a
+skip.
+
+**Sent but unconfirmed.** A segment whose article was sent but whose server
+acknowledgement never arrived (e.g. the connection dropped between `POST` and
+reading `240`) is cached in a `.pesto-spool` sidecar directory as soon as it's
+encoded, before it goes over the wire. On `--resume`, that exact article is
+replayed under its original `Message-ID` instead of being re-encoded and
+posted under a new one — avoiding a duplicate article if the original `POST`
+had, in fact, gone through.
 
 ### Per-upload logs
 
@@ -588,6 +626,10 @@ automatically if still missing.
 | `--check-delay <SECS>` | `posting.check_delay` | `30` | Seconds to wait before the STAT pass (implies `--check`) |
 | `--check-retries <N>` | `posting.check_retries` | `3` | STAT attempts per article; 20 s between each |
 | `--check-connections <N>` | `posting.check_connections` | same as upload | Parallel connections for the STAT pass |
+| `--check-post-retries <N>` | `posting.check_post_retries` | `1` | Repost-then-verify rounds for articles still missing after `--check` |
+| `--allow-incomplete-nzb` | `posting.allow_incomplete_nzb` | off | Write the `.nzb` anyway if articles are still confirmed missing after `--check-post-retries` |
+| `--check-recover-percent <N>` | `posting.check_recover_percent` | `15` | Skip the automatic final recovery pass below if still-missing articles exceed this percent of the release |
+| `--check-recover-max <N>` | `posting.check_recover_max` | `50` | After `--check-post-retries` is exhausted, automatically retry once more if at most this many articles (and within `--check-recover-percent`) are still missing; `0` disables |
 
 ### Rate limiting
 
@@ -854,7 +896,7 @@ picked up automatically — no config change needed.
 | `--par2 <PERCENT>` | `posting.par2` | `10` | PAR2 recovery percentage (0 = off) |
 | `--par2-only` | — | off | Write PAR2 files only; do not post |
 | `--dry-run` | — | off | Encode only; never touch the network |
-| `--resume` | `output.resume` | off | Resume interrupted upload from `.pesto-state` file |
+| `--resume` | `output.resume` | off | Load a prior run's `.pesto-state` file and skip already-posted segments |
 | `--slice-size <SIZE>` | — | auto | Manual PAR2 slice size (e.g. `"1 MiB"`) |
 | `--slice-count <N>` | — | auto | Target number of PAR2 input slices |
 | `--recovery-count <N>` | — | auto | Exact number of PAR2 recovery blocks |

--- a/config.example.toml
+++ b/config.example.toml
@@ -144,6 +144,17 @@ groups = ["alt.binaries.test"]
 # check_post_retries round. Default: false.
 # allow_incomplete_nzb = false
 
+# check_recover_percent / check_recover_max — after every check_post_retries
+# round is exhausted, pesto makes one more automatic repost-and-verify
+# attempt for whatever is still missing, but only when that's cheap: at or
+# below check_recover_max articles, AND at or below check_recover_percent of
+# the release's total segments (whichever cap is smaller wins). This is what
+# turns "posting finished but the check failed for a handful of articles"
+# into a self-healing run instead of a failed one requiring a manual
+# --resume. Set check_recover_max = 0 to disable. Defaults: 15 and 50.
+# check_recover_percent = 15
+# check_recover_max = 50
+
 # upload_rate — maximum total upload speed across all connections.
 # Accepts human-readable values: "50 MiB/s", "10 MB/s", "1024 KiB/s".
 # 0 or omitted means unlimited. Also settable with --rate.
@@ -217,12 +228,16 @@ groups = ["alt.binaries.test"]
 # Use this only to set a static password independently of --compress.
 # nzb_password = "archive_pass"
 
-# resume — save upload progress to a .pesto-state sidecar file after every
-# article. If the upload is interrupted, re-running the same command resumes
-# from where it stopped instead of starting over. The state file is placed
-# beside the .nzb output (same name, .pesto-state extension). Note: state
-# files are NOT automatically deleted on success — remove them manually.
-# Default: false.
+# resume — load a prior run's saved progress (from a .pesto-state sidecar
+# file beside the .nzb output) and skip already-posted segments. Progress is
+# always tracked and saved when a run ends incomplete, regardless of this
+# setting; `resume` only controls whether that saved state is actually
+# loaded back on the next run. The state file is deleted automatically once
+# a run completes successfully — nothing to clean up by hand. A saved state
+# is only trusted if it was recorded under matching posting parameters
+# (article_size, obfuscate, compress, par2) and, per file, the same size and
+# modification time; any mismatch is discarded rather than reused, so a
+# stale or unrelated state file can't corrupt the .nzb. Default: false.
 # resume = false
 
 # nfo — generate a .nfo text file alongside the .nzb. Default: false.

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -26,6 +26,62 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
   now an explicit, documented (deprecated) alias for `+` with the same
   effect, so existing configs relying on it keep working and print a
   one-line warning nudging towards `+`. See #66.
+- **`--check-recover-percent` / `--check-recover-max`**: after every
+  `--check-post-retries` round is exhausted, `pesto` now makes one more
+  automatic repost-and-verify attempt for whatever is still missing, as long
+  as that's cheap — at most `--check-recover-max` articles (default 50) and
+  within `--check-recover-percent` of the release's total segments (default
+  15%, whichever cap is smaller). This resolves the common case of "posting
+  finished, the check failed for a handful of articles" without requiring a
+  second `--resume` invocation. Set `--check-recover-max 0` to disable.
+- **Resume state now protects itself against corruption instead of trusting
+  blindly** (issue #18): before skipping any recorded segment, `--resume`
+  checks that this run's posting parameters (`--article-size`, `--obfuscate`,
+  `--compress`, `--par2`) and, per file, its size and modification time,
+  match what the state was recorded under. Any mismatch is discarded
+  (safely) instead of reused — a run-level mismatch clears the whole state,
+  a single changed file clears only that file's segments (and, when `--par2`
+  is active, the whole state — PAR2 recovery blocks are computed over every
+  file together, so one file changing invalidates all of them, not just its
+  own). On mismatch or failure, `pesto` now prints a ready-to-copy retry
+  command with the original parameters filled in.
+- **Resume state is now tracked for every run, not just ones started with
+  `--resume`**: if a run ends incomplete, its progress is always saved so a
+  later `--resume` has something to load — previously, deciding you needed
+  `--resume` only happened *after* a failure, which was too late if nothing
+  had been recorded. `--resume` itself still only controls whether a *prior*
+  run's saved state is loaded and reused, so nothing changes for a run that
+  already used it from the start.
+- **A segment that was sent but never confirmed (e.g. the connection dropped
+  between `POST` and reading the `240`) can now be resumed safely**: its
+  fully-encoded article is cached in a `.pesto-spool` sidecar directory as
+  soon as it's encoded, and replayed byte-for-byte under its original
+  Message-ID on `--resume`, instead of being silently re-encoded and posted
+  under a fresh one — which risked a duplicate article if the original
+  `POST` had, in fact, succeeded. Only active when `--resume` is passed.
+- The obfuscated archive name produced by `--compress`+`--obfuscate`, and the
+  shared identity used by `--obfuscate=full-shared`, now persist across
+  `--resume` runs with matching parameters instead of being regenerated
+  every time — needed for either to be resumable at all, since the resume
+  key is the name itself.
+
+### Fixed
+- **`--resume` no longer trusts stale or mismatched state, closing several
+  silent-corruption paths reported in issue #18**: a `.pesto-state` file
+  left over from an unrelated run, an edited file reusing the same output
+  name, or a retry using a different `--article-size`/`--obfuscate`/
+  `--compress`/`--par2` no longer gets blindly reused — see "Added" above.
+- **Resume state is deleted once a run completes successfully** —
+  previously left on disk indefinitely, so a later unrelated run at the same
+  output path could silently skip every segment and post nothing at all.
+- **Resumed segments now report their real wire size in the `.nzb`** instead
+  of a hardcoded `0`.
+
+### Changed
+- Resume-state persistence moved off the posting hot path: every confirmed
+  segment used to trigger a full rewrite of the state file while holding a
+  shared lock across all workers (O(n²) disk I/O on large uploads); it is
+  now written once, at the end of the run, based on the final outcome.
 
 ## [0.4.7] — 2026-08-02
 

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -509,12 +509,17 @@ deleted if `--watch-done` is not set.
 
 ### Upload resume
 
-If a posting run is interrupted (Ctrl-C, network failure, etc.), `pesto` can save
-state to a `.pesto-state` sidecar file next to the `.nzb`. On the next run with
-the same output path, already-posted articles are skipped and their `Message-ID`s
-are reused, so the final `.nzb` is complete and correct.
+If a posting run is interrupted (Ctrl-C, network failure, articles still
+missing after every automatic retry, etc.), `pesto` can pick up where it left
+off instead of re-posting everything from scratch.
 
-Resume is **off by default**. Enable it for a single run:
+Progress is tracked automatically for every run. If a run ends incomplete, that
+progress is saved to a `.pesto-state` sidecar file next to the `.nzb`; if it
+completes successfully, any state file is deleted — there is nothing left to
+resume from a finished upload. `--resume` controls the other half: whether a
+*prior* run's saved state is actually loaded and its already-posted segments
+skipped. Without it, `pesto` always starts fresh, even if a `.pesto-state` file
+is sitting right there.
 
 ```bash
 pesto --resume movie.mkv
@@ -526,8 +531,41 @@ Or enable it permanently in config.toml:
 resume = true
 ```
 
-State files are created beside the .nzb and are not automatically cleaned up.
-You can delete them manually when you no longer need them.
+When posting finishes but only a handful of articles fail the post-check,
+`pesto` already retries them automatically in the same run before giving up
+(see `--check-post-retries` and `--check-recover-max` above) — `--resume` is
+for what that can't cover: a run interrupted outright, or one where too many
+articles failed to justify an automatic retry. When a run does end that way,
+the printed error includes a ready-to-run retry command with the original
+`--article-size`/`--obfuscate`/`--par2`/`--compress` values already filled in.
+
+**Safety.** A saved state is only trusted if it was recorded under the same
+posting parameters (`--article-size`, `--obfuscate`, `--compress`, `--par2`)
+and, per file, the same size and modification time as what `--resume` sees
+now. Any mismatch — different parameters, or a file that changed since the
+state was recorded — is discarded rather than partially trusted, so a
+mismatched retry never corrupts the `.nzb`; it just re-posts as if `--resume`
+had not found anything.
+
+**Compressed uploads (`--compress`).** The archive is rebuilt from scratch on
+every run, so it always looks "changed" to the per-file check above and its
+segments can't be skipped on `--resume` — the archive's *content* is not
+resumable today. What does carry over: the obfuscated name/identity used to
+build it (reused instead of regenerated, so at least the file doesn't change
+identity every retry), and any article that was sent but never got a
+confirmed response (see below). The same applies to PAR2 recovery volumes for
+segments an interrupted run never reached — they're regenerated, not resumed.
+A plain, uncompressed upload gets full data-level resume; a compressed one
+mainly gets a safe, fast "no" instead of a slow re-post pretending to be a
+skip.
+
+**Sent but unconfirmed.** A segment whose article was sent but whose server
+acknowledgement never arrived (e.g. the connection dropped between `POST` and
+reading `240`) is cached in a `.pesto-spool` sidecar directory as soon as it's
+encoded, before it goes over the wire. On `--resume`, that exact article is
+replayed under its original `Message-ID` instead of being re-encoded and
+posted under a new one — avoiding a duplicate article if the original `POST`
+had, in fact, gone through.
 
 ### Post-verification via STAT
 
@@ -831,7 +869,7 @@ picked up automatically — no config change needed.
 | `--par2 <PERCENT>` | `posting.par2` | `10` | PAR2 recovery percentage (0 = off) |
 | `--par2-only` | — | off | Write PAR2 files only; do not post |
 | `--dry-run` | — | off | Encode only; never touch the network |
-| `--resume` | `output.resume` | off | Resume interrupted upload from `.pesto-state` file |
+| `--resume` | `output.resume` | off | Load a prior run's `.pesto-state` file and skip already-posted segments |
 | `--slice-size <SIZE>` | — | auto | Manual PAR2 slice size (e.g. `"1 MiB"`) |
 | `--slice-count <N>` | — | auto | Target number of PAR2 input slices |
 | `--recovery-count <N>` | — | auto | Exact number of PAR2 recovery blocks |
@@ -845,6 +883,8 @@ picked up automatically — no config change needed.
 | `--check-connections <N>` | `posting.check_connections` | same as upload | Parallel connections for STAT pass |
 | `--check-post-retries <N>` | `posting.check_post_retries` | `1` | Repost-then-verify rounds for articles still missing after `--check` |
 | `--allow-incomplete-nzb` | `posting.allow_incomplete_nzb` | off | Write the `.nzb` and run hooks even if some articles are still confirmed missing after `--check-post-retries` |
+| `--check-recover-percent <N>` | `posting.check_recover_percent` | `15` | Skip the automatic final recovery pass below if still-missing articles exceed this percent of the release |
+| `--check-recover-max <N>` | `posting.check_recover_max` | `50` | After `--check-post-retries` is exhausted, automatically retry once more if at most this many articles (and within `--check-recover-percent`) are still missing; `0` disables |
 | `--rate <RATE>` | `posting.upload_rate` | unlimited | Max upload rate (e.g. `"50 MiB/s"`) |
 | **Compression** | | | |
 | `--compress [FORMAT]` | `compression.format` | off | Bundle into an archive (`7z`, `zip`, `rar`) |

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -206,8 +206,15 @@ struct Cli {
     #[arg(long)]
     dry_run: bool,
 
-    /// Resume an interrupted upload from where it left off. Without this flag
-    /// pesto always starts fresh, even if a state file exists
+    /// Resume an interrupted upload from where it left off. Without this
+    /// flag pesto always starts fresh, even if a state file exists from a
+    /// previous incomplete run at the same output path — progress is always
+    /// saved on an incomplete run regardless of this flag, but only loaded
+    /// back (to skip already-posted segments) when --resume is passed. With
+    /// --compress, the archive is always rebuilt from scratch and its
+    /// segments can't be skipped — only its identity and any sent-but-
+    /// unconfirmed article carry over. See the README's "Upload resume"
+    /// section for the full picture
     /// [config: output.resume = true].
     #[arg(long)]
     resume: bool,
@@ -455,6 +462,26 @@ struct Cli {
     #[arg(long)]
     allow_incomplete_nzb: bool,
 
+    /// After every --check-post-retries round is exhausted, skip the
+    /// automatic final recovery pass (see --check-recover-max) if the
+    /// still-missing articles exceed this percentage of the release's total
+    /// segments — past this point it looks like a systemic problem, not a
+    /// handful of unlucky articles, and retrying automatically would just
+    /// hammer an already-struggling server
+    /// [config: posting.check_recover_percent, default 15].
+    #[arg(long, value_name = "PERCENT")]
+    check_recover_percent: Option<u8>,
+
+    /// After every --check-post-retries round is exhausted, if the number of
+    /// still-missing articles is at or below this count (and within
+    /// --check-recover-percent of the release), automatically make one more
+    /// repost-and-verify attempt for just those articles before giving up —
+    /// cheap enough to be worth doing without a separate --resume run. Set
+    /// to 0 to disable
+    /// [config: posting.check_recover_max, default 50].
+    #[arg(long, value_name = "N")]
+    check_recover_max: Option<usize>,
+
     /// Name to use when reading from stdin (`-`). Required when a `-` path is
     /// given; determines the filename in the NZB and PAR2 metadata.
     #[arg(long, value_name = "NAME")]
@@ -598,6 +625,8 @@ impl Cli {
             } else {
                 None
             },
+            check_recover_percent: self.check_recover_percent,
+            check_recover_max: self.check_recover_max,
             pipeline_depth: self.pipeline_depth,
         }
     }
@@ -749,123 +778,10 @@ async fn run_single_upload(
         pesto::ui::terminal::spawn_renderer_with(params.renderer_opts.clone())
     };
 
-    // ── Compression ──────────────────────────────────────────────────────────
-    let compress_format_str: Option<String> = config.compress_format.clone().or_else(|| {
-        if config.compress_password.is_some() {
-            Some("7z".to_string())
-        } else {
-            None
-        }
-    });
-    let effective_password: Option<String> = config.compress_password.clone();
-
-    let compress_temp_dir: Option<PathBuf>;
-    if let Some(fmt_str) = &compress_format_str {
-        let format = ArchiveFormat::parse(fmt_str).ok_or_else(|| {
-            anyhow::anyhow!("unknown compression format `{fmt_str}`; supported: 7z, zip, rar")
-        })?;
-
-        if format == ArchiveFormat::Rar && pesto::compress::find_binary("rar").is_none() {
-            eprintln!("note: rar password protection requires the `rar` binary in PATH");
-        }
-
-        let archive_stem = upload_root(&inputs)
-            .or_else(|| {
-                inputs.first().map(|f| {
-                    PathBuf::from(&f.name)
-                        .file_stem()
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                        .into_owned()
-                })
-            })
-            .unwrap_or_else(|| "archive".to_string());
-
-        let archive_stem = if config.obfuscate != ObfuscateMode::None {
-            pesto::article::obfuscated_name()
-        } else {
-            archive_stem
-        };
-
-        let tmp_dir = std::env::temp_dir().join(format!(
-            "pesto_compress_{}_{}",
-            std::process::id(),
-            entry_label
-        ));
-        compress_temp_dir = Some(tmp_dir.clone());
-
-        let fs_paths: Vec<PathBuf> = collect_compress_roots(&inputs);
-        let compress_input_bytes: u64 = fs_paths.iter().map(|p| dir_or_file_size(p)).sum();
-
-        let t_compress = std::time::Instant::now();
-        let _ = progress_tx.send(pesto::progress::ProgressEvent::CompressStarted {
-            total_bytes: compress_input_bytes,
-        });
-
-        let archive_path_for_poll =
-            tmp_dir.join(format!("{}.{}", archive_stem, format.extension()));
-        let poll_tx = progress_tx.clone();
-        let poll_path = archive_path_for_poll.clone();
-        let poll_handle = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_millis(200));
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                interval.tick().await;
-                if let Ok(meta) = tokio::fs::metadata(&poll_path).await {
-                    let _ = poll_tx.send(pesto::progress::ProgressEvent::CompressProgress {
-                        bytes_written: meta.len(),
-                    });
-                }
-            }
-        });
-
-        let compress_inputs = fs_paths.clone();
-        let compress_stem = archive_stem.clone();
-        let compress_dest = tmp_dir.clone();
-        let compress_pass = effective_password.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            compress(
-                &compress_inputs,
-                &compress_stem,
-                &compress_dest,
-                format,
-                compress_pass.as_deref(),
-            )
-        })
-        .await
-        .context("compressor task panicked")??;
-
-        poll_handle.abort();
-        let _ = progress_tx.send(pesto::progress::ProgressEvent::CompressDone);
-        let compress_ms = t_compress.elapsed().as_millis();
-        info!(elapsed_ms = compress_ms, phase = "compress", "phase done");
-        timings.compress_ms = Some(compress_ms);
-
-        let archive_name = result
-            .path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .into_owned();
-        inputs = vec![pesto::walk::InputFile {
-            path: result.path,
-            name: archive_name,
-        }];
-
-        if let Some(pw) = &effective_password {
-            let was_auto = params.archive_password_raw.as_deref() == Some("");
-            if was_auto {
-                println!("archive password: {pw}");
-            }
-        }
-    } else {
-        compress_temp_dir = None;
-    }
-    // ─────────────────────────────────────────────────────────────────────────
-
     // Derive NZB stem from: --out > nzb_default > nzb_dir/<stem>.nzb > ./<stem>.nzb
-    // Always use the original entry_paths for the stem so obfuscation/compression
-    // does not leak the randomised archive name into the output filenames.
+    // Computed from the original entry_paths, before compression, so it never
+    // depends on the (possibly obfuscated/randomised) archive name compression
+    // produces below.
     //
     // nzb_stem: bare filename without extension, used to name the NZB.
     // nzb_user_dest: optional user-requested destination (--out or nzb_dir).
@@ -962,6 +878,131 @@ async fn run_single_upload(
     // nzb_out_path is resolved at write time (after post) — placeholder kept for
     // symmetry with the rest of the function.
     let nzb_out_path: Option<String> = nzb_stem.clone();
+
+    // ── Compression ──────────────────────────────────────────────────────────
+    let compress_format_str: Option<String> = config.compress_format.clone().or_else(|| {
+        if config.compress_password.is_some() {
+            Some("7z".to_string())
+        } else {
+            None
+        }
+    });
+    let effective_password: Option<String> = config.compress_password.clone();
+
+    let compress_temp_dir: Option<PathBuf>;
+    if let Some(fmt_str) = &compress_format_str {
+        let format = ArchiveFormat::parse(fmt_str).ok_or_else(|| {
+            anyhow::anyhow!("unknown compression format `{fmt_str}`; supported: 7z, zip, rar")
+        })?;
+
+        if format == ArchiveFormat::Rar && pesto::compress::find_binary("rar").is_none() {
+            eprintln!("note: rar password protection requires the `rar` binary in PATH");
+        }
+
+        let archive_stem = upload_root(&inputs)
+            .or_else(|| {
+                inputs.first().map(|f| {
+                    PathBuf::from(&f.name)
+                        .file_stem()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .into_owned()
+                })
+            })
+            .unwrap_or_else(|| "archive".to_string());
+
+        // The obfuscated archive name is normally regenerated fresh on every
+        // run — but that means a --resume run can never match this file's
+        // segments back up, since the resume key is this very name. When a
+        // compatible prior state exists (same posting parameters — see
+        // `resume::RunFingerprint`) and already recorded one, reuse it
+        // instead of generating a new one; otherwise generate fresh and
+        // record it (tracked unconditionally, same as segment state — see
+        // issue #18's follow-up discussion) so a *future* --resume can reuse
+        // it. `poster::post_files_with_progress_and_cancel` still validates
+        // the fingerprint itself, so a genuinely incompatible resume run
+        // simply gets a fresh stem here and a wiped segment state there.
+        let archive_stem = if config.obfuscate != ObfuscateMode::None {
+            reuse_or_generate_archive_stem(resume_path.as_deref(), config)
+        } else {
+            archive_stem
+        };
+
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "pesto_compress_{}_{}",
+            std::process::id(),
+            entry_label
+        ));
+        compress_temp_dir = Some(tmp_dir.clone());
+
+        let fs_paths: Vec<PathBuf> = collect_compress_roots(&inputs);
+        let compress_input_bytes: u64 = fs_paths.iter().map(|p| dir_or_file_size(p)).sum();
+
+        let t_compress = std::time::Instant::now();
+        let _ = progress_tx.send(pesto::progress::ProgressEvent::CompressStarted {
+            total_bytes: compress_input_bytes,
+        });
+
+        let archive_path_for_poll =
+            tmp_dir.join(format!("{}.{}", archive_stem, format.extension()));
+        let poll_tx = progress_tx.clone();
+        let poll_path = archive_path_for_poll.clone();
+        let poll_handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(200));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                if let Ok(meta) = tokio::fs::metadata(&poll_path).await {
+                    let _ = poll_tx.send(pesto::progress::ProgressEvent::CompressProgress {
+                        bytes_written: meta.len(),
+                    });
+                }
+            }
+        });
+
+        let compress_inputs = fs_paths.clone();
+        let compress_stem = archive_stem.clone();
+        let compress_dest = tmp_dir.clone();
+        let compress_pass = effective_password.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            compress(
+                &compress_inputs,
+                &compress_stem,
+                &compress_dest,
+                format,
+                compress_pass.as_deref(),
+            )
+        })
+        .await
+        .context("compressor task panicked")??;
+
+        poll_handle.abort();
+        let _ = progress_tx.send(pesto::progress::ProgressEvent::CompressDone);
+        let compress_ms = t_compress.elapsed().as_millis();
+        info!(elapsed_ms = compress_ms, phase = "compress", "phase done");
+        timings.compress_ms = Some(compress_ms);
+
+        let archive_name = result
+            .path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        inputs = vec![pesto::walk::InputFile {
+            path: result.path,
+            name: archive_name,
+        }];
+
+        if let Some(pw) = &effective_password {
+            let was_auto = params.archive_password_raw.as_deref() == Some("");
+            if was_auto {
+                println!("archive password: {pw}");
+            }
+        }
+    } else {
+        compress_temp_dir = None;
+    }
+    // ─────────────────────────────────────────────────────────────────────────
 
     let t_post = std::time::Instant::now();
     let outcome = pesto::poster::post_files_with_progress_and_cancel(
@@ -1061,23 +1102,32 @@ async fn run_single_upload(
     let has_confirmed_missing = !check_missing.is_empty() && !config.dry_run && !config.par2_only;
     let has_unrecoverable_failures =
         has_post_failures || (has_confirmed_missing && !config.allow_incomplete_nzb);
+    let files_str = || {
+        entry_paths
+            .iter()
+            .map(|p| format!("\"{}\"", p.display()))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    let resume_flags_str = || resume_flags_string(config);
     if has_post_failures {
         let n = outcome.failed_tasks.len();
         eprintln!();
         eprintln!("error: {n} segment(s) could not be posted after all retries.");
         eprintln!("The NZB will NOT be written — the upload is incomplete.");
+        // Resume state is tracked for every run (not just ones started with
+        // --resume) and persisted whenever a run ends incomplete like this
+        // one — see `post_files_with_progress_and_cancel`'s final
+        // persist-or-delete decision — so the segments that did succeed are
+        // always recoverable here, regardless of whether --resume was
+        // originally passed.
         if let Some(ref state_path) = resume_path {
             eprintln!();
             eprintln!("The successfully posted segments have been saved to:");
             eprintln!("  {}", state_path.display());
             eprintln!();
-            let files_str = entry_paths
-                .iter()
-                .map(|p| format!("\"{}\"", p.display()))
-                .collect::<Vec<_>>()
-                .join(" ");
             eprintln!("To retry the missing segments and finish the upload, run:");
-            eprintln!("  pesto {files_str} --resume");
+            eprintln!("  pesto {} --resume {}", files_str(), resume_flags_str());
         }
         eprintln!();
     }
@@ -1086,17 +1136,33 @@ async fn run_single_upload(
         eprintln!();
         if config.allow_incomplete_nzb {
             eprintln!(
-                "warning: {n} article(s) still missing on the server after every repost attempt."
+                "warning: {n} article(s) still missing on the server after every repost \
+                 attempt, including one final automatic recovery pass when the miss count \
+                 was small enough."
             );
             eprintln!("Publishing anyway — --allow-incomplete-nzb was set.");
         } else {
             eprintln!(
-                "error: {n} article(s) still missing on the server after every repost attempt."
+                "error: {n} article(s) still missing on the server after every repost \
+                 attempt, including one final automatic recovery pass when the miss count \
+                 was small enough."
             );
             eprintln!(
                 "The NZB will NOT be written — pass --allow-incomplete-nzb to publish anyway \
                  (e.g. relying on PAR2 recovery)."
             );
+            // Same reasoning as the has_post_failures branch above: resume
+            // state is always tracked and gets persisted here regardless of
+            // whether --resume was passed to this run.
+            if let Some(ref state_path) = resume_path {
+                eprintln!();
+                eprintln!(
+                    "Or retry just the missing article(s) — the segments already \
+                     confirmed present have been saved to:"
+                );
+                eprintln!("  {}", state_path.display());
+                eprintln!("  pesto {} --resume {}", files_str(), resume_flags_str());
+            }
         }
         eprintln!();
     }
@@ -2518,6 +2584,72 @@ fn upload_root(inputs: &[pesto::walk::InputFile]) -> Option<String> {
     root.map(str::to_string)
 }
 
+/// Decide the obfuscated archive stem for a `--compress`+`--obfuscate` run:
+/// reuse the value a compatible prior `--resume` run recorded, or generate a
+/// fresh one and record it for a *future* `--resume` to find.
+///
+/// Only touches the resume-state file when `--resume` is passed. Doing this
+/// unconditionally would conflict with
+/// `poster::post_files_with_progress_and_cancel`'s own handling of the same
+/// file: when `--resume` is *not* passed, that function deliberately starts
+/// from a fresh, empty state (see issue #18 — trusting whatever happens to
+/// be on disk without being asked is the exact hazard it guards against),
+/// which would silently erase whatever this function wrote moments earlier.
+/// The practical result is the same rule as everywhere else in resume
+/// handling: a stem only survives into a later run when every run in the
+/// chain, including the first, passes `--resume`.
+fn reuse_or_generate_archive_stem(resume_path: Option<&Path>, config: &Config) -> String {
+    if !config.resume {
+        return pesto::article::obfuscated_name();
+    }
+    let Some(rp) = resume_path else {
+        return pesto::article::obfuscated_name();
+    };
+    let fingerprint = pesto::resume::RunFingerprint {
+        article_size: config.article_size as u64,
+        obfuscate: config.obfuscate,
+        compress_format: config.compress_format.clone(),
+        par2_percent: config.par2,
+    };
+    let mut state = pesto::resume::ResumeState::load(rp).unwrap_or_default();
+    // Normalizes the loaded state first: a fingerprint mismatch clears any
+    // stale archive_stem (and segments/files) before we look at it, so an
+    // incompatible prior run's name is never reused.
+    state.validate_run(&fingerprint);
+    if let Some(stem) = state.archive_stem() {
+        return stem.to_string();
+    }
+    let stem = pesto::article::obfuscated_name();
+    state.set_archive_stem(stem.clone());
+    let _ = state.save(rp);
+    stem
+}
+
+/// The posting flags that `resume::RunFingerprint` actually checks,
+/// formatted for a copy-pasteable `--resume` retry command. A retry using
+/// different values for any of these gets its resume state silently (and
+/// safely) discarded by `validate_run` — printing them explicitly means a
+/// copy-pasted retry command actually resumes instead of quietly re-posting
+/// everything from scratch. Closes the gap issue #18 called out: "the
+/// printed resume hint only suggests `pesto <file> --resume` and drops the
+/// original flags".
+fn resume_flags_string(config: &Config) -> String {
+    let obfuscate = match config.obfuscate {
+        ObfuscateMode::None => "none",
+        ObfuscateMode::Full => "full",
+        ObfuscateMode::FullShared => "full-shared",
+        ObfuscateMode::Paranoid => "paranoid",
+    };
+    let mut flags = format!(
+        "--article-size {} --obfuscate={obfuscate} --par2 {}",
+        config.article_size, config.par2
+    );
+    if let Some(fmt) = &config.compress_format {
+        flags.push_str(&format!(" --compress={fmt}"));
+    }
+    flags
+}
+
 /// Recursively sum bytes for a path that may be a file or a directory.
 fn dir_or_file_size(path: &Path) -> u64 {
     match std::fs::metadata(path) {
@@ -2926,7 +3058,133 @@ fn expand_tilde(path: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pesto::config::{FileConfig, Overrides};
     use pesto::walk::InputFile;
+
+    fn test_config(
+        article_size: usize,
+        obfuscate: ObfuscateMode,
+        compress_format: Option<&str>,
+        par2: u8,
+    ) -> Config {
+        let mut file = FileConfig::default();
+        file.server.host = Some("news.example.com".into());
+        file.posting.groups = Some(vec!["alt.test".into()]);
+        Config::resolve(
+            file,
+            Overrides {
+                article_size: Some(article_size),
+                obfuscate: Some(obfuscate),
+                compress_format: compress_format.map(str::to_string),
+                par2: Some(par2),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn resume_flags_string_includes_every_fingerprinted_flag() {
+        let config = test_config(384_000, ObfuscateMode::Full, None, 10);
+        assert_eq!(
+            resume_flags_string(&config),
+            "--article-size 384000 --obfuscate=full --par2 10"
+        );
+    }
+
+    #[test]
+    fn resume_flags_string_includes_compress_only_when_set() {
+        let none_compressed = test_config(768_000, ObfuscateMode::None, None, 0);
+        assert!(!resume_flags_string(&none_compressed).contains("--compress"));
+
+        let compressed = test_config(768_000, ObfuscateMode::FullShared, Some("7z"), 5);
+        assert_eq!(
+            resume_flags_string(&compressed),
+            "--article-size 768000 --obfuscate=full-shared --par2 5 --compress=7z"
+        );
+    }
+
+    // ── reuse_or_generate_archive_stem ─────────────────────────────────────
+
+    #[test]
+    fn archive_stem_without_resume_is_always_fresh_and_untracked() {
+        let mut config = test_config(768_000, ObfuscateMode::Full, Some("7z"), 0);
+        config.resume = false;
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("release.pesto-state");
+
+        let a = reuse_or_generate_archive_stem(Some(&state_path), &config);
+        let b = reuse_or_generate_archive_stem(Some(&state_path), &config);
+
+        assert_ne!(
+            a, b,
+            "without --resume, every call must generate a fresh name"
+        );
+        assert!(
+            !state_path.exists(),
+            "without --resume, nothing should be written to disk"
+        );
+    }
+
+    #[test]
+    fn archive_stem_without_a_resume_path_is_fresh() {
+        let mut config = test_config(768_000, ObfuscateMode::Full, Some("7z"), 0);
+        config.resume = true;
+        let a = reuse_or_generate_archive_stem(None, &config);
+        let b = reuse_or_generate_archive_stem(None, &config);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn archive_stem_is_generated_and_recorded_on_first_resume_run() {
+        let mut config = test_config(768_000, ObfuscateMode::Full, Some("7z"), 0);
+        config.resume = true;
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("release.pesto-state");
+
+        let stem = reuse_or_generate_archive_stem(Some(&state_path), &config);
+
+        let state = pesto::resume::ResumeState::load(&state_path).unwrap();
+        assert_eq!(state.archive_stem(), Some(stem.as_str()));
+    }
+
+    #[test]
+    fn archive_stem_is_reused_on_a_compatible_resume_run() {
+        let mut config = test_config(768_000, ObfuscateMode::Full, Some("7z"), 0);
+        config.resume = true;
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("release.pesto-state");
+
+        let first = reuse_or_generate_archive_stem(Some(&state_path), &config);
+        let second = reuse_or_generate_archive_stem(Some(&state_path), &config);
+
+        assert_eq!(
+            first, second,
+            "a compatible resume run must reuse the same stem"
+        );
+    }
+
+    #[test]
+    fn archive_stem_is_regenerated_when_posting_parameters_changed() {
+        let mut config = test_config(768_000, ObfuscateMode::Full, Some("7z"), 0);
+        config.resume = true;
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("release.pesto-state");
+
+        let first = reuse_or_generate_archive_stem(Some(&state_path), &config);
+
+        // A later run using a different --article-size: the old stem
+        // (recorded under a now-mismatched fingerprint) must not be reused.
+        config.article_size = 384_000;
+        let second = reuse_or_generate_archive_stem(Some(&state_path), &config);
+
+        assert_ne!(
+            first, second,
+            "a fingerprint mismatch must not reuse the old stem"
+        );
+        let state = pesto::resume::ResumeState::load(&state_path).unwrap();
+        assert_eq!(state.archive_stem(), Some(second.as_str()));
+    }
 
     fn inputs(names: &[&str]) -> Vec<InputFile> {
         names

--- a/crates/pesto/src/config/parse.rs
+++ b/crates/pesto/src/config/parse.rs
@@ -330,6 +330,14 @@ impl Config {
                 .allow_incomplete_nzb
                 .or(file.posting.allow_incomplete_nzb)
                 .unwrap_or(false),
+            check_recover_percent: cli
+                .check_recover_percent
+                .or(file.posting.check_recover_percent)
+                .unwrap_or(15),
+            check_recover_max: cli
+                .check_recover_max
+                .or(file.posting.check_recover_max)
+                .unwrap_or(50),
             // 0 = adaptive; any positive value is the explicit fixed depth.
             pipeline_depth: cli
                 .pipeline_depth

--- a/crates/pesto/src/config/types.rs
+++ b/crates/pesto/src/config/types.rs
@@ -179,6 +179,19 @@ pub struct PostingSection {
     /// `check_post_retries` round. Default: false — pesto refuses to write
     /// an NZB that references content it never confirmed is retrievable.
     pub allow_incomplete_nzb: Option<bool>,
+    /// Above this percentage of the release's total segments, a final
+    /// recovery pass (see `check_recover_max`) is skipped even if the
+    /// absolute count would otherwise qualify — a large fraction missing
+    /// looks like a systemic problem, not a handful of unlucky articles.
+    /// Default: 15.
+    pub check_recover_percent: Option<u8>,
+    /// After every `check_post_retries` round is exhausted, if the number of
+    /// still-missing articles is at or below this count (and within
+    /// `check_recover_percent` of the release), pesto makes one more
+    /// dedicated repost-and-verify attempt for just those articles before
+    /// giving up — cheap enough in practice to be worth doing automatically,
+    /// without requiring a separate `--resume` run. Default: 50.
+    pub check_recover_max: Option<usize>,
     /// Number of articles to send per connection before reading responses.
     /// Values > 1 enable NNTP pipelining, which cuts per-article RTT cost.
     /// Default: 1.
@@ -359,6 +372,8 @@ pub struct Overrides {
     pub check_connections: Option<usize>,
     pub check_post_retries: Option<u32>,
     pub allow_incomplete_nzb: Option<bool>,
+    pub check_recover_percent: Option<u8>,
+    pub check_recover_max: Option<usize>,
     pub pipeline_depth: Option<usize>,
 }
 
@@ -438,6 +453,8 @@ pub struct Config {
     pub check_connections: usize,
     pub check_post_retries: u32,
     pub allow_incomplete_nzb: bool,
+    pub check_recover_percent: u8,
+    pub check_recover_max: usize,
     pub pipeline_depth: usize,
     /// Keepalive interval in seconds; 0 = disabled. See [`DEFAULT_KEEPALIVE_SECS`].
     pub keepalive_interval: u64,

--- a/crates/pesto/src/lib.rs
+++ b/crates/pesto/src/lib.rs
@@ -39,6 +39,7 @@ pub use parmesan as par2;
 pub mod poster;
 pub mod progress;
 pub mod resume;
+pub mod spool;
 pub mod ui;
 pub mod update;
 pub mod upload;

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -22,7 +22,7 @@
 //! answered by flooding an already-struggling server with reposts.
 
 use std::cmp::Ordering as CmpOrdering;
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashMap};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -646,6 +646,73 @@ async fn repost_one(
         }
     }
     Err(last_err)
+}
+
+/// One extra, bounded recovery attempt for articles that are still missing
+/// after every `check_post_retries` round already ran out — the caller (see
+/// `poster::maybe_recover_missing`) has already decided this batch is small
+/// enough to be worth it. Unlike the streaming coordinator's normal flow,
+/// every item here is already *known* to be missing (that's how it ended up
+/// here), so this skips straight to [`repost_one`] instead of re-running the
+/// patient STAT-retry sequence first, then verifies once via a single STAT
+/// after `check_delay_secs` — one round trip per article, not the full
+/// `check_retries`-attempt cycle.
+///
+/// Returns the subset of `segments` that got reposted *and* confirmed
+/// present; anything not in the returned list is still genuinely missing.
+pub(crate) async fn recover_missing(
+    config: &Config,
+    groups: &[String],
+    segments: Vec<PostedSegment>,
+    events: Option<&ProgressSender>,
+) -> Vec<PostedSegment> {
+    if segments.is_empty() {
+        return Vec::new();
+    }
+
+    let servers: Arc<Vec<_>> = Arc::new(config.all_servers().collect());
+    // One connection per distinct server actually referenced, reused across
+    // the whole batch instead of reconnecting per article.
+    let mut slots: HashMap<usize, ConnectionSlot> = HashMap::new();
+    let mut recovered = Vec::with_capacity(segments.len());
+
+    for seg in segments {
+        let idx = seg.server_idx.min(servers.len().saturating_sub(1));
+        let slot = slots
+            .entry(idx)
+            .or_insert_with(|| ConnectionSlot::new(Arc::clone(&servers), idx));
+
+        let new_seg = match repost_one(config, slot, &seg, groups).await {
+            Ok(new_seg) => new_seg,
+            Err(e) => {
+                warn!(id = %seg.message_id, error = %e, "check: final recovery repost failed");
+                continue;
+            }
+        };
+
+        tokio::time::sleep(Duration::from_secs(config.check_delay_secs)).await;
+
+        let confirmed = match slot.ensure_connected().await {
+            Ok(conn) => conn.stat(&new_seg.message_id).await.unwrap_or(false),
+            Err(_) => false,
+        };
+
+        if confirmed {
+            if let Some(tx) = events {
+                let _ = tx.send(ProgressEvent::Status {
+                    text: format!(
+                        "check: recovered {} on final pass ({}/{})",
+                        new_seg.message_id, new_seg.part, new_seg.total
+                    ),
+                });
+            }
+            recovered.push(new_seg);
+        } else {
+            warn!(id = %new_seg.message_id, "check: recovery repost accepted but not confirmed on final STAT");
+        }
+    }
+
+    recovered
 }
 
 #[cfg(test)]

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -342,10 +342,20 @@ struct Shared {
     /// Progress channel; `None` keeps the poster silent (library default).
     events: Option<ProgressSender>,
     cancelled: Arc<AtomicBool>,
-    /// Resume state shared among workers. `None` when resume is disabled.
+    /// Resume state shared among workers. `Some` whenever a resume-state
+    /// path was given and this isn't a dry run/`--par2-only` — tracked
+    /// unconditionally, regardless of `--resume` (see `validate_run`'s call
+    /// site), so an incomplete run always has something to persist.
     resume: Option<Arc<Mutex<ResumeState>>>,
-    /// Path of the resume state file; `None` when resume is disabled.
+    /// Path of the resume state file; `None` when resume tracking is disabled
+    /// (dry run / `--par2-only`).
     resume_path: Option<PathBuf>,
+    /// Directory for the type-1 spool (cached encoded articles) — `Some`
+    /// only when `config.resume` is explicitly set, unlike `resume` itself:
+    /// spooling writes real article bytes to disk on the posting hot path,
+    /// a cost a plain run must never pay just because a resume-state path
+    /// happened to be available. See `crate::spool`.
+    spool_dir: Option<PathBuf>,
     /// Reusable article byte buffers (Phase 12b). Workers return their buffer
     /// here after encoding so the producer and reader tasks can reuse it
     /// instead of allocating a fresh `Vec<u8>` for every article.
@@ -418,8 +428,12 @@ pub async fn post_files(config: &Config, files: &[InputFile]) -> Result<PostOutc
 /// Post every file in `files`, emitting [`ProgressEvent`]s on `events`.
 ///
 /// `resume_state_path` is the path of the `.pesto-state` sidecar file.
-/// When `config.resume` is `true` and the path is `Some`, already-posted
-/// segments are skipped and the state is updated after each successful post.
+/// Progress is tracked in memory whenever this path is given, regardless of
+/// `config.resume` — that flag only controls whether a *prior* run's
+/// on-disk state at this path is loaded and used to skip already-posted
+/// segments. At the end of the run, the state is written to disk once if
+/// the run ended incomplete (so a later `--resume` has something to load),
+/// or deleted if it ended complete (nothing left to resume).
 ///
 /// Passing `None` for `events` keeps the poster silent (library default).
 pub async fn post_files_with_progress(
@@ -448,11 +462,93 @@ pub async fn post_files_with_progress_and_cancel(
 ) -> Result<PostOutcome> {
     configure_rayon(config.threads);
 
+    // Resume state is tracked in memory for *every* run that could plausibly
+    // need it (not gated behind --resume), so a run that ends incomplete
+    // always has something to persist for a later retry — without
+    // `--resume`, deciding you need it only happens *after* a failure, which
+    // is too late if nothing was ever recorded (see issue #18). Only
+    // *loading* a prior run's on-disk state (to skip already-posted
+    // segments) stays gated behind --resume: silently trusting whatever
+    // `.pesto-state` file happens to already sit next to the target, without
+    // being asked to, is exactly the "stale state reused blindly" hazard
+    // issue #18 warns about.
+    let (resume_arc, resume_path_owned) = if !config.dry_run && !config.par2_only {
+        if let Some(rp) = resume_state_path {
+            let state = if config.resume {
+                ResumeState::load(rp)?
+            } else {
+                ResumeState::default()
+            };
+            (Some(Arc::new(Mutex::new(state))), Some(rp.to_path_buf()))
+        } else {
+            (None, None)
+        }
+    } else {
+        (None, None)
+    };
+
+    // Type-1 spool: only when --resume was actually passed (see the field
+    // doc on `Shared::spool_dir` for why this is a stricter condition than
+    // `resume_arc` itself).
+    let spool_dir_owned = if config.resume {
+        resume_path_owned.as_deref().map(crate::spool::spool_dir)
+    } else {
+        None
+    };
+
+    // Posting parameters that change how the whole input is chunked or
+    // named — compared against whatever fingerprint a loaded state was
+    // recorded under. A mismatch (e.g. this run's --article-size differs
+    // from the run that originally populated the state) means every
+    // recorded Message-ID could reference the wrong byte range, so the
+    // *entire* state is discarded rather than trusted partially — see
+    // `resume::RunFingerprint` and GitHub issue #18.
+    let run_fingerprint = crate::resume::RunFingerprint {
+        article_size: config.article_size as u64,
+        obfuscate: config.obfuscate,
+        compress_format: config.compress_format.clone(),
+        par2_percent: config.par2,
+    };
+    if let Some(resume) = &resume_arc {
+        let mut state = resume.lock().unwrap();
+        let had_segments = !state.is_empty();
+        if !state.validate_run(&run_fingerprint) {
+            eprintln!(
+                "resume: posting parameters changed since the saved state was recorded \
+                 (--article-size/--obfuscate/--compress/--par2) — ignoring it and starting fresh"
+            );
+        } else if had_segments {
+            eprintln!(
+                "resuming: {} segment(s) already posted, skipping",
+                state.len()
+            );
+        }
+    }
+
     // Generated once per run (not per file) so every file posted under
     // `FullShared` — archive parts and PAR2 volumes alike — shares the same
     // wire name prefix and sender identity. See `ObfuscateMode::FullShared`.
+    // Randomly generated fresh by default, which would otherwise make a
+    // `--resume` run's segments unmatchable against a prior run's (its
+    // wire identity, though not the resume key itself, would differ) — a
+    // compatible prior state (see `validate_run` above) reuses the same
+    // identity instead of generating a new one; see issue #18's resume
+    // follow-up discussion.
     let (release_prefix, release_from) = if config.obfuscate == ObfuscateMode::FullShared {
-        (Some(obfuscated_name()), Some(random_from()))
+        let reused = resume_arc.as_ref().and_then(|r| {
+            r.lock()
+                .unwrap()
+                .release_identity()
+                .map(|(p, f)| (p.to_string(), f.to_string()))
+        });
+        let (prefix, from) = reused.unwrap_or_else(|| (obfuscated_name(), random_from()));
+        if let Some(resume) = &resume_arc {
+            resume
+                .lock()
+                .unwrap()
+                .set_release_identity(prefix.clone(), from.clone());
+        }
+        (Some(prefix), Some(from))
     } else {
         (None, None)
     };
@@ -470,6 +566,43 @@ pub async fn post_files_with_progress_and_cancel(
         // `season01/ep01.mkv` for files found inside a directory argument.
         let real_name = input.name.clone();
         let size = md.len();
+
+        if let Some(resume) = &resume_arc {
+            let mtime = md
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs());
+            let file_fp = crate::resume::FileFingerprint { size, mtime };
+            let mut state = resume.lock().unwrap();
+            if !state.file_matches(&real_name, &file_fp) {
+                if config.par2 > 0 {
+                    // PAR2 recovery blocks are computed over the whole
+                    // recovery set together, not per file — one file's
+                    // content changing invalidates every volume's segments
+                    // too, not just this file's own (see
+                    // `forget_all_segments`'s doc comment). PAR2 volumes
+                    // never go through this per-file check themselves
+                    // (they're generated later, straight into the posting
+                    // queue — see `push_par2_file`), so this is the only
+                    // place that can catch it.
+                    eprintln!(
+                        "resume: `{real_name}` changed size or modification time since the \
+                         saved state was recorded — ignoring all saved segments, including \
+                         PAR2 volumes, since recovery data no longer matches this file"
+                    );
+                    state.forget_all_segments();
+                } else {
+                    eprintln!(
+                        "resume: `{real_name}` changed size or modification time since the \
+                         saved state was recorded — ignoring its saved segments and \
+                         re-posting it"
+                    );
+                    state.forget_file(&real_name);
+                }
+            }
+            state.record_file(&real_name, file_fp);
+        }
         let (subject_name, yenc_name, from) = match config.obfuscate {
             ObfuscateMode::None => {
                 let wn = wire_name(&real_name).to_string();
@@ -573,24 +706,6 @@ pub async fn post_files_with_progress_and_cancel(
         "connection pool"
     );
 
-    // Load resume state when enabled and a state path is provided.
-    let (resume_arc, resume_path_owned) = if config.resume && !config.dry_run && !config.par2_only {
-        if let Some(rp) = resume_state_path {
-            let state = ResumeState::load(rp)?;
-            if !state.is_empty() {
-                eprintln!(
-                    "resuming: {} segment(s) already posted, skipping",
-                    state.len()
-                );
-            }
-            (Some(Arc::new(Mutex::new(state))), Some(rp.to_path_buf()))
-        } else {
-            (None, None)
-        }
-    } else {
-        (None, None)
-    };
-
     // Pre-seed the buffer pool with enough buffers to keep all workers and the
     // double-buffer reader supplied without allocating during the hot path.
     let pool_size = worker_count + 4;
@@ -616,6 +731,7 @@ pub async fn post_files_with_progress_and_cancel(
         cancelled: Arc::new(AtomicBool::new(false)),
         resume: resume_arc,
         resume_path: resume_path_owned,
+        spool_dir: spool_dir_owned,
         pool: Arc::new(Mutex::new(initial_pool)),
         total_retries: std::sync::atomic::AtomicUsize::new(0),
         post_group: pick_post_group(&config.groups),
@@ -836,11 +952,132 @@ pub async fn post_files_with_progress_and_cancel(
     // removing `par2_temp_dir()` once it's truly done with the run (see
     // `run_single_upload` / `run_upload`).
     drop(check_tx);
-    let still_missing = if let Some(coordinator) = check_coordinator {
+    let mut still_missing = if let Some(coordinator) = check_coordinator {
         coordinator.finish_and_drain().await
     } else {
         Vec::new()
     };
+
+    // One more, bounded automatic recovery attempt for a small stubborn
+    // tail. The common real-world case this targets: posting finished, the
+    // streaming check failed to confirm a handful of articles even after
+    // every `check_post_retries` round, and the NZB is about to be refused.
+    // Reposting those few articles right here — still in this same process,
+    // with the source files still on disk — is strictly cheaper and simpler
+    // than requiring the user to notice the failure and rerun with
+    // `--resume` by hand. Only kicks in when the leftover count is small
+    // enough (`check_recover_percent`/`check_recover_max`) to still count as
+    // "cheap": a release with a large fraction missing looks like a
+    // systemic server problem, not a handful of unlucky articles, and
+    // retrying that automatically would just hammer an already-struggling
+    // server.
+    if !still_missing.is_empty() && !cancelled {
+        let total = shared.results.lock().unwrap().len();
+        if is_cheap_to_recover(still_missing.len(), total, config) {
+            let candidates: Vec<PostedSegment> = {
+                let results = shared.results.lock().unwrap();
+                results
+                    .iter()
+                    .filter(|s| still_missing.contains(&s.message_id))
+                    .cloned()
+                    .collect()
+            };
+            shared.emit(ProgressEvent::Status {
+                text: format!(
+                    "check: {} article(s) still missing after every round; \
+                     attempting one more automatic recovery pass",
+                    candidates.len()
+                ),
+            });
+            // `recover_missing` returns *fresh* Message-IDs (every repost
+            // gets a new one — see `repost_one`), so its output can never be
+            // matched directly against `still_missing`'s old ids. Snapshot
+            // old-id -> (file_name, part) identity before the candidates are
+            // moved into the call, so the retain below can match by that
+            // identity instead.
+            let old_identity: std::collections::HashMap<String, (String, u32)> = candidates
+                .iter()
+                .map(|c| (c.message_id.clone(), (c.file_name.clone(), c.part)))
+                .collect();
+            let recovered = check::recover_missing(
+                config,
+                &shared.post_group,
+                candidates,
+                shared.events.as_ref(),
+            )
+            .await;
+            for seg in &recovered {
+                let mut results = shared.results.lock().unwrap();
+                if let Some(existing) = results
+                    .iter_mut()
+                    .find(|s| s.file_name == seg.file_name && s.part == seg.part)
+                {
+                    *existing = seg.clone();
+                }
+            }
+            let recovered_keys: std::collections::HashSet<(String, u32)> = recovered
+                .iter()
+                .map(|s| (s.file_name.clone(), s.part))
+                .collect();
+            still_missing.retain(|id| {
+                !old_identity
+                    .get(id)
+                    .is_some_and(|key| recovered_keys.contains(key))
+            });
+        }
+    }
+
+    // Whatever is left in `still_missing` at this point is confirmed bad:
+    // the original POST got a `240`, but every STAT check and every repost
+    // attempt (both the normal `check_post_retries` rounds and the recovery
+    // pass above) failed to make the article retrievable. Its recorded
+    // Message-ID must be forgotten now — otherwise a later `--resume` would
+    // trust that known-bad ID and silently skip re-posting the segment,
+    // producing an NZB that looks complete but references an article that
+    // was never actually confirmed present.
+    if let Some(resume) = &shared.resume {
+        if !still_missing.is_empty() {
+            let results = shared.results.lock().unwrap();
+            let mut state = resume.lock().unwrap();
+            for id in &still_missing {
+                if let Some(seg) = results.iter().find(|s| &s.message_id == id) {
+                    state.remove(&seg.file_name, seg.part);
+                    // No spool cleanup needed here: a segment can only reach
+                    // `still_missing` after already being confirmed posted
+                    // once (`commit_result`'s `posted: true` branch), and
+                    // that branch already removes its spool entry — before
+                    // the check coordinator that could ever mark it missing
+                    // even sees it. See `crate::spool`.
+                }
+            }
+        }
+    }
+
+    // Single, final resume-state persistence decision, replacing the old
+    // per-segment write in `commit_result`. Mirrors the completeness check
+    // `run_single_upload` uses to decide whether the NZB itself gets
+    // written: a run cancellation makes `still_missing` meaningless (the
+    // check simply didn't get to finish verifying everything, not a
+    // confirmed gap), and `allow_incomplete_nzb` means the user has already
+    // accepted the remaining gap and is relying on PAR2, not `--resume`, to
+    // fill it. Whenever the run is *not* complete by those terms, persist
+    // once so a later `--resume` has something to load; otherwise delete
+    // any state file (freshly written or left over from an earlier failed
+    // attempt at the same output path) — there is nothing left to resume.
+    if let (Some(resume), Some(rp)) = (&shared.resume, &shared.resume_path) {
+        let has_post_failures = !failed_tasks.is_empty();
+        let has_confirmed_missing = !cancelled && !still_missing.is_empty();
+        let incomplete =
+            has_post_failures || (has_confirmed_missing && !config.allow_incomplete_nzb);
+        if incomplete {
+            let _ = resume.lock().unwrap().save(rp);
+        } else {
+            let _ = std::fs::remove_file(rp);
+            if let Some(dir) = &shared.spool_dir {
+                crate::spool::remove_all(dir);
+            }
+        }
+    }
 
     shared.emit(ProgressEvent::Finished);
 
@@ -1967,12 +2204,12 @@ async fn worker(
             });
 
             if let Some(resume) = &shared.resume {
-                if let Some(existing_id) = resume
+                let existing = resume
                     .lock()
                     .unwrap()
                     .get(&task.meta.real_name, task.part)
-                    .map(str::to_string)
-                {
+                    .cloned();
+                if let Some(existing) = existing {
                     shared.results.lock().unwrap().push(PostedSegment {
                         file_name: task.meta.real_name.clone(),
                         file_path: task.meta.path.clone(),
@@ -1980,8 +2217,8 @@ async fn worker(
                         file_size: task.meta.size,
                         part: task.part,
                         total: task.total,
-                        message_id: existing_id,
-                        bytes: 0,
+                        message_id: existing.message_id,
+                        bytes: existing.bytes,
                         from: task.from.clone(),
                         date: task.date.clone(),
                         full_crc32: task.file_crc32.unwrap_or(0),
@@ -1989,46 +2226,94 @@ async fn worker(
                         // into the check queue this run — see the field doc.
                         server_idx: 0,
                     });
-                    let bytes = task.data.len() as u64;
+                    let raw_bytes = task.data.len() as u64;
                     shared.release_buffer(task.data);
                     shared.emit(ProgressEvent::SegmentDone {
                         file: task.meta.real_name.clone(),
-                        bytes,
+                        bytes: raw_bytes,
                         ok: true,
                     });
                     continue;
                 }
             }
 
-            let t_enc = Instant::now();
-            let file_crc32 = task.file_crc32;
-            let encoded = yenc::encode_part(
-                &task.meta.yenc_name,
-                task.meta.size,
-                yenc::PartSpec {
+            // Type-1 spool: this exact segment may already have reached the
+            // server on a prior interrupted attempt whose `240`
+            // acknowledgement was lost (e.g. the connection dropped between
+            // sending the article and reading the response) — an ambiguity
+            // the resume state above can't resolve, since it only records a
+            // segment once the response actually came back. Replaying the
+            // identical bytes under the identical Message-ID lets the
+            // server's own dedup (`435 Already exists`) settle it, instead
+            // of silently re-encoding and posting under a fresh ID, which
+            // risks a duplicate article if the original POST had in fact
+            // succeeded. See `crate::spool`.
+            let spooled = shared
+                .spool_dir
+                .as_ref()
+                .and_then(|dir| crate::spool::read(dir, &task.meta.real_name, task.part));
+
+            let (message_id, headers, encoded, encode_time) = if let Some(spooled) = spooled {
+                let encoded = yenc::EncodedPart {
                     number: task.part,
                     total: task.total,
-                    offset: task.offset,
-                },
-                &task.data,
-                shared.config.line_length,
-                file_crc32,
-            );
-            let encode_time = t_enc.elapsed();
-            let message_id = generate_message_id(shared.config.message_id_domain.as_deref());
-            let (rfc_date, _ts) = &task.date;
-            if let Some(d) = &rfc_date {
-                debug!(segment = %message_id, date = %d, "article date");
-            }
-            let article = Article {
-                message_id: message_id.clone(),
-                from: task.from.clone(),
-                newsgroups: shared.post_group.clone(),
-                subject: default_subject(&task.meta.subject_name, task.part, task.total),
-                date: rfc_date.clone(),
-                no_archive: shared.config.no_archive,
+                    begin: 0,
+                    end: 0,
+                    crc32: 0,
+                    body: spooled.body,
+                };
+                (spooled.message_id, spooled.headers, encoded, Duration::ZERO)
+            } else {
+                let t_enc = Instant::now();
+                let file_crc32 = task.file_crc32;
+                let encoded = yenc::encode_part(
+                    &task.meta.yenc_name,
+                    task.meta.size,
+                    yenc::PartSpec {
+                        number: task.part,
+                        total: task.total,
+                        offset: task.offset,
+                    },
+                    &task.data,
+                    shared.config.line_length,
+                    file_crc32,
+                );
+                let encode_time = t_enc.elapsed();
+                let message_id = generate_message_id(shared.config.message_id_domain.as_deref());
+                let (rfc_date, _ts) = &task.date;
+                if let Some(d) = &rfc_date {
+                    debug!(segment = %message_id, date = %d, "article date");
+                }
+                let article = Article {
+                    message_id: message_id.clone(),
+                    from: task.from.clone(),
+                    newsgroups: shared.post_group.clone(),
+                    subject: default_subject(&task.meta.subject_name, task.part, task.total),
+                    date: rfc_date.clone(),
+                    no_archive: shared.config.no_archive,
+                };
+                let headers = article.build_headers();
+
+                // Cache the encoded article before it goes over the wire.
+                // Best-effort: a spool write failing must never abort an
+                // otherwise successful post.
+                if let Some(dir) = &shared.spool_dir {
+                    if let Err(e) = crate::spool::write(
+                        dir,
+                        &task.meta.real_name,
+                        task.part,
+                        &message_id,
+                        &headers,
+                        &encoded.body,
+                    )
+                    .await
+                    {
+                        warn!(error = %e, "resume: failed to write spool entry; continuing without it");
+                    }
+                }
+
+                (message_id, headers, encoded, encode_time)
             };
-            let headers = article.build_headers();
             let task_date = task.date.clone();
             pending.push(Pending {
                 task,
@@ -2418,11 +2703,27 @@ fn commit_result(
 ) {
     if posted {
         if let Some(resume) = &shared.resume {
-            let mut state = resume.lock().unwrap();
-            state.record(&task.meta.real_name, task.part, &message_id);
-            if let Some(rp) = &shared.resume_path {
-                let _ = state.save(rp);
-            }
+            // In-memory only — no disk write here. Every commit used to
+            // rewrite the entire state file while holding this lock, which
+            // serialized all workers through one lock and turned state
+            // tracking into an O(n^2) hot-path cost on large uploads. Now
+            // that resume state is tracked unconditionally (not just when
+            // --resume is passed), persisting had to move off this path
+            // regardless — the whole point of resume is to survive the *end*
+            // of a run being incomplete, not every individual segment, so a
+            // single persist decided by the final outcome (see the
+            // still_missing handling and `run_single_upload`'s cleanup)
+            // covers the same guarantee at a fraction of the cost.
+            resume.lock().unwrap().record(
+                &task.meta.real_name,
+                task.part,
+                &message_id,
+                wire_bytes as u64,
+            );
+        }
+        // Confirmed posted — any spooled copy has served its purpose.
+        if let Some(dir) = &shared.spool_dir {
+            crate::spool::remove(dir, &task.meta.real_name, task.part);
         }
         let seg = PostedSegment {
             file_name: task.meta.real_name.clone(),
@@ -2467,6 +2768,25 @@ fn jittered(base: Duration, slot_id: usize) -> Duration {
     let noise = (ns.wrapping_add(slot_id as u64 * 2_654_435_761) % 1000) as u32;
     let extra_ms = (base.as_millis() as u64 * noise as u64 / 2000) as u32;
     base + Duration::from_millis(extra_ms as u64)
+}
+
+/// Whether an automatic final recovery pass (see `check::recover_missing`)
+/// is worth attempting for `missing` still-unconfirmed articles out of
+/// `total` posted this run. Gated by *both* an absolute cap
+/// (`check_recover_max`) and a percentage of the release
+/// (`check_recover_percent`) — whichever is smaller wins, so behaviour
+/// scales sanely from a small release (where even a large fraction missing
+/// is only a handful of articles) to a huge one (where 15% could still be
+/// thousands of articles, no longer "cheap" to retry automatically).
+fn is_cheap_to_recover(missing: usize, total: usize, config: &Config) -> bool {
+    if missing == 0 || config.check_recover_max == 0 {
+        return false;
+    }
+    if missing > config.check_recover_max {
+        return false;
+    }
+    let percent_cap = (total as f64 * config.check_recover_percent as f64 / 100.0).ceil() as usize;
+    missing <= percent_cap.max(1)
 }
 
 /// Build the "→ ..." label shown in the live panel header and the `Started`
@@ -2987,6 +3307,50 @@ mod tests {
         .unwrap()
     }
 
+    // ── automatic recovery threshold (is_cheap_to_recover) ────────────────────
+
+    fn recover_config(check_recover_percent: u8, check_recover_max: usize) -> Config {
+        let mut config = dry_run_config();
+        config.check_recover_percent = check_recover_percent;
+        config.check_recover_max = check_recover_max;
+        config
+    }
+
+    #[test]
+    fn small_release_within_both_caps_is_cheap() {
+        let config = recover_config(15, 50);
+        // 3 missing out of 20 (15%) — right at the percent cap, under the max.
+        assert!(is_cheap_to_recover(3, 20, &config));
+    }
+
+    #[test]
+    fn huge_release_capped_by_absolute_max_even_under_percent() {
+        let config = recover_config(15, 50);
+        // 15% of 100,000 is 15,000 — nowhere near cheap, even though it's
+        // exactly the configured percentage.
+        assert!(!is_cheap_to_recover(15_000, 100_000, &config));
+    }
+
+    #[test]
+    fn small_absolute_count_rejected_when_it_is_most_of_the_release() {
+        let config = recover_config(15, 50);
+        // 5 missing out of 10 (50%) — small in absolute terms, but a large
+        // fraction of a tiny release looks systemic, not incidental.
+        assert!(!is_cheap_to_recover(5, 10, &config));
+    }
+
+    #[test]
+    fn zero_missing_is_never_worth_recovering() {
+        let config = recover_config(15, 50);
+        assert!(!is_cheap_to_recover(0, 1000, &config));
+    }
+
+    #[test]
+    fn max_zero_disables_recovery_entirely() {
+        let config = recover_config(100, 0);
+        assert!(!is_cheap_to_recover(1, 2, &config));
+    }
+
     // ── connection splitting (upload vs. streaming check) ─────────────────────
 
     #[test]
@@ -3246,6 +3610,7 @@ mod tests {
             cancelled: Arc::new(AtomicBool::new(false)),
             resume: None,
             resume_path: None,
+            spool_dir: None,
             pool: Arc::new(Mutex::new(Vec::new())),
             total_retries: std::sync::atomic::AtomicUsize::new(0),
             post_group,
@@ -3384,15 +3749,16 @@ mod tests {
     #[tokio::test]
     async fn dry_run_ignores_resume_state_by_design() {
         // Resume is explicitly disabled in dry_run mode (post_files_with_progress
-        // checks `config.resume && !config.dry_run`). Segments get fresh
-        // Message-IDs even when a state file with recorded entries is present.
+        // only creates resume state when `!config.dry_run && !config.par2_only`).
+        // Segments get fresh Message-IDs even when a state file with recorded
+        // entries is present.
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("r.bin");
         std::fs::write(&f, vec![0u8; 100]).unwrap();
 
         let state_path = dir.path().join("r.bin.pesto-state");
         let mut state = crate::resume::ResumeState::default();
-        state.record("r.bin", 1, "<stored-id@pesto>");
+        state.record("r.bin", 1, "<stored-id@pesto>", 100);
         state.save(&state_path).unwrap();
 
         let files = vec![InputFile {

--- a/crates/pesto/src/resume.rs
+++ b/crates/pesto/src/resume.rs
@@ -3,9 +3,18 @@
 //!
 //! State is stored as a JSON file (`.pesto-state`) beside the `.nzb` output.
 //! Each record maps a `(relative_file_name, part_number)` pair to the
-//! `Message-ID` that was issued when the segment was originally posted.
-//! On resume, workers skip segments present in the state and inject the stored
-//! `Message-ID` directly into the results, so the final `.nzb` is correct.
+//! `Message-ID` (and wire size) issued when the segment was originally
+//! posted. On resume, workers skip segments present in the state and inject
+//! the stored `Message-ID`/`bytes` directly into the results, so the final
+//! `.nzb` is correct.
+//!
+//! Trusting a state file blindly is unsafe (see GitHub issue #18): the same
+//! output name can be reused for an unrelated or edited file, or with
+//! different posting parameters (`--article-size`, `--obfuscate`,
+//! `--compress`, `--par2`) that change how the input is chunked and named.
+//! [`RunFingerprint`] and [`FileFingerprint`] guard against exactly that —
+//! a run-level mismatch discards the whole state, a per-file mismatch
+//! discards only that file's segments.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -13,11 +22,70 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::config::ObfuscateMode;
+
+/// Posting parameters that change how the *whole* input is chunked or named.
+/// Captured once per run and compared on `--resume`: any difference means
+/// every recorded Message-ID in the state could reference the wrong byte
+/// range or the wrong wire name, so the whole state is discarded rather than
+/// trusted partially.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunFingerprint {
+    pub article_size: u64,
+    pub obfuscate: ObfuscateMode,
+    pub compress_format: Option<String>,
+    pub par2_percent: u8,
+}
+
+/// A single file's identity at the time its segments were recorded. Compared
+/// on `--resume` to catch the same output name being reused for edited or
+/// unrelated content — a mismatch discards only this file's segments, not
+/// the whole state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileFingerprint {
+    pub size: u64,
+    /// Unix timestamp (seconds). `None` when the filesystem/platform can't
+    /// report an mtime — treated as "nothing to compare", not a mismatch.
+    pub mtime: Option<u64>,
+}
+
+/// One recorded segment: the `Message-ID` a prior run's `POST` was
+/// acknowledged under, and the wire size actually sent (headers + encoded
+/// body) — needed so a resumed segment can report its real size in the NZB
+/// instead of `0`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SegmentRecord {
+    pub message_id: String,
+    pub bytes: u64,
+}
+
 /// Persistent state for a single upload session.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ResumeState {
-    /// Key: `"{file_name}\0{part}"`. Value: the posted `Message-ID`.
-    segments: HashMap<String, String>,
+    /// Posting parameters this state was recorded under. `None` for a fresh
+    /// state (nothing recorded yet) or a state file written before this
+    /// field existed — in either case there is nothing to compare against
+    /// yet, so `validate_run` treats it as compatible and starts tracking.
+    fingerprint: Option<RunFingerprint>,
+    /// The obfuscated archive stem this release was compressed under, when
+    /// `--compress`+`--obfuscate` produced one. Randomly generated fresh on
+    /// every run by default — recorded here so a `--resume` run with a
+    /// matching fingerprint can reuse the *same* name instead of generating
+    /// a new one, which would otherwise make this file's segments
+    /// unresumable (the resume key is this very name). See issue #18's
+    /// resume follow-up discussion.
+    archive_stem: Option<String>,
+    /// The shared wire name prefix and sender identity every file in an
+    /// `ObfuscateMode::FullShared` run posts under — see
+    /// `ObfuscateMode::FullShared`. Randomly generated fresh on every run by
+    /// default; recorded here for the same reason as `archive_stem`, so a
+    /// `--resume` run reuses the same identity instead of a new one.
+    release_prefix: Option<String>,
+    release_from: Option<String>,
+    /// Per-file identity, keyed by `file_name`.
+    files: HashMap<String, FileFingerprint>,
+    /// Key: `"{file_name}\0{part}"`.
+    segments: HashMap<String, SegmentRecord>,
 }
 
 impl ResumeState {
@@ -44,17 +112,115 @@ impl ResumeState {
             .with_context(|| format!("writing resume state `{}`", path.display()))
     }
 
-    /// Return the stored `Message-ID` for a segment, if it was already posted.
-    pub fn get(&self, file_name: &str, part: u32) -> Option<&str> {
-        self.segments
-            .get(&Self::key(file_name, part))
-            .map(String::as_str)
+    /// Compare `current` against the fingerprint this state was last
+    /// recorded under. On a mismatch, every segment and per-file fingerprint
+    /// is discarded (the whole state can no longer be trusted — see the
+    /// module doc comment) and `false` is returned so the caller can warn
+    /// the user. On a match, or when this state has no fingerprint yet
+    /// (fresh state, or one written before this field existed), the
+    /// fingerprint is set to `current` and `true` is returned.
+    pub fn validate_run(&mut self, current: &RunFingerprint) -> bool {
+        if let Some(stored) = &self.fingerprint {
+            if stored != current {
+                self.segments.clear();
+                self.files.clear();
+                self.archive_stem = None;
+                self.release_prefix = None;
+                self.release_from = None;
+                self.fingerprint = Some(current.clone());
+                return false;
+            }
+        }
+        self.fingerprint = Some(current.clone());
+        true
+    }
+
+    /// The archive stem recorded for this state, if any — see the field doc.
+    pub fn archive_stem(&self) -> Option<&str> {
+        self.archive_stem.as_deref()
+    }
+
+    /// Record the archive stem this run decided on, for a future `--resume`
+    /// to reuse. Call only after `validate_run` so a mismatched fingerprint
+    /// has already cleared any stale value first.
+    pub fn set_archive_stem(&mut self, stem: String) {
+        self.archive_stem = Some(stem);
+    }
+
+    /// The `ObfuscateMode::FullShared` prefix/sender identity recorded for
+    /// this state, if any — see the field doc.
+    pub fn release_identity(&self) -> Option<(&str, &str)> {
+        Some((
+            self.release_prefix.as_deref()?,
+            self.release_from.as_deref()?,
+        ))
+    }
+
+    /// Record the `FullShared` prefix/sender identity this run decided on,
+    /// for a future `--resume` to reuse. Call only after `validate_run`.
+    pub fn set_release_identity(&mut self, prefix: String, from: String) {
+        self.release_prefix = Some(prefix);
+        self.release_from = Some(from);
+    }
+
+    /// Compare `current` against the fingerprint recorded for `file_name`,
+    /// if any. `None` recorded yet (a new file, or a state file written
+    /// before this field existed) is treated as compatible — there is
+    /// nothing to contradict. A concrete mismatch returns `false`.
+    pub fn file_matches(&self, file_name: &str, current: &FileFingerprint) -> bool {
+        match self.files.get(file_name) {
+            Some(stored) => stored == current,
+            None => true,
+        }
+    }
+
+    /// Record (or update) a file's fingerprint.
+    pub fn record_file(&mut self, file_name: &str, fp: FileFingerprint) {
+        self.files.insert(file_name.to_string(), fp);
+    }
+
+    /// Forget every segment recorded for `file_name` — used when
+    /// `file_matches` reports a mismatch, so stale segments for the old
+    /// content don't linger keyed under the same name.
+    pub fn forget_file(&mut self, file_name: &str) {
+        let prefix = format!("{file_name}\0");
+        self.segments.retain(|k, _| !k.starts_with(&prefix));
+    }
+
+    /// Forget every segment recorded for *every* file, including PAR2
+    /// volumes (which never go through `record_file`/`file_matches` at all
+    /// — see the call site). Used instead of `forget_file` when PAR2 is
+    /// active: PAR2 recovery blocks are computed over the *whole* recovery
+    /// set together, not per file, so one file's content changing
+    /// invalidates every recovery volume's segments too, not just that
+    /// file's own. Per-file fingerprints are kept so an unrelated,
+    /// unchanged file doesn't get re-flagged as new on the next check.
+    pub fn forget_all_segments(&mut self) {
+        self.segments.clear();
+    }
+
+    /// Return the stored record for a segment, if it was already posted.
+    pub fn get(&self, file_name: &str, part: u32) -> Option<&SegmentRecord> {
+        self.segments.get(&Self::key(file_name, part))
     }
 
     /// Record a successfully posted segment.
-    pub fn record(&mut self, file_name: &str, part: u32, message_id: &str) {
-        self.segments
-            .insert(Self::key(file_name, part), message_id.to_string());
+    pub fn record(&mut self, file_name: &str, part: u32, message_id: &str, bytes: u64) {
+        self.segments.insert(
+            Self::key(file_name, part),
+            SegmentRecord {
+                message_id: message_id.to_string(),
+                bytes,
+            },
+        );
+    }
+
+    /// Forget a segment — used when a POST that once succeeded is later
+    /// confirmed missing by the streaming check (and every repost/recovery
+    /// attempt for it also failed): the recorded Message-ID is known bad, so
+    /// a later `--resume` must not trust it and skip re-posting the segment.
+    pub fn remove(&mut self, file_name: &str, part: u32) {
+        self.segments.remove(&Self::key(file_name, part));
     }
 
     /// Number of segments recorded in this state.
@@ -71,14 +237,43 @@ impl ResumeState {
 mod tests {
     use super::*;
 
+    fn fp(article_size: u64) -> RunFingerprint {
+        RunFingerprint {
+            article_size,
+            obfuscate: ObfuscateMode::None,
+            compress_format: None,
+            par2_percent: 0,
+        }
+    }
+
     #[test]
     fn round_trip() {
         let mut s = ResumeState::default();
-        s.record("file.bin", 1, "abc@example.com");
-        s.record("file.bin", 2, "def@example.com");
-        assert_eq!(s.get("file.bin", 1), Some("abc@example.com"));
-        assert_eq!(s.get("file.bin", 3), None);
+        s.record("file.bin", 1, "abc@example.com", 100);
+        s.record("file.bin", 2, "def@example.com", 200);
+        assert_eq!(s.get("file.bin", 1).unwrap().message_id, "abc@example.com");
+        assert_eq!(s.get("file.bin", 1).unwrap().bytes, 100);
+        assert!(s.get("file.bin", 3).is_none());
         assert_eq!(s.len(), 2);
+    }
+
+    #[test]
+    fn remove_forgets_a_recorded_segment() {
+        let mut s = ResumeState::default();
+        s.record("file.bin", 1, "abc@example.com", 100);
+        s.record("file.bin", 2, "def@example.com", 200);
+        s.remove("file.bin", 1);
+        assert!(s.get("file.bin", 1).is_none());
+        assert_eq!(s.get("file.bin", 2).unwrap().message_id, "def@example.com");
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn remove_of_an_unrecorded_segment_is_a_no_op() {
+        let mut s = ResumeState::default();
+        s.record("file.bin", 1, "abc@example.com", 100);
+        s.remove("file.bin", 99);
+        assert_eq!(s.len(), 1);
     }
 
     #[test]
@@ -86,15 +281,157 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("state.json");
         let mut s = ResumeState::default();
-        s.record("a.bin", 1, "id1@x");
+        s.record("a.bin", 1, "id1@x", 100);
         s.save(&path).unwrap();
         let loaded = ResumeState::load(&path).unwrap();
-        assert_eq!(loaded.get("a.bin", 1), Some("id1@x"));
+        assert_eq!(loaded.get("a.bin", 1).unwrap().message_id, "id1@x");
+        assert_eq!(loaded.get("a.bin", 1).unwrap().bytes, 100);
     }
 
     #[test]
     fn missing_file_returns_empty() {
         let state = ResumeState::load(Path::new("/nonexistent/path.json")).unwrap();
         assert!(state.is_empty());
+    }
+
+    #[test]
+    fn fresh_state_accepts_any_fingerprint() {
+        let mut s = ResumeState::default();
+        assert!(s.validate_run(&fp(768_000)));
+    }
+
+    #[test]
+    fn matching_fingerprint_keeps_segments() {
+        let mut s = ResumeState::default();
+        assert!(s.validate_run(&fp(768_000)));
+        s.record("a.bin", 1, "id1@x", 100);
+        assert!(s.validate_run(&fp(768_000)));
+        assert_eq!(s.len(), 1, "matching fingerprint must not clear segments");
+    }
+
+    #[test]
+    fn mismatched_fingerprint_discards_everything() {
+        let mut s = ResumeState::default();
+        assert!(s.validate_run(&fp(768_000)));
+        s.record_file(
+            "a.bin",
+            FileFingerprint {
+                size: 10,
+                mtime: Some(1),
+            },
+        );
+        s.record("a.bin", 1, "id1@x", 100);
+        s.set_archive_stem("Xk3mQp".to_string());
+        // A resume run using a different --article-size than the original.
+        assert!(!s.validate_run(&fp(384_000)));
+        assert_eq!(s.len(), 0, "mismatched fingerprint must discard segments");
+        assert!(
+            s.file_matches(
+                "a.bin",
+                &FileFingerprint {
+                    size: 10,
+                    mtime: Some(1)
+                }
+            ),
+            "per-file fingerprints must be cleared too"
+        );
+        assert_eq!(
+            s.archive_stem(),
+            None,
+            "archive stem must be cleared too — reusing it for incompatible parameters is unsafe"
+        );
+    }
+
+    #[test]
+    fn archive_stem_survives_a_matching_fingerprint() {
+        let mut s = ResumeState::default();
+        assert!(s.validate_run(&fp(768_000)));
+        s.set_archive_stem("Xk3mQp".to_string());
+        assert!(s.validate_run(&fp(768_000)));
+        assert_eq!(s.archive_stem(), Some("Xk3mQp"));
+    }
+
+    #[test]
+    fn file_matches_is_permissive_when_nothing_was_recorded() {
+        let s = ResumeState::default();
+        assert!(s.file_matches(
+            "new.bin",
+            &FileFingerprint {
+                size: 5,
+                mtime: Some(1)
+            }
+        ));
+    }
+
+    #[test]
+    fn file_matches_detects_content_change() {
+        let mut s = ResumeState::default();
+        s.record_file(
+            "a.bin",
+            FileFingerprint {
+                size: 100,
+                mtime: Some(1000),
+            },
+        );
+        assert!(s.file_matches(
+            "a.bin",
+            &FileFingerprint {
+                size: 100,
+                mtime: Some(1000)
+            }
+        ));
+        assert!(!s.file_matches(
+            "a.bin",
+            &FileFingerprint {
+                size: 200,
+                mtime: Some(1000)
+            }
+        ));
+        assert!(!s.file_matches(
+            "a.bin",
+            &FileFingerprint {
+                size: 100,
+                mtime: Some(2000)
+            }
+        ));
+    }
+
+    #[test]
+    fn forget_file_only_removes_that_files_segments() {
+        let mut s = ResumeState::default();
+        s.record("a.bin", 1, "id1@x", 10);
+        s.record("a.bin", 2, "id2@x", 10);
+        s.record("b.bin", 1, "id3@x", 10);
+        s.forget_file("a.bin");
+        assert!(s.get("a.bin", 1).is_none());
+        assert!(s.get("a.bin", 2).is_none());
+        assert!(s.get("b.bin", 1).is_some());
+    }
+
+    #[test]
+    fn forget_all_segments_clears_everything_including_par2_volumes() {
+        let mut s = ResumeState::default();
+        s.record("movie.mkv", 1, "id1@x", 10);
+        s.record("movie.mkv.vol000+001.par2", 1, "id2@x", 10);
+        s.record_file(
+            "movie.mkv",
+            FileFingerprint {
+                size: 100,
+                mtime: Some(1),
+            },
+        );
+        s.forget_all_segments();
+        assert!(s.get("movie.mkv", 1).is_none());
+        assert!(s.get("movie.mkv.vol000+001.par2", 1).is_none());
+        assert_eq!(s.len(), 0);
+        // Per-file fingerprints survive — an unrelated file's identity is
+        // still worth remembering.
+        assert!(s.file_matches(
+            "movie.mkv",
+            &FileFingerprint {
+                size: 100,
+                mtime: Some(1)
+            }
+        ));
     }
 }

--- a/crates/pesto/src/spool.rs
+++ b/crates/pesto/src/spool.rs
@@ -1,0 +1,196 @@
+//! Type-1 resume spool: cache the fully-encoded article (headers + yEnc
+//! body, under the exact `Message-ID` it was sent with) for a segment right
+//! before it goes over the wire, so a `POST` whose `240` acknowledgement is
+//! lost to a dropped connection can be resumed by replaying the *exact same
+//! bytes under the exact same Message-ID* — instead of silently re-encoding
+//! and re-posting under a fresh one, which risks a duplicate article on the
+//! server if the original `POST` actually succeeded.
+//!
+//! This only closes the "maybe-posted, ack lost" ambiguity for whatever
+//! segment(s) were in flight at the moment of interruption — it does not
+//! remove the need to re-derive segments the run never reached at all (see
+//! `resume`'s module doc comment for the broader picture).
+//!
+//! Opt-in (only active when `config.resume` is set): every write here is a
+//! real disk write on the posting hot path, which a plain (non-resume) run
+//! must never pay for. See GitHub issue #18's resume follow-up discussion.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Directory holding spooled articles for one upload session — a sibling of
+/// the `.pesto-state` file (not nested inside it, since that path is a
+/// plain file), so both can be inspected or deleted independently.
+pub fn spool_dir(resume_path: &Path) -> PathBuf {
+    resume_path.with_extension("pesto-spool")
+}
+
+fn entry_path(dir: &Path, file_name: &str, part: u32) -> PathBuf {
+    // `file_name` is a relative path (e.g. `season01/ep01.mkv`) — replace
+    // separators so it collapses to a single valid path component instead
+    // of implying subdirectories that were never created.
+    let safe_name = file_name.replace(['/', '\\'], "_");
+    dir.join(format!("{safe_name}.{part}.spool"))
+}
+
+/// One spooled article, as read back for replay.
+pub struct SpooledArticle {
+    pub message_id: String,
+    pub headers: Vec<u8>,
+    pub body: Vec<u8>,
+}
+
+/// Persist a fully-encoded article to the spool, creating the directory on
+/// first use. Best-effort by design: a spool write failing (e.g. disk full)
+/// must never abort an otherwise-successful post — callers log and move on
+/// rather than propagate.
+pub async fn write(
+    dir: &Path,
+    file_name: &str,
+    part: u32,
+    message_id: &str,
+    headers: &[u8],
+    body: &[u8],
+) -> Result<()> {
+    tokio::fs::create_dir_all(dir)
+        .await
+        .with_context(|| format!("creating spool directory `{}`", dir.display()))?;
+    // Layout: [u32 LE id_len][id bytes][u32 LE headers_len][headers][body].
+    // Hand-rolled instead of pulling in a serialization crate — the body is
+    // raw (non-UTF-8) yEnc bytes, and this format only ever needs one
+    // reader/writer (this module), so there's nothing a general-purpose
+    // format would buy here.
+    let mut buf = Vec::with_capacity(4 + message_id.len() + 4 + headers.len() + body.len());
+    buf.extend_from_slice(&(message_id.len() as u32).to_le_bytes());
+    buf.extend_from_slice(message_id.as_bytes());
+    buf.extend_from_slice(&(headers.len() as u32).to_le_bytes());
+    buf.extend_from_slice(headers);
+    buf.extend_from_slice(body);
+    let path = entry_path(dir, file_name, part);
+    tokio::fs::write(&path, buf)
+        .await
+        .with_context(|| format!("writing spool entry `{}`", path.display()))
+}
+
+fn parse(buf: &[u8]) -> Option<SpooledArticle> {
+    let mut pos = 0usize;
+    let id_len = u32::from_le_bytes(buf.get(pos..pos + 4)?.try_into().ok()?) as usize;
+    pos += 4;
+    let message_id = String::from_utf8(buf.get(pos..pos + id_len)?.to_vec()).ok()?;
+    pos += id_len;
+    let headers_len = u32::from_le_bytes(buf.get(pos..pos + 4)?.try_into().ok()?) as usize;
+    pos += 4;
+    let headers = buf.get(pos..pos + headers_len)?.to_vec();
+    pos += headers_len;
+    let body = buf.get(pos..)?.to_vec();
+    Some(SpooledArticle {
+        message_id,
+        headers,
+        body,
+    })
+}
+
+/// Load a spooled article for `(file_name, part)`, if one was recorded.
+/// `None` covers both "nothing spooled" (the common case) and a corrupt
+/// entry — either way the caller's only sane response is a cache miss
+/// (fall back to a fresh encode), never a hard failure of the whole run.
+pub fn read(dir: &Path, file_name: &str, part: u32) -> Option<SpooledArticle> {
+    let buf = std::fs::read(entry_path(dir, file_name, part)).ok()?;
+    parse(&buf)
+}
+
+/// Remove one segment's spool entry — once it's confirmed posted (success or
+/// permanently failed), its cached bytes serve no further purpose. A no-op
+/// if nothing was ever spooled for it.
+pub fn remove(dir: &Path, file_name: &str, part: u32) {
+    let _ = std::fs::remove_file(entry_path(dir, file_name, part));
+}
+
+/// Remove the whole spool directory — called once a run's resume state
+/// itself is deleted (fully successful run: nothing left to ever replay).
+pub fn remove_all(dir: &Path) {
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("release.pesto-spool");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(write(
+            &spool,
+            "season01/ep01.mkv",
+            3,
+            "abc123@pesto.test",
+            b"Message-ID: <abc123@pesto.test>\r\n",
+            b"=ybegin ...\r\nnot valid utf8 \xff\xfe\r\n=yend",
+        ))
+        .unwrap();
+
+        let entry = read(&spool, "season01/ep01.mkv", 3).unwrap();
+        assert_eq!(entry.message_id, "abc123@pesto.test");
+        assert_eq!(entry.headers, b"Message-ID: <abc123@pesto.test>\r\n");
+        assert_eq!(
+            entry.body,
+            b"=ybegin ...\r\nnot valid utf8 \xff\xfe\r\n=yend"
+        );
+    }
+
+    #[test]
+    fn read_of_missing_entry_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("release.pesto-spool");
+        assert!(read(&spool, "never-spooled.bin", 1).is_none());
+    }
+
+    #[test]
+    fn read_of_corrupt_entry_is_none_not_a_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("release.pesto-spool");
+        std::fs::create_dir_all(&spool).unwrap();
+        std::fs::write(entry_path(&spool, "a.bin", 1), b"\x00\x00\x00\xff").unwrap();
+        assert!(read(&spool, "a.bin", 1).is_none());
+    }
+
+    #[test]
+    fn remove_deletes_only_the_named_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("release.pesto-spool");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(write(&spool, "a.bin", 1, "id-a@x", b"h", b"b"))
+            .unwrap();
+        rt.block_on(write(&spool, "b.bin", 1, "id-b@x", b"h", b"b"))
+            .unwrap();
+        remove(&spool, "a.bin", 1);
+        assert!(read(&spool, "a.bin", 1).is_none());
+        assert!(read(&spool, "b.bin", 1).is_some());
+    }
+
+    #[test]
+    fn remove_all_deletes_the_whole_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("release.pesto-spool");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(write(&spool, "a.bin", 1, "id-a@x", b"h", b"b"))
+            .unwrap();
+        remove_all(&spool);
+        assert!(!spool.exists());
+    }
+
+    #[test]
+    fn file_names_with_path_separators_are_sanitised_to_one_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("release.pesto-spool");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(write(&spool, "season01/ep01.mkv", 1, "id@x", b"h", b"b"))
+            .unwrap();
+        // No subdirectory was implied by the '/' in the file name.
+        assert!(!spool.join("season01").exists());
+        assert!(read(&spool, "season01/ep01.mkv", 1).is_some());
+    }
+}

--- a/crates/pesto/tests/check_fast_reposts_isolated_miss.rs
+++ b/crates/pesto/tests/check_fast_reposts_isolated_miss.rs
@@ -233,6 +233,8 @@ async fn check_fast_reposts_an_isolated_miss_instead_of_waiting_out_patient_retr
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: true,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/check_post_retries.rs
+++ b/crates/pesto/tests/check_post_retries.rs
@@ -258,14 +258,18 @@ fn one_repost_attempt_is_not_enough_when_the_server_keeps_losing_the_article() {
     // The first 2 distinct Message-IDs the server ever sees are cursed: the
     // original post (1st) and the one allowed repost's fresh ID (2nd) both
     // fail STAT. `check-post-retries 1` allows only one repost attempt per
-    // article, so it's not enough.
+    // article, so it's not enough on its own — `--check-recover-max 0`
+    // disables the separate automatic final-recovery pass (on by default,
+    // see issue #18's resume follow-up), which would otherwise make a 3rd
+    // attempt and land past `cursed_count`, masking exactly the behavior
+    // this test exists to verify.
     let addr = spawn_flaky_dedup_server(2);
     let dir = tempfile::tempdir().unwrap();
     let input = dir.path().join("movie.bin");
     std::fs::write(&input, vec![0xABu8; 64]).unwrap();
     let out = dir.path().join("out.nzb");
 
-    let output = run_pesto(addr.port(), 1, &input, &out);
+    let output = run_pesto_with_args(addr.port(), 1, &input, &out, &["--check-recover-max", "0"]);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(

--- a/crates/pesto/tests/check_recover_pass.rs
+++ b/crates/pesto/tests/check_recover_pass.rs
@@ -1,0 +1,246 @@
+//! End-to-end regression guard for the automatic final recovery pass added
+//! alongside issue #18's resume follow-up (`check_recover_percent` /
+//! `check_recover_max`, see `poster::is_cheap_to_recover` /
+//! `poster::check::recover_missing`).
+//!
+//! This is the primary real-world case the feature targets: posting
+//! finishes, the streaming check can't confirm an article even after every
+//! `check_post_retries` round, and — because so few articles are missing —
+//! `pesto` makes one more repost-and-verify attempt automatically, in the
+//! same run, instead of requiring the caller to notice the failure and
+//! rerun with `--resume`.
+//!
+//! Every other integration test in this crate sets `check_recover_max: 0`
+//! (disabling the pass) to avoid an unrelated side effect — meaning this
+//! file is the only place the feature actually runs end to end.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use pesto::config::{Config, ObfuscateMode};
+use pesto::poster::post_files_with_progress;
+use pesto::walk::expand_inputs;
+
+/// A mock NNTP server for a single-segment upload: every `POST` succeeds,
+/// but the first two `STAT` commands it receives report the article
+/// missing — modelling the normal check-and-repost cycle (one STAT on the
+/// original copy, one on the single `check_post_retries` repost) both
+/// failing — while the third and any later `STAT` succeed, modelling the
+/// automatic recovery pass's own repost finally landing.
+fn spawn_mock_server() -> (SocketAddr, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let post_count = Arc::new(AtomicUsize::new(0));
+    let stat_count = Arc::new(AtomicUsize::new(0));
+
+    let post_count_clone = Arc::clone(&post_count);
+    let stat_count_clone = Arc::clone(&stat_count);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            let post_count = Arc::clone(&post_count_clone);
+            let stat_count = Arc::clone(&stat_count_clone);
+            std::thread::spawn(move || handle_connection(stream, post_count, stat_count));
+        }
+    });
+
+    (addr, post_count, stat_count)
+}
+
+fn handle_connection(
+    stream: TcpStream,
+    post_count: Arc<AtomicUsize>,
+    stat_count: Arc<AtomicUsize>,
+) {
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+    let mut reader = BufReader::new(stream);
+    if writer.write_all(b"200 pesto mock ready\r\n").is_err() {
+        return;
+    }
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+        let command = line.trim_end().to_string();
+
+        if command == "POST" {
+            if writer.write_all(b"340 send article\r\n").is_err() {
+                return;
+            }
+            let mut raw = Vec::new();
+            loop {
+                raw.clear();
+                match reader.read_until(b'\n', &mut raw) {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+                if raw == b".\r\n" {
+                    break;
+                }
+            }
+            post_count.fetch_add(1, Ordering::SeqCst);
+            if writer.write_all(b"240 article received\r\n").is_err() {
+                return;
+            }
+        } else if command.starts_with("STAT ") {
+            let seen = stat_count.fetch_add(1, Ordering::SeqCst);
+            let resp: &[u8] = if seen < 2 {
+                b"430 no such article found\r\n"
+            } else {
+                b"223 0 <id> article exists\r\n"
+            };
+            if writer.write_all(resp).is_err() {
+                return;
+            }
+        } else if command.starts_with("MODE READER") {
+            if writer.write_all(b"200 reader mode\r\n").is_err() {
+                return;
+            }
+        } else if command == "QUIT" {
+            let _ = writer.write_all(b"205 bye\r\n");
+            return;
+        } else if writer.write_all(b"500 unknown command\r\n").is_err() {
+            return;
+        }
+    }
+}
+
+fn test_config(addr: SocketAddr) -> Config {
+    Config {
+        host: addr.ip().to_string(),
+        port: addr.port(),
+        ssl: false,
+        connections: 1,
+        username: None,
+        password: None,
+        from: "tester <t@pesto.test>".to_string(),
+        groups: vec!["alt.binaries.test".to_string()],
+        article_size: 100_000,
+        line_length: 128,
+        retries: 1,
+        retry_delay: 0,
+        timeout: pesto::config::DEFAULT_TIMEOUT_SECS,
+        obfuscate: ObfuscateMode::None,
+        dry_run: false,
+        par2: 0,
+        par2_slice_size: None,
+        par2_slice_count: None,
+        par2_recovery_count: None,
+        par2_memory_limit: Some(1_000_000_000),
+        par2_temp_dir: None,
+        par2_only: false,
+        threads: 0,
+        simd: pesto::par2::SimdPath::Auto,
+        extra_servers: vec![],
+        resume: false,
+        upload_rate: 0,
+        compress_format: None,
+        compress_password: None,
+        nzb_name: None,
+        nzb_password: None,
+        nzb_category: None,
+        nzb_tags: vec![],
+        tmdb_id: None,
+        tmdb_kind: None,
+        imdb_id: None,
+        tvdb_id: None,
+        mal_id: None,
+        indexer_url: None,
+        indexer_api_key: None,
+        notify_webhook: None,
+        notify_ntfy: None,
+        notify: None,
+        history: false,
+        history_dir: None,
+        nzb_dir: None,
+        date: None,
+        no_archive: false,
+        message_id_domain: None,
+        pre_hooks: vec![],
+        post_hooks: vec![],
+        no_hooks: false,
+        nfo: false,
+        nzb_conflict: pesto::config::NzbConflict::Overwrite,
+        quiet: false,
+        bell: false,
+        check: true,
+        check_delay_secs: 0,
+        // A single STAT attempt per copy and a single check_post_retries
+        // round: the normal cycle gets exactly 2 chances (original +
+        // 1 repost) before giving up, both of which the mock server fails.
+        check_retries: 1,
+        check_connections: 1,
+        check_post_retries: 1,
+        allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 5,
+        pipeline_depth: 1,
+        keepalive_interval: 0,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_recovery_pass_resolves_a_stubborn_miss_after_normal_retries_are_exhausted() {
+    let (addr, post_count, stat_count) = spawn_mock_server();
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("movie.bin");
+    std::fs::write(&input, vec![7u8; 50_000]).unwrap();
+
+    let config = test_config(addr);
+    let inputs = expand_inputs(std::slice::from_ref(&input)).unwrap();
+    let outcome = post_files_with_progress(&config, &inputs, None, None, None)
+        .await
+        .unwrap();
+
+    assert!(
+        outcome.still_missing.is_empty(),
+        "the automatic recovery pass should have resolved the stubborn miss: {:?}",
+        outcome.still_missing
+    );
+    assert!(outcome.failures.is_empty());
+    assert_eq!(outcome.segments.len(), 1);
+    // 1 original POST + 1 check_post_retries repost + 1 recovery-pass repost.
+    assert_eq!(
+        post_count.load(Ordering::SeqCst),
+        3,
+        "expected the original POST plus exactly two reposts"
+    );
+    // 2 failing STATs (original + first repost) + 1 succeeding STAT (recovery repost).
+    assert_eq!(stat_count.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recovery_pass_disabled_leaves_the_segment_missing() {
+    let (addr, post_count, stat_count) = spawn_mock_server();
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("movie.bin");
+    std::fs::write(&input, vec![7u8; 50_000]).unwrap();
+
+    let mut config = test_config(addr);
+    config.check_recover_max = 0; // matches every other test file's default
+
+    let inputs = expand_inputs(std::slice::from_ref(&input)).unwrap();
+    let outcome = post_files_with_progress(&config, &inputs, None, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        outcome.still_missing.len(),
+        1,
+        "with recovery disabled the stubborn miss must remain unresolved"
+    );
+    // Only the normal cycle ran: 1 original POST + 1 check_post_retries repost.
+    assert_eq!(post_count.load(Ordering::SeqCst), 2);
+    assert_eq!(stat_count.load(Ordering::SeqCst), 2);
+}

--- a/crates/pesto/tests/check_targets_posting_server.rs
+++ b/crates/pesto/tests/check_targets_posting_server.rs
@@ -221,6 +221,8 @@ async fn check_stats_the_server_the_article_was_actually_posted_to() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: true,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/each_concurrent_par2_temp_dirs.rs
+++ b/crates/pesto/tests/each_concurrent_par2_temp_dirs.rs
@@ -159,6 +159,8 @@ fn par2_config(port: u16) -> Config {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     }

--- a/crates/pesto/tests/full_file_crc32.rs
+++ b/crates/pesto/tests/full_file_crc32.rs
@@ -177,6 +177,8 @@ async fn last_segment_of_a_multipart_file_carries_the_whole_file_crc32() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/full_shared_obfuscation.rs
+++ b/crates/pesto/tests/full_shared_obfuscation.rs
@@ -77,6 +77,8 @@ fn dry_run_config(obfuscate: ObfuscateMode) -> Config {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     }
@@ -370,6 +372,8 @@ async fn full_shared_obfuscation_par2_set_shares_prefix_with_content() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/integration.rs
+++ b/crates/pesto/tests/integration.rs
@@ -146,6 +146,8 @@ async fn posts_every_segment_to_a_mock_server() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };
@@ -310,6 +312,8 @@ fn make_config(port: u16) -> Config {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     }
@@ -389,9 +393,9 @@ async fn resume_skips_already_posted_segments() {
     // Pre-populate the resume state with all 3 segments.
     let state_path = dir.path().join("resume_test.bin.pesto-state");
     let mut state = pesto::resume::ResumeState::default();
-    state.record("resume_test.bin", 1, "seg1@preposted.example");
-    state.record("resume_test.bin", 2, "seg2@preposted.example");
-    state.record("resume_test.bin", 3, "seg3@preposted.example");
+    state.record("resume_test.bin", 1, "seg1@preposted.example", 100);
+    state.record("resume_test.bin", 2, "seg2@preposted.example", 100);
+    state.record("resume_test.bin", 3, "seg3@preposted.example", 50);
     state.save(&state_path).unwrap();
 
     let mut config = make_config(addr.port());
@@ -427,4 +431,372 @@ async fn resume_skips_already_posted_segments() {
     assert!(ids.contains(&"seg1@preposted.example"));
     assert!(ids.contains(&"seg2@preposted.example"));
     assert!(ids.contains(&"seg3@preposted.example"));
+}
+
+/// Resume state must be tracked and persisted on an incomplete run even when
+/// `--resume` was never passed — otherwise a user who didn't think to opt in
+/// up front (the common case: nobody expects a failure before it happens)
+/// has nothing to recover from after the fact. See issue #18.
+#[tokio::test]
+async fn resume_state_is_saved_after_failure_even_without_the_resume_flag() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let posts = Arc::new(AtomicUsize::new(0));
+    // Reject every attempt, on every connection, so the segment exhausts
+    // `config.retries` and lands in `failed_tasks` no matter how many times
+    // it reconnects.
+    let fail_count = Arc::new(AtomicUsize::new(1_000));
+
+    {
+        let posts = posts.clone();
+        let fail_count = fail_count.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection_with_failures(
+                    stream,
+                    posts.clone(),
+                    fail_count.clone(),
+                ));
+            }
+        });
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("never_posts.bin");
+    std::fs::write(&path, vec![0xAB_u8; 80]).unwrap();
+    let state_path = dir.path().join("never_posts.bin.pesto-state");
+
+    let mut config = make_config(addr.port());
+    config.resume = false; // deliberately not passed
+    config.retries = 2;
+
+    let inputs = vec![pesto::walk::InputFile {
+        path: path.clone(),
+        name: "never_posts.bin".to_string(),
+    }];
+    let outcome = post_files_with_progress(&config, &inputs, None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(
+        !outcome.failed_tasks.is_empty(),
+        "expected the segment to end up in failed_tasks after exhausting retries"
+    );
+    assert!(
+        state_path.exists(),
+        "resume state should have been written for a later retry, even though \
+         --resume was not passed on this run"
+    );
+}
+
+/// A run that completes fully must have no leftover resume state — both a
+/// freshly-tracked one from this run, and any stale file left over from an
+/// earlier failed attempt at the same output path (the exact hazard behind
+/// issue #18's "silent no-op re-posts" bug: an old state file left on disk
+/// after a successful run gets blindly trusted by a later invocation).
+#[tokio::test]
+async fn resume_state_is_deleted_after_a_fully_successful_run() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let posts = Arc::new(AtomicUsize::new(0));
+
+    {
+        let posts = posts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection(stream, posts.clone()));
+            }
+        });
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("succeeds.bin");
+    std::fs::write(&path, vec![0xCD_u8; 80]).unwrap();
+    let state_path = dir.path().join("succeeds.bin.pesto-state");
+
+    // Simulate a stale leftover from an earlier, unrelated failed run at the
+    // same output path — exactly what issue #18 warns must not be trusted
+    // (or left behind) once this run succeeds.
+    let mut stale = pesto::resume::ResumeState::default();
+    stale.record("succeeds.bin", 1, "stale@leftover.example", 80);
+    stale.save(&state_path).unwrap();
+
+    let config = make_config(addr.port()); // resume: false, per make_config's default
+
+    let inputs = vec![pesto::walk::InputFile {
+        path: path.clone(),
+        name: "succeeds.bin".to_string(),
+    }];
+    let outcome = post_files_with_progress(&config, &inputs, None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(outcome.failures.is_empty());
+    assert_eq!(outcome.segments.len(), 1);
+    // The stale ID must not have been reused — a real POST happened.
+    assert_eq!(posts.load(Ordering::Relaxed), 1);
+    assert!(
+        !state_path.exists(),
+        "resume state must be deleted once the run completes successfully"
+    );
+}
+
+/// Reproduces issue #18 bug #3 verbatim: a `--resume` run using a different
+/// `--article-size` than the run that originally populated the state must
+/// not trust the stale segments (whose Message-IDs reference different,
+/// wrongly-sized byte ranges) — it must detect the mismatch, discard the
+/// whole state, and actually re-post under the new geometry.
+#[tokio::test]
+async fn resume_with_different_article_size_discards_stale_state_instead_of_corrupting_output() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let posts = Arc::new(AtomicUsize::new(0));
+
+    {
+        let posts = posts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection(stream, posts.clone()));
+            }
+        });
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("resize.bin");
+    std::fs::write(&path, vec![0xEF_u8; 200]).unwrap();
+    let state_path = dir.path().join("resize.bin.pesto-state");
+
+    // A prior run posted this file with article_size=100 (2 segments) and
+    // its state was never cleaned up (e.g. the run was killed before the
+    // final persist-or-delete decision could run). `validate_run` is called
+    // here to record the fingerprint that run would have recorded, so this
+    // accurately simulates a real prior run rather than a hand-crafted
+    // pre-fingerprint state file.
+    let mut stale = pesto::resume::ResumeState::default();
+    stale.validate_run(&pesto::resume::RunFingerprint {
+        article_size: 100,
+        obfuscate: ObfuscateMode::None,
+        compress_format: None,
+        par2_percent: 0,
+    });
+    stale.record("resize.bin", 1, "stale-part1@x", 100);
+    stale.record("resize.bin", 2, "stale-part2@x", 100);
+    stale.save(&state_path).unwrap();
+
+    let mut config = make_config(addr.port());
+    config.resume = true;
+    config.article_size = 40; // different geometry: 5 segments, not 2
+
+    let inputs = vec![pesto::walk::InputFile {
+        path: path.clone(),
+        name: "resize.bin".to_string(),
+    }];
+    let outcome = post_files_with_progress(&config, &inputs, None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(outcome.failures.is_empty());
+    // The new article_size produces 5 segments, not the stale 2 — proof the
+    // old state was discarded rather than partially trusted.
+    assert_eq!(outcome.segments.len(), 5);
+    assert_eq!(
+        posts.load(Ordering::Relaxed),
+        5,
+        "every segment must have been freshly posted, not skipped via stale state"
+    );
+    let ids: Vec<&str> = outcome
+        .segments
+        .iter()
+        .map(|s| s.message_id.as_str())
+        .collect();
+    assert!(!ids.contains(&"stale-part1@x"));
+    assert!(!ids.contains(&"stale-part2@x"));
+}
+
+/// `ObfuscateMode::FullShared` gives every file in a release the same wire
+/// name prefix so indexers can group them — but that prefix is normally
+/// randomly regenerated every run, which would otherwise make a `--resume`
+/// continuation post its remaining files under a *different* prefix than the
+/// segments the interrupted run already confirmed, splitting one release's
+/// articles across two indexer-visible names. A compatible prior state must
+/// make the continuation reuse the exact same prefix.
+#[tokio::test]
+async fn resume_reuses_the_full_shared_prefix_across_runs() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let posts = Arc::new(AtomicUsize::new(0));
+
+    {
+        let posts = posts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection(stream, posts.clone()));
+            }
+        });
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let a_path = dir.path().join("a.bin");
+    let b_path = dir.path().join("b.bin");
+    std::fs::write(&a_path, vec![0x11_u8; 50]).unwrap();
+    std::fs::write(&b_path, vec![0x22_u8; 50]).unwrap();
+    let state_path = dir.path().join("release.pesto-state");
+
+    let mut config = make_config(addr.port());
+    config.resume = true;
+    config.obfuscate = ObfuscateMode::FullShared;
+
+    // Simulate an interrupted prior run: `a.bin` already confirmed posted,
+    // under a prefix that run generated, `b.bin` never reached.
+    let a_md = std::fs::metadata(&a_path).unwrap();
+    let a_mtime = a_md
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs());
+    let mut prior = pesto::resume::ResumeState::default();
+    prior.validate_run(&pesto::resume::RunFingerprint {
+        article_size: config.article_size as u64,
+        obfuscate: ObfuscateMode::FullShared,
+        compress_format: None,
+        par2_percent: 0,
+    });
+    prior.record_file(
+        "a.bin",
+        pesto::resume::FileFingerprint {
+            size: a_md.len(),
+            mtime: a_mtime,
+        },
+    );
+    prior.record("a.bin", 1, "a-part1@prior-run.example", 60);
+    prior.set_release_identity(
+        "PriorPrefix123".to_string(),
+        "prior@sender.example".to_string(),
+    );
+    prior.save(&state_path).unwrap();
+
+    let inputs = vec![
+        pesto::walk::InputFile {
+            path: a_path,
+            name: "a.bin".to_string(),
+        },
+        pesto::walk::InputFile {
+            path: b_path,
+            name: "b.bin".to_string(),
+        },
+    ];
+    let outcome = post_files_with_progress(&config, &inputs, None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(outcome.failures.is_empty());
+    assert_eq!(outcome.segments.len(), 2);
+
+    let a_seg = outcome
+        .segments
+        .iter()
+        .find(|s| s.file_name == "a.bin")
+        .unwrap();
+    let b_seg = outcome
+        .segments
+        .iter()
+        .find(|s| s.file_name == "b.bin")
+        .unwrap();
+
+    // a.bin was resumed from state, untouched.
+    assert_eq!(a_seg.message_id, "a-part1@prior-run.example");
+    // b.bin was freshly posted this run.
+    assert_ne!(b_seg.message_id, "a-part1@prior-run.example");
+    assert_eq!(
+        posts.load(Ordering::Relaxed),
+        1,
+        "only b.bin should have actually been posted"
+    );
+
+    // Both must carry the *reused* prefix, not a freshly-generated one —
+    // otherwise the release would be split across two prefixes.
+    assert!(
+        a_seg.subject_name.starts_with("PriorPrefix123"),
+        "a.bin subject was `{}`",
+        a_seg.subject_name
+    );
+    assert!(
+        b_seg.subject_name.starts_with("PriorPrefix123"),
+        "b.bin subject was `{}`",
+        b_seg.subject_name
+    );
+}
+
+/// Type-1 spool: a segment that was encoded and (maybe) sent before an
+/// interruption, but never confirmed by the streaming check nor recorded in
+/// resume state, must be replayed byte-for-byte under its original
+/// Message-ID on `--resume` — not silently re-encoded and posted under a
+/// fresh one, which would risk a duplicate article if the original `POST`
+/// had actually landed. See `pesto::spool` / GitHub issue #18's resume
+/// follow-up discussion.
+#[tokio::test]
+async fn resume_replays_a_spooled_article_under_its_original_message_id() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let posts = Arc::new(AtomicUsize::new(0));
+
+    {
+        let posts = posts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection(stream, posts.clone()));
+            }
+        });
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("replay.bin");
+    std::fs::write(&path, vec![0x99_u8; 50]).unwrap();
+    let state_path = dir.path().join("replay.bin.pesto-state");
+
+    let mut config = make_config(addr.port());
+    config.resume = true;
+
+    // Simulate an interrupted run that had already encoded and spooled this
+    // segment's article (and quite possibly sent it — the ack was lost)
+    // before dying, without ever getting far enough to record it in resume
+    // state (that only happens once the response comes back).
+    let spool_dir = pesto::spool::spool_dir(&state_path);
+    pesto::spool::write(
+        &spool_dir,
+        "replay.bin",
+        1,
+        "already-sent@spool.test",
+        b"Message-ID: <already-sent@spool.test>\r\nSubject: test\r\n",
+        b"=ybegin line=128 size=50 name=replay.bin\r\nfake-body\r\n=yend size=50 crc32=00000000\r\n",
+    )
+    .await
+    .unwrap();
+
+    let inputs = vec![pesto::walk::InputFile {
+        path: path.clone(),
+        name: "replay.bin".to_string(),
+    }];
+    let outcome = post_files_with_progress(&config, &inputs, None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(outcome.failures.is_empty());
+    assert_eq!(outcome.segments.len(), 1);
+    assert_eq!(
+        outcome.segments[0].message_id, "already-sent@spool.test",
+        "the spooled Message-ID must be reused verbatim, not a freshly generated one"
+    );
+    assert_eq!(
+        posts.load(Ordering::Relaxed),
+        1,
+        "the spooled article must actually be (re)sent to the server, not skipped"
+    );
+    // The spool entry is consumed once the replay is confirmed.
+    assert!(pesto::spool::read(&spool_dir, "replay.bin", 1).is_none());
 }

--- a/crates/pesto/tests/obfuscated_directory.rs
+++ b/crates/pesto/tests/obfuscated_directory.rs
@@ -72,6 +72,8 @@ fn dry_run_config(obfuscate: ObfuscateMode) -> Config {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     }

--- a/crates/pesto/tests/par2_directory.rs
+++ b/crates/pesto/tests/par2_directory.rs
@@ -101,6 +101,8 @@ async fn par2_zero_byte_file_verifies() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };
@@ -234,6 +236,8 @@ async fn par2_only_directory_repair_recreates_tree() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/par2_exact_multiple_of_slice_size.rs
+++ b/crates/pesto/tests/par2_exact_multiple_of_slice_size.rs
@@ -180,6 +180,8 @@ async fn file_size_exact_multiple_of_par2_slice_size_does_not_panic() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/par2_temp_dir_survives_post.rs
+++ b/crates/pesto/tests/par2_temp_dir_survives_post.rs
@@ -173,6 +173,8 @@ async fn par2_temp_dir_is_not_deleted_by_post_files() {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/producer_error_surfaces_reason.rs
+++ b/crates/pesto/tests/producer_error_surfaces_reason.rs
@@ -89,6 +89,8 @@ async fn producer_error_is_reported_via_failure_reason_not_a_bare_cancellation()
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 1,
         keepalive_interval: 0,
     };

--- a/crates/pesto/tests/resume_par2_cross_invalidation.rs
+++ b/crates/pesto/tests/resume_par2_cross_invalidation.rs
@@ -1,0 +1,232 @@
+//! PAR2 recovery blocks are computed over a release's *entire* recovery set
+//! together, not per file — so if a data file's content changes between
+//! runs, every PAR2 volume's previously-recorded resume segments are just as
+//! untrustworthy as that file's own, even though PAR2 volumes never go
+//! through the per-file fingerprint check themselves (they're generated
+//! straight into the posting queue — see `push_par2_file`). This is the
+//! fix documented alongside issue #18's resume follow-up (task #9): a
+//! per-file mismatch with `--par2` active must discard the *whole* resume
+//! state, not just the changed file's own segments.
+//!
+//! `pesto::resume`'s own unit tests cover `forget_all_segments` in
+//! isolation; this exercises the real wiring end to end through
+//! `post_files_with_progress` with actual PAR2 generation and posting.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+use pesto::config::{Config, ObfuscateMode};
+use pesto::poster::post_files_with_progress;
+use pesto::resume::{FileFingerprint, ResumeState, RunFingerprint};
+
+/// Accepts every `POST` unconditionally — PAR2 volumes and data segments
+/// alike.
+async fn handle_connection(stream: TcpStream, posts: Arc<AtomicUsize>) {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    write_half
+        .write_all(b"200 pesto mock ready\r\n")
+        .await
+        .unwrap();
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await.unwrap() == 0 {
+            return;
+        }
+        let command = line.trim_end();
+
+        if command.starts_with("AUTHINFO USER") {
+            write_half
+                .write_all(b"381 password required\r\n")
+                .await
+                .unwrap();
+        } else if command.starts_with("AUTHINFO PASS") {
+            write_half
+                .write_all(b"281 authenticated\r\n")
+                .await
+                .unwrap();
+        } else if command == "POST" {
+            write_half.write_all(b"340 send article\r\n").await.unwrap();
+            let mut body = Vec::new();
+            loop {
+                body.clear();
+                if reader.read_until(b'\n', &mut body).await.unwrap() == 0 {
+                    return;
+                }
+                if body == b".\r\n" {
+                    break;
+                }
+            }
+            posts.fetch_add(1, Ordering::Relaxed);
+            write_half
+                .write_all(b"240 article received\r\n")
+                .await
+                .unwrap();
+        } else if command == "QUIT" {
+            write_half.write_all(b"205 bye\r\n").await.unwrap();
+            return;
+        }
+    }
+}
+
+fn test_config(port: u16) -> Config {
+    Config {
+        host: "127.0.0.1".to_string(),
+        port,
+        ssl: false,
+        connections: 2,
+        username: Some("user".to_string()),
+        password: Some("pass".to_string()),
+        from: "tester <t@pesto.test>".to_string(),
+        groups: vec!["alt.binaries.test".to_string()],
+        article_size: 500,
+        line_length: 128,
+        retries: 3,
+        retry_delay: 0,
+        timeout: pesto::config::DEFAULT_TIMEOUT_SECS,
+        obfuscate: ObfuscateMode::None,
+        dry_run: false,
+        par2: 100,
+        par2_memory_limit: Some(1_000_000_000),
+        par2_temp_dir: None,
+        par2_slice_size: None,
+        par2_slice_count: None,
+        par2_recovery_count: None,
+        par2_only: false,
+        threads: 0,
+        simd: parmesan::SimdPath::Auto,
+        extra_servers: vec![],
+        resume: true,
+        upload_rate: 0,
+        compress_format: None,
+        compress_password: None,
+        nzb_name: None,
+        nzb_password: None,
+        nzb_category: None,
+        nzb_tags: vec![],
+        tmdb_id: None,
+        tmdb_kind: None,
+        imdb_id: None,
+        tvdb_id: None,
+        mal_id: None,
+        indexer_url: None,
+        indexer_api_key: None,
+        notify_webhook: None,
+        notify_ntfy: None,
+        notify: None,
+        history: false,
+        history_dir: None,
+        nzb_dir: None,
+        date: None,
+        no_archive: false,
+        message_id_domain: None,
+        pre_hooks: vec![],
+        post_hooks: vec![],
+        no_hooks: false,
+        nfo: false,
+        nzb_conflict: pesto::config::NzbConflict::Overwrite,
+        quiet: false,
+        bell: false,
+        check: false,
+        check_delay_secs: 30,
+        check_retries: 2,
+        check_connections: 1,
+        check_post_retries: 1,
+        allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
+        pipeline_depth: 1,
+        keepalive_interval: 0,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn changed_file_with_par2_invalidates_previously_resumed_par2_volumes_too() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let posts = Arc::new(AtomicUsize::new(0));
+
+    {
+        let posts = posts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection(stream, posts.clone()));
+            }
+        });
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("movie.bin");
+    std::fs::write(&path, vec![0x42_u8; 2000]).unwrap();
+    let state_path = dir.path().join("movie.bin.pesto-state");
+
+    let config = test_config(addr.port());
+
+    // Simulate a prior run over *different* content (old size), whose state
+    // recorded both the data segment and a PAR2 volume — the PAR2 volume
+    // entry is hand-crafted, since PAR2 volumes never go through the
+    // per-file fingerprint check that would otherwise catch this on their
+    // own (see the module doc comment).
+    let mut prior = ResumeState::default();
+    prior.validate_run(&RunFingerprint {
+        article_size: config.article_size as u64,
+        obfuscate: ObfuscateMode::None,
+        compress_format: None,
+        par2_percent: config.par2,
+    });
+    prior.record_file(
+        "movie.bin",
+        FileFingerprint {
+            size: 999, // does not match the 2000-byte file actually on disk
+            mtime: Some(1),
+        },
+    );
+    prior.record("movie.bin", 1, "old-data-part1@prior-run.example", 500);
+    prior.record(
+        "movie.bin.vol000+001.par2",
+        1,
+        "old-par2-vol@prior-run.example",
+        500,
+    );
+    prior.save(&state_path).unwrap();
+
+    let inputs = vec![pesto::walk::InputFile {
+        path: path.clone(),
+        name: "movie.bin".to_string(),
+    }];
+    let outcome = post_files_with_progress(&config, &inputs, None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(outcome.failures.is_empty());
+    // At least the 4 data segments (2000 / 500) plus some PAR2 volume(s).
+    assert!(
+        outcome.segments.len() > 4,
+        "expected data segments plus at least one freshly generated PAR2 volume, got {}",
+        outcome.segments.len()
+    );
+
+    let ids: Vec<&str> = outcome
+        .segments
+        .iter()
+        .map(|s| s.message_id.as_str())
+        .collect();
+    assert!(
+        !ids.contains(&"old-data-part1@prior-run.example"),
+        "the changed file's own stale segment must not be reused"
+    );
+    assert!(
+        !ids.contains(&"old-par2-vol@prior-run.example"),
+        "a PAR2 volume's stale segment must not be reused either, even though PAR2 volumes \
+         never go through the per-file fingerprint check on their own"
+    );
+    // Every segment was freshly (re-)posted: the whole recovery set had to
+    // be regenerated once the underlying data was considered changed.
+    assert_eq!(posts.load(Ordering::Relaxed), outcome.segments.len());
+}

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1745,6 +1745,8 @@ fn build_dry_run_config() -> Config {
         check_connections: 1,
         check_post_retries: 1,
         allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
         pipeline_depth: 0,
         keepalive_interval: 60,
     }


### PR DESCRIPTION
## Summary

Closes #18. `--resume` previously trusted whatever `.pesto-state` file it found blindly — no fingerprint, no per-file identity check, and the state was never deleted after a successful run. A retry with a different `--article-size` (or against an edited file, or a leftover state from an unrelated run) could silently corrupt the `.nzb` with wrong-sized or wrong-content article references.

- **Fingerprinted state**: `ResumeState` now carries a `RunFingerprint` (`article_size`, `obfuscate`, `compress_format`, `par2_percent`) and a per-file `FileFingerprint` (size, mtime). Any mismatch discards the affected state instead of reusing it; with `--par2` active, a per-file mismatch discards the *whole* state, since PAR2 recovery blocks are computed over every file together.
- **Unconditional tracking**: resume progress is now tracked for every run (not gated behind `--resume`), so a run that ends incomplete always has something to persist for a later retry. `--resume` itself now only controls whether a *prior* run's saved state is loaded and reused. State is deleted automatically once a run completes successfully.
- **Off the hot path**: persistence used to rewrite the whole state file under a shared lock on every confirmed segment (O(n²) on large uploads); now written once, at the end of the run, based on the final outcome.
- **Type-1 spool**: a new `.pesto-spool` sidecar caches each article's encoded bytes before sending, so a segment whose ack was lost to a dropped connection is replayed under its original Message-ID on `--resume` instead of risking a duplicate under a fresh one.
- **Stable identity**: the obfuscated archive name (`--compress`+`--obfuscate`) and the shared `--obfuscate=full-shared` identity now persist across `--resume` runs with matching parameters, instead of being regenerated (and thus unresumable) every time.
- **Better retry hint**: resume failure messages now print a ready-to-copy retry command with the original parameters filled in.

Also adds an automatic final recovery pass (`--check-recover-percent` / `--check-recover-max`) for the common case of posting finishing but a handful of articles failing the post-check: one more repost-and-verify attempt happens automatically, in the same run, before giving up — no second `--resume` invocation needed for a small, cheap-to-fix gap.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 432 unit tests + 47 integration tests, 0 failures
- [x] Reproduced and verified the fix for the original corruption bug (different `--article-size` on resume)
- [x] Reproduced and verified the PAR2 cross-invalidation edge case (changed file discards PAR2 volume segments too, not just its own)
- [x] Verified the automatic recovery pass end-to-end against a mock server that only succeeds on the extra attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnW1ANL1Nuxazk9Dpgb4VZ