### PR TITLE
parmesan: fix AVX-512+GFNI encoder silently corrupting recovery blocks (fixes #51)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - name: Environment diagnostics
+        # Baseline info for issue #51 (parmesan's decoder proptest fails
+        # intermittently on CI, never locally): capture what SIMD tier and
+        # core count this runner actually has on every run, not just failing
+        # ones, so a future failure can be cross-referenced against a run
+        # that passed under the same environment.
+        run: |
+          echo "nproc: $(nproc)"
+          echo "CPU flags of interest:"
+          grep -o -E '\b(avx2|avx512f|avx512bw|gfni|ssse3)\b' /proc/cpuinfo | sort -u || true
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/crates/parmesan/src/decoder.rs
+++ b/crates/parmesan/src/decoder.rs
@@ -457,6 +457,54 @@ mod tests {
                     .reconstruct(|j| Ok(slices[j].clone()), &recovery_blocks)
                     .unwrap();
 
+                let mismatched = result.iter().any(|(idx, data)| data != &slices[*idx]);
+                if mismatched {
+                    // Diagnostic capture for issue #51: this failure has
+                    // reproduced on CI 9 times and never once locally across
+                    // three investigation rounds. Before failing, gather the
+                    // two things the plain "minimal failing input" report
+                    // never has: (1) whether it's a genuine data race (some
+                    // retries of the *identical* inputs pass) or a
+                    // deterministic environment-specific bug (every retry
+                    // fails the same way), and (2) which SIMD tier and
+                    // thread count this machine actually used, since that's
+                    // exactly what differs between CI and every local
+                    // attempt so far.
+                    eprintln!(
+                        "issue #51 diagnostic: mismatch at n={n} recovery_count={recovery_count} seed={seed}"
+                    );
+                    eprintln!(
+                        "  simd={} gfni={} nproc={}",
+                        crate::detect_simd(),
+                        {
+                            #[cfg(target_arch = "x86_64")]
+                            { std::is_x86_feature_detected!("gfni") }
+                            #[cfg(not(target_arch = "x86_64"))]
+                            { false }
+                        },
+                        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(0),
+                    );
+                    for attempt in 1..=5 {
+                        let retry = dec
+                            .reconstruct(|j| Ok(slices[j].clone()), &recovery_blocks)
+                            .unwrap();
+                        let retry_mismatched =
+                            retry.iter().any(|(idx, data)| data != &slices[*idx]);
+                        eprintln!(
+                            "  retry {attempt} (same recovery_blocks): {}",
+                            if retry_mismatched { "mismatch" } else { "MATCH (non-deterministic!)" }
+                        );
+                    }
+                    // Encode fresh from the same slices too, in case the bug
+                    // is in `encode` producing different bytes run-to-run
+                    // (e.g. rayon scheduling) rather than in `reconstruct`.
+                    let re_encoded = encode(&slices, slice_size, recovery_count);
+                    eprintln!(
+                        "  re-encode produced identical recovery blocks: {}",
+                        re_encoded == recovery_blocks
+                    );
+                }
+
                 prop_assert_eq!(result.len(), missing.len());
                 for (idx, data) in result {
                     prop_assert_eq!(data, slices[idx].clone(), "slice {} mismatch", idx);

--- a/crates/parmesan/src/encoder.rs
+++ b/crates/parmesan/src/encoder.rs
@@ -2701,66 +2701,86 @@ impl RecoveryEncoder {
                                 }
                             });
                     }
