### PR TITLE
pesto: fix off-by-one in compress root resolution bundling sibling folders

### DIFF
--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -2552,10 +2552,16 @@ fn collect_compress_roots(inputs: &[pesto::walk::InputFile]) -> Vec<PathBuf> {
         let root = if depth <= 1 {
             input.path.clone()
         } else {
+            // Strip `depth - 1` trailing components (everything in `name`
+            // after the top-level folder) to land on the top-level folder
+            // itself, not its parent. `ancestors().nth(k)` strips `k`
+            // trailing components, so `nth(depth)` was one level too high —
+            // it landed on the folder's *parent*, which under `--watch`
+            // silently pulled in sibling top-level entries (issue #67).
             input
                 .path
                 .ancestors()
-                .nth(depth)
+                .nth(depth - 1)
                 .filter(|p| !p.as_os_str().is_empty())
                 .map(|p| p.to_path_buf())
                 .unwrap_or_else(|| input.path.clone())
@@ -3237,8 +3243,44 @@ mod tests {
         ];
         assert_eq!(
             collect_compress_roots(&files),
-            vec![PathBuf::from("/media")]
+            vec![PathBuf::from("/media/Show")]
         );
+    }
+
+    #[test]
+    fn collect_compress_roots_nested_subfolder_strips_to_top_level() {
+        // Regression test for issue #67: a file nested two levels deep
+        // inside the top-level folder (e.g. `Test1/Subs/en.srt`) must still
+        // resolve to `Test1`, not to `Test1`'s parent.
+        let files = vec![InputFile {
+            path: PathBuf::from("/home/user/upload/Test1/Subs/en.srt"),
+            name: "Test1/Subs/en.srt".to_string(),
+        }];
+        assert_eq!(
+            collect_compress_roots(&files),
+            vec![PathBuf::from("/home/user/upload/Test1")]
+        );
+    }
+
+    #[test]
+    fn collect_compress_roots_does_not_leak_sibling_top_level_folders() {
+        // Regression test for issue #67: compressing `Test1` under
+        // `--watch` must never resolve to the watch directory itself, or
+        // sibling entries like `Test2` end up bundled into the same
+        // archive.
+        let files = vec![
+            InputFile {
+                path: PathBuf::from("/home/user/upload/Test1/movie.mkv"),
+                name: "Test1/movie.mkv".to_string(),
+            },
+            InputFile {
+                path: PathBuf::from("/home/user/upload/Test1/movie.nfo"),
+                name: "Test1/movie.nfo".to_string(),
+            },
+        ];
+        let roots = collect_compress_roots(&files);
+        assert_eq!(roots, vec![PathBuf::from("/home/user/upload/Test1")]);
+        assert!(!roots.contains(&PathBuf::from("/home/user/upload")));
     }
 
     #[test]

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -3263,6 +3263,24 @@ mod tests {
     }
 
     #[test]
+    fn collect_compress_roots_relative_folder_resolves_to_folder_itself() {
+        // A directory passed with a bare relative path (e.g. `pesto Test1
+        // --compress` run from Test1's parent) must still resolve to
+        // `Test1`, not fall back to per-file roots or an empty path.
+        let files = vec![
+            InputFile {
+                path: PathBuf::from("Test1/movie.mkv"),
+                name: "Test1/movie.mkv".to_string(),
+            },
+            InputFile {
+                path: PathBuf::from("Test1/movie.nfo"),
+                name: "Test1/movie.nfo".to_string(),
+            },
+        ];
+        assert_eq!(collect_compress_roots(&files), vec![PathBuf::from("Test1")]);
+    }
+
+    #[test]
     fn collect_compress_roots_does_not_leak_sibling_top_level_folders() {
         // Regression test for issue #67: compressing `Test1` under
         // `--watch` must never resolve to the watch directory itself, or

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -500,10 +500,16 @@ fn collect_compress_roots(inputs: &[crate::walk::InputFile]) -> Vec<PathBuf> {
         let root = if depth <= 1 {
             input.path.clone()
         } else {
+            // Strip `depth - 1` trailing components (everything in `name`
+            // after the top-level folder) to land on the top-level folder
+            // itself, not its parent. `ancestors().nth(k)` strips `k`
+            // trailing components, so `nth(depth)` was one level too high —
+            // it landed on the folder's *parent*, which under `--watch`
+            // silently pulled in sibling top-level entries (issue #67).
             input
                 .path
                 .ancestors()
-                .nth(depth)
+                .nth(depth - 1)
                 .filter(|p| !p.as_os_str().is_empty())
                 .map(|p| p.to_path_buf())
                 .unwrap_or_else(|| input.path.clone())
@@ -591,5 +597,77 @@ async fn versioned_nzb_path(base: &Path) -> PathBuf {
         if n > 999 {
             return dir.join(format!("{stem}.nzb"));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::walk::InputFile;
+
+    #[test]
+    fn collect_compress_roots_loose_file_is_the_file_itself() {
+        let files = vec![InputFile {
+            path: PathBuf::from("/media/downloads/movie.mkv"),
+            name: "movie.mkv".to_string(),
+        }];
+        assert_eq!(
+            collect_compress_roots(&files),
+            vec![PathBuf::from("/media/downloads/movie.mkv")]
+        );
+    }
+
+    #[test]
+    fn collect_compress_roots_directory_input_strips_correctly() {
+        let files = vec![
+            InputFile {
+                path: PathBuf::from("/media/Show/ep01.mkv"),
+                name: "Show/ep01.mkv".to_string(),
+            },
+            InputFile {
+                path: PathBuf::from("/media/Show/ep02.mkv"),
+                name: "Show/ep02.mkv".to_string(),
+            },
+        ];
+        assert_eq!(
+            collect_compress_roots(&files),
+            vec![PathBuf::from("/media/Show")]
+        );
+    }
+
+    #[test]
+    fn collect_compress_roots_nested_subfolder_strips_to_top_level() {
+        // Regression test for issue #67: a file nested two levels deep
+        // inside the top-level folder (e.g. `Test1/Subs/en.srt`) must still
+        // resolve to `Test1`, not to `Test1`'s parent.
+        let files = vec![InputFile {
+            path: PathBuf::from("/home/user/upload/Test1/Subs/en.srt"),
+            name: "Test1/Subs/en.srt".to_string(),
+        }];
+        assert_eq!(
+            collect_compress_roots(&files),
+            vec![PathBuf::from("/home/user/upload/Test1")]
+        );
+    }
+
+    #[test]
+    fn collect_compress_roots_does_not_leak_sibling_top_level_folders() {
+        // Regression test for issue #67: compressing `Test1` under
+        // `--watch` must never resolve to the watch directory itself, or
+        // sibling entries like `Test2` end up bundled into the same
+        // archive.
+        let files = vec![
+            InputFile {
+                path: PathBuf::from("/home/user/upload/Test1/movie.mkv"),
+                name: "Test1/movie.mkv".to_string(),
+            },
+            InputFile {
+                path: PathBuf::from("/home/user/upload/Test1/movie.nfo"),
+                name: "Test1/movie.nfo".to_string(),
+            },
+        ];
+        let roots = collect_compress_roots(&files);
+        assert_eq!(roots, vec![PathBuf::from("/home/user/upload/Test1")]);
+        assert!(!roots.contains(&PathBuf::from("/home/user/upload")));
     }
 }

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -651,6 +651,24 @@ mod tests {
     }
 
     #[test]
+    fn collect_compress_roots_relative_folder_resolves_to_folder_itself() {
+        // A directory passed with a bare relative path (e.g. `pesto Test1
+        // --compress` run from Test1's parent) must still resolve to
+        // `Test1`, not fall back to per-file roots or an empty path.
+        let files = vec![
+            InputFile {
+                path: PathBuf::from("Test1/movie.mkv"),
+                name: "Test1/movie.mkv".to_string(),
+            },
+            InputFile {
+                path: PathBuf::from("Test1/movie.nfo"),
+                name: "Test1/movie.nfo".to_string(),
+            },
+        ];
+        assert_eq!(collect_compress_roots(&files), vec![PathBuf::from("Test1")]);
+    }
+
+    #[test]
     fn collect_compress_roots_does_not_leak_sibling_top_level_folders() {
         // Regression test for issue #67: compressing `Test1` under
         // `--watch` must never resolve to the watch directory itself, or


### PR DESCRIPTION
## Summary
- `collect_compress_roots()` stripped `depth` trailing path components instead of `depth - 1`, landing one level above the top-level entry being uploaded. Under `--watch`, that parent is the watch directory itself, so `--compress` silently archived every sibling folder present there alongside the one actually being posted (e.g. `Test1.nzb` ended up containing both `Test1` and `Test2`).
- Fixed in both copies of the helper (`src/bin/pesto.rs` and `src/upload.rs`, the latter shared with `upapasta`).
- Added regression tests: nested subfolder resolution, the sibling-leak case from the report, and a relative-path (single-component) folder input case.

Fixes #67.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p pesto-poster` (436 lib tests, 20 bin tests incl. the new regression tests, all integration suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsPWHDfRzZVGRSENf2HDJ3