### PR TITLE
parmesan: add regression/diagnostic tests for issue #51's flaky decoder proptest

### DIFF
--- a/crates/parmesan/src/decoder.rs
+++ b/crates/parmesan/src/decoder.rs
@@ -320,6 +320,46 @@ mod tests {
                 .collect()
         }
 
+        // Pinned regression check for the 3 known CI-failing minimal inputs
+        // from issue #51 (seed always 0; n/recovery_count vary but all
+        // satisfy recovery_count == n + 1, and recovery_count % 4 == 3).
+        // Never reproduced locally so far — this exists to make each new
+        // investigation attempt (different core count, RAYON_NUM_THREADS,
+        // toolchain) trivially re-checkable without waiting on proptest to
+        // land on the same inputs by chance.
+        #[test]
+        fn known_ci_failing_inputs_from_issue_51() {
+            for (n, recovery_count) in [(2usize, 3usize), (5, 7), (9, 11)] {
+                let seed = 0u64;
+                let slice_size = 16;
+                let m = recovery_count.min(n);
+                let missing = distinct_below(seed, m, n);
+
+                let slices: Vec<Vec<u8>> = (0..n)
+                    .map(|i| pseudo_random_bytes(seed ^ 0x9E3779B9 ^ (i as u64), slice_size))
+                    .collect();
+                let recovery_blocks = encode(&slices, slice_size, recovery_count);
+
+                let dec = RecoveryDecoder::new(slice_size, n, missing.clone());
+                let result = dec
+                    .reconstruct(|j| Ok(slices[j].clone()), &recovery_blocks)
+                    .unwrap();
+
+                assert_eq!(
+                    result.len(),
+                    missing.len(),
+                    "n={n} recovery_count={recovery_count}"
+                );
+                for (idx, data) in result {
+                    assert_eq!(
+                        data,
+                        slices[idx].clone(),
+                        "slice {idx} mismatch (n={n}, recovery_count={recovery_count}, missing={missing:?})"
+                    );
+                }
+            }
+        }
+
         proptest! {
             #![proptest_config(ProptestConfig::with_cases(96))]
 

--- a/crates/parmesan/src/encoder.rs
+++ b/crates/parmesan/src/encoder.rs
@@ -3904,6 +3904,68 @@ mod tests {
         }
     }
 
+    // `simd_recovery_matches_scalar_for_larger_slices` above only exercises
+    // recovery_count=4, a clean multiple of the 4-wide unrolled group size in
+    // `flush_avx2_work`'s `buffers.par_chunks_mut(4)` — so it never touches the
+    // `[buf_a, buf_b]` (remainder 2) or `rest` (remainder 1 or 3) fallback arms.
+    // Investigating a flaky proptest failure (round_trip_reconstructs_arbitrary_missing_sets)
+    // whose 3 known failing inputs (recovery_count 3, 7, 11) all hit exactly
+    // those under-tested fallback arms — this sweeps every remainder case
+    // directly against the scalar reference to isolate whether the bug lives
+    // in AVX2 encoding itself (as opposed to the decoder or a timing issue).
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn avx2_recovery_matches_scalar_across_all_group_remainders() {
+        if !std::is_x86_feature_detected!("avx2") {
+            eprintln!(
+                "avx2_recovery_matches_scalar_across_all_group_remainders: skipped (no AVX2)"
+            );
+            return;
+        }
+        let slice_size = 16;
+        for total_slices in [1usize, 2, 3, 5] {
+            for recovery_count in 1usize..=12 {
+                let slices: Vec<Vec<u8>> = (0..total_slices)
+                    .map(|s| {
+                        (0..slice_size)
+                            .map(|i| ((s * 37 + i * 13 + 7) & 0xFF) as u8)
+                            .collect()
+                    })
+                    .collect();
+
+                let mut enc = RecoveryEncoder::new(slice_size, total_slices, 0, recovery_count);
+                for s in &slices {
+                    enc.add_slice(s.clone());
+                }
+                let (simd_recovery, _) = enc.finish();
+
+                let gf = Gf16::new();
+                let logbases = input_logbases(total_slices);
+                let mut scalar_buffers = vec![vec![0u16; slice_size / 2]; recovery_count];
+                RecoveryEncoder::flush_scalar_work(
+                    &mut scalar_buffers,
+                    &slices,
+                    0,
+                    &logbases,
+                    0,
+                    &gf,
+                );
+                let scalar_recovery: Vec<Vec<u8>> = scalar_buffers
+                    .into_iter()
+                    .map(|buf| buf.into_iter().flat_map(|w| w.to_le_bytes()).collect())
+                    .collect();
+
+                for (i, (simd, scalar)) in simd_recovery.iter().zip(&scalar_recovery).enumerate() {
+                    assert_eq!(
+                        simd.data, *scalar,
+                        "SIMD and scalar disagree on recovery block {i} \
+                         (total_slices={total_slices}, recovery_count={recovery_count})"
+                    );
+                }
+            }
+        }
+    }
+
     // Validates that flush_avx512_gfni produces bit-identical output to the
     // scalar reference.  Requires the `bench-internals` feature to force the
     // path; skips cleanly on CPUs without AVX-512/GFNI.

--- a/crates/parmesan/src/gf16_mac.rs
+++ b/crates/parmesan/src/gf16_mac.rs
@@ -438,6 +438,52 @@ mod tests {
             }
         }
 
+        /// Same exhaustive-coefficient agreement check as above, but at
+        /// words=8 (16 bytes) — small enough that `blocks_32 == 0` in both
+        /// `mac_avx2` and `mac_ssse3`, so the *entire* buffer goes through
+        /// `scalar_tail` with zero preceding SIMD main-loop iterations. The
+        /// 200-word test above only exercises `scalar_tail` after 12 (AVX2)
+        /// or 25 (SSSE3) full main-loop iterations already ran, so it never
+        /// covers this all-tail case. This exact length (16 bytes) is what
+        /// `RecoveryDecoder::reconstruct` uses in the proptest
+        /// `decoder::tests::props::round_trip_reconstructs_arbitrary_missing_sets`,
+        /// which has failed intermittently in CI (never locally) —
+        /// this test isolates whether `mac`'s all-tail path is the cause.
+        #[test]
+        fn scalar_ssse3_and_avx2_agree_for_every_coefficient_all_tail_no_main_loop() {
+            if !std::is_x86_feature_detected!("ssse3") || !std::is_x86_feature_detected!("avx2") {
+                eprintln!("skipping: SSSE3/AVX2 not available on this CPU");
+                return;
+            }
+            let gf = Gf16::new();
+            let words = 8usize;
+            let src: Vec<u8> = (0..words as u32 * 2)
+                .map(|i| (i.wrapping_mul(2654435761) >> 24) as u8)
+                .collect();
+
+            for coeff in 0u32..=65535 {
+                let coeff = coeff as u16;
+
+                let mut d_scalar = vec![0xFFu8; src.len()];
+                mac_scalar(&gf, &mut d_scalar, &src, coeff);
+
+                let mut d_ssse3 = vec![0xFFu8; src.len()];
+                unsafe { mac_ssse3(&gf, &mut d_ssse3, &src, coeff) };
+
+                let mut d_avx2 = vec![0xFFu8; src.len()];
+                unsafe { mac_avx2(&gf, &mut d_avx2, &src, coeff) };
+
+                assert_eq!(
+                    d_ssse3, d_scalar,
+                    "SSSE3 vs scalar mismatch at coeff={coeff:#06x}"
+                );
+                assert_eq!(
+                    d_avx2, d_scalar,
+                    "AVX2 vs scalar mismatch at coeff={coeff:#06x}"
+                );
+            }
+        }
+
         /// Same agreement check but accumulating (non-zero starting `dst`,
         /// like real decode usage where multiple `mac` calls XOR into the
         /// same buffer) rather than starting from a fixed fill value.


### PR DESCRIPTION
## Summary

Continues the investigation into #51 (`decoder::tests::props::round_trip_reconstructs_arbitrary_missing_sets` failing intermittently in CI, never locally, with silent data corruption).

This session ruled out several more suspects without finding the root cause — adding the tests as permanent regression coverage rather than continuing to guess-and-check, per the issue's own suggested next steps.

**Ruled out this round (all pass):**
- Encoder AVX2 SIMD, every buffer-count remainder (1/2/3/4) the 4-wide grouping in `flush_avx2_work` can produce, against the scalar reference.
- Decoder's `mac` primitive, exhaustively across all 65536 possible coefficients, at the exact 16-byte all-tail buffer size `RecoveryDecoder::reconstruct` uses.
- The 3 exact minimal failing inputs from CI (`n`/`recovery_count`/`seed`), pinned directly (no longer dependent on proptest re-landing on them by chance), under `RAYON_NUM_THREADS` 1/2/3/4/12.
- Manual review of `matrix.rs`'s Gauss-Jordan `invert()`/`build_reduced()` and `gf16.rs`'s `pow`/`mul`/`inverse` — mathematically consistent with their own existing reference tests.

Root cause still unknown. Posted full findings to #51.

## Test plan

- [x] `cargo fmt --check -p parmesan-par2`
- [x] `cargo clippy -p parmesan-par2 --all-targets -- -D warnings`
- [x] `cargo test -p parmesan-par2` — 99 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnW1ANL1Nuxazk9Dpgb4VZ