-                    [buf_a] => {
-                        let base = i * n_queued;
-                        buf_a.par_chunks_mut(chunk_size).enumerate().for_each(
-                            |(chunk_idx, chunk_a)| unsafe {
-                                let byte_offset = chunk_idx * chunk_size * 2;
-                                let byte_len = chunk_a.len() * 2;
-                                let blocks_64 = byte_len / 64;
-                                let remainder = byte_len % 64;
+                    // Fallback for 1 or 3 remaining buffers (2 is handled
+                    // above). Previously only `[buf_a]` (exactly 1) was
+                    // matched here, with everything else — crucially, a
+                    // remainder of *3*, which is exactly what
+                    // `par_chunks_mut(4)` leaves whenever `recovery_count %
+                    // 4 == 3` — silently falling through to an empty `_ =>
+                    // {}` arm. Those recovery blocks were never written to
+                    // at all, left as zero-initialized `buffers` entries
+                    // instead of real recovery data: this was the root
+                    // cause of issue #51's "silent data corruption" (the
+                    // decoder faithfully reconstructing from all-zero
+                    // recovery blocks). See the issue for the investigation
+                    // history — this is what every local repro attempt
+                    // couldn't catch, since it only reproduces on hardware
+                    // with AVX-512+GFNI, which none of those attempts had.
+                    rest => {
+                        for (j, buf_a) in rest.iter_mut().enumerate() {
+                            let base = (i + j) * n_queued;
+                            buf_a.par_chunks_mut(chunk_size).enumerate().for_each(
+                                |(chunk_idx, chunk_a)| unsafe {
+                                    let byte_offset = chunk_idx * chunk_size * 2;
+                                    let byte_len = chunk_a.len() * 2;
+                                    let blocks_64 = byte_len / 64;
+                                    let remainder = byte_len % 64;
 
-                                for q_idx in 0..n_queued {
-                                    let (mat_lo, mat_hi, ref table_low, ref table_high) =
-                                        all_tables[base + q_idx];
-                                    let slice_chunk =
-                                        &queued[q_idx][byte_offset..byte_offset + byte_len];
+                                    for q_idx in 0..n_queued {
+                                        let (mat_lo, mat_hi, ref table_low, ref table_high) =
+                                            all_tables[base + q_idx];
+                                        let slice_chunk =
+                                            &queued[q_idx][byte_offset..byte_offset + byte_len];
 
-                                    let mut ptr_buf = chunk_a.as_mut_ptr() as *mut __m512i;
-                                    let mut ptr_in = slice_chunk.as_ptr() as *const __m512i;
-                                    let end = ptr_in.add(blocks_64);
+                                        let mut ptr_buf = chunk_a.as_mut_ptr() as *mut __m512i;
+                                        let mut ptr_in = slice_chunk.as_ptr() as *const __m512i;
+                                        let end = ptr_in.add(blocks_64);
 
-                                    while ptr_in < end {
-                                        let input = _mm512_loadu_si512(ptr_in.cast());
-                                        let separated = _mm512_shuffle_epi8(input, deint_mask);
+                                        while ptr_in < end {
+                                            let input = _mm512_loadu_si512(ptr_in.cast());
+                                            let separated = _mm512_shuffle_epi8(input, deint_mask);
 
-                                        let v_lo =
-                                            _mm512_gf2p8affine_epi64_epi8(separated, mat_lo, 0);
-                                        let new_lo =
-                                            _mm512_xor_si512(v_lo, _mm512_bsrli_epi128::<8>(v_lo));
-                                        let v_hi =
-                                            _mm512_gf2p8affine_epi64_epi8(separated, mat_hi, 0);
-                                        let new_hi =
-                                            _mm512_xor_si512(v_hi, _mm512_bsrli_epi128::<8>(v_hi));
-                                        let out = _mm512_unpacklo_epi8(new_lo, new_hi);
-                                        let prev = _mm512_loadu_si512(ptr_buf.cast());
-                                        _mm512_storeu_si512(
-                                            ptr_buf.cast(),
-                                            _mm512_xor_si512(prev, out),
-                                        );
+                                            let v_lo =
+                                                _mm512_gf2p8affine_epi64_epi8(separated, mat_lo, 0);
+                                            let new_lo = _mm512_xor_si512(
+                                                v_lo,
+                                                _mm512_bsrli_epi128::<8>(v_lo),
+                                            );
+                                            let v_hi =
+                                                _mm512_gf2p8affine_epi64_epi8(separated, mat_hi, 0);
+                                            let new_hi = _mm512_xor_si512(
+                                                v_hi,
+                                                _mm512_bsrli_epi128::<8>(v_hi),
+                                            );
+                                            let out = _mm512_unpacklo_epi8(new_lo, new_hi);
+                                            let prev = _mm512_loadu_si512(ptr_buf.cast());
+                                            _mm512_storeu_si512(
+                                                ptr_buf.cast(),
+                                                _mm512_xor_si512(prev, out),
+                                            );
 
-                                        ptr_in = ptr_in.add(1);
-                                        ptr_buf = ptr_buf.add(1);
-                                    }
+                                            ptr_in = ptr_in.add(1);
+                                            ptr_buf = ptr_buf.add(1);
+                                        }
 
-                                    if remainder > 0 {
-                                        let ow = blocks_64 * 32;
-                                        let mut pw = chunk_a[ow..].as_mut_ptr();
-                                        let mut p_in = slice_chunk[blocks_64 * 64..].as_ptr();
-                                        let tail_end = p_in.add(remainder);
-                                        while p_in < tail_end {
-                                            let lo = *p_in as usize;
-                                            let hi = *p_in.add(1) as usize;
-                                            *pw ^= table_low[lo] ^ table_high[hi];
-                                            pw = pw.add(1);
-                                            p_in = p_in.add(2);
+                                        if remainder > 0 {
+                                            let ow = blocks_64 * 32;
+                                            let mut pw = chunk_a[ow..].as_mut_ptr();
+                                            let mut p_in = slice_chunk[blocks_64 * 64..].as_ptr();
+                                            let tail_end = p_in.add(remainder);
+                                            while p_in < tail_end {
+                                                let lo = *p_in as usize;
+                                                let hi = *p_in.add(1) as usize;
+                                                *pw ^= table_low[lo] ^ table_high[hi];
+                                                pw = pw.add(1);
+                                                p_in = p_in.add(2);
+                                            }
                                         }
                                     }
-                                }
-                            },
-                        );
+                                },
+                            );
+                        }
                     }
-                    _ => {}
                 }
             });
     }


### PR DESCRIPTION
## Summary

**This is the fix for #51**, found via the diagnostic instrumentation this PR originally only added — CI's very first run after the instrumentation landed captured everything needed to root-cause it immediately.

**Root cause:** `flush_avx512_gfni_work` groups recovery-block buffers by 4 via `par_chunks_mut(4)` and pattern-matches the resulting chunk's exact shape (`[a,b,c,d]`, `[a,b]`, `[a]`), with `_ => {}` as the catch-all. A chunk of exactly **3** buffers — produced whenever `recovery_count % 4 == 3` — matches none of the explicit arms and fell into that empty arm: those 3 recovery blocks were never computed, left as zero-initialized `Vec<u16>` instead of real data. The decoder then faithfully reconstructed garbage from all-zero recovery blocks — `Ok` with silently wrong bytes, never a panic or clean error.

This explains every fact gathered across 3 investigation rounds:
- `recovery_count % 4 == 3` in all 9 known CI failures (the only way to get a remainder of exactly 3).
- Never reproduced locally — confirmed via the new diagnostic that CI's runner uses **AVX-512+GFNI** (`nproc=4`), which none of the machines used for local investigation have.
- Every retry of identical inputs failed identically — dead code, not a race.
- Re-encoding produced byte-identical (still wrong) output — the bug is in `encode`, not `reconstruct`.

**Fix:** replaced the exactly-1-buffer arm with a `rest` arm that loops over whatever's left (1, 2, or 3), mirroring how `flush_avx2_work`'s equivalent fallback already handles its own remainder correctly. Audited every other 4-wide/8-wide SIMD kernel in the file for the same match-arm-gap pattern — all others already have a generic `rest =>` fallback or chunk by a width whose only possible remainders are covered explicitly. This was the only real gap.

**Verification:** can't run this locally (no AVX-512+GFNI hardware available in this investigation), so this relies on CI's own runner — which reproduced the failure 100% of the time it hit `recovery_count % 4 == 3` — to confirm it. It did: `known_ci_failing_inputs_from_issue_51`, `avx2_recovery_matches_scalar_across_all_group_remainders`, and `round_trip_reconstructs_arbitrary_missing_sets` all now pass on the same runner that failed them moments earlier in this same PR's history.

Instrumentation from the original commit (retry-on-mismatch determinism check, SIMD tier/GFNI/nproc reporting, CI environment logging) is kept — it's what made this fixable in one round trip instead of a tenth blind local attempt.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p parmesan-par2` locally — 99 passed, 0 failed (doesn't exercise AVX-512+GFNI on this machine)
- [x] **CI (has AVX-512+GFNI) — failed on the pre-fix commit, passes on the fix commit**, for all 3 previously-failing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnW1ANL1Nuxazk9Dpgb4VZ