### PR TITLE
pesto: always emit (part/total) in subjects, fixing indexer grouping gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -541,6 +541,14 @@ GitHub issue #68, which was closed as indexer-side (NZBIndex/Binsearch key their
 test against NZBIndex showed no change in that specific grouping gap. The flag stays available (and now on by
 default for `none`/`full-shared`) for compatibility with any other indexer/tool that does read it.
 
+**Update — the actual grouping gap was found, and it's unrelated to `--file-counter`:** the bare PAR2 index file
+(and any other single-segment file posted alongside multi-segment siblings) had a subject shaped differently
+from the rest of the release — `"name" yEnc`, no `(part/total)` trailer, per the yEnc spec's own allowance for
+omitting it on a single-article file. `default_subject()` now always emits `(part/total)`, including `(1/1)`.
+Confirmed live against Binsearch: a `--compress`/`--par2` release went from 8 of 9 files grouped (bare `.par2`
+excluded) to 9 of 9 once every file's subject had the same shape. See the CHANGELOG `[Unreleased]` entry for
+issue #68.
+
 References:
 - yEnc draft v1.3: <http://www.yenc.org/yenc-draft.1.3.txt>
 - Mirror: <https://github.com/caronc/newsreap/blob/master/docs/yenc-draft.1.3.txt>

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -28,6 +28,22 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
   the merged release would need a different password per episode. An
   explicit `--password VALUE` also keeps behaving as before: reused verbatim
   by every entry in the run, `--each`/`--season`/`--watch` alike.
+- **A single-segment file's subject now always carries `(1/1)` instead of
+  omitting it, fixing an indexer grouping gap tracked in #68**: the yEnc
+  spec allows dropping the `(part/total)` trailer for a file that fits in
+  one article — the bare PAR2 index in a `--par2` release is the common
+  case — and `default_subject()` used to do exactly that. That left the
+  single-segment file's subject shaped differently from every multi-segment
+  sibling in the same release (`.rar`, each `.volNNN+MMM.par2`). Confirmed
+  live against Binsearch: some indexers' "collection cleaning" regexes key
+  off that trailer to recover a release's shared base name, so the
+  differently-shaped subject hashed the file into its own collection
+  instead of grouping it with the rest — a real release with `--compress`
+  went from "8 of 9 files grouped" (bare `.par2` excluded) to "9 of 9"
+  once every file emitted `(1/1)`/`(part/total)` uniformly. No downside:
+  `(1/1)` is still a spec-valid subject, and reading NZBs/subjects without
+  it (other tools, older pesto releases) is unaffected — `nzb::strip_part_suffix`
+  already handled both forms.
 
 ## [0.5.1] — 2026-08-03
 

--- a/crates/pesto/src/article.rs
+++ b/crates/pesto/src/article.rs
@@ -215,13 +215,25 @@ pub fn random_from() -> String {
 
 /// Build a default subject line for one part of a file.
 ///
-/// Follows the yEnc draft v1.3 specification:
+/// Loosely follows the yEnc draft v1.3 specification:
 /// - Primary: <http://www.yenc.org/yenc-draft.1.3.txt>
 /// - Mirror:  <https://github.com/caronc/newsreap/blob/master/docs/yenc-draft.1.3.txt>
 ///
-/// Formats:
-/// - Single-part: `"name" yEnc`
-/// - Multi-part:  `"name" yEnc (part/total)`
+/// Format: `"name" yEnc (part/total)`, always — including `(1/1)` for a file
+/// that fits in a single segment. The spec itself allows omitting the
+/// `(part/total)` trailer in that case, and pesto used to; a small file (the
+/// bare PAR2 index in a `--compress`/`--par2` release is the common case, but
+/// any file — `.nfo`, `.sfv`, a loose small upload — posted single-segment
+/// alongside multi-segment siblings hits the same thing) then had a subject
+/// shaped differently from the rest of the release. Confirmed live against
+/// Binsearch (issue #68): several indexers' "collection cleaning" regexes
+/// key off that trailer to recover a release's shared base name, so the
+/// single-segment file's differently-shaped subject hashed it into a
+/// separate collection — it never joined the rest of the release, even
+/// though every file shared the same name/prefix otherwise. Always emitting
+/// `(1/1)` gives every file in a release the same subject shape and fixed
+/// that grouping gap in a real repro; no known downside, since `(1/1)` is
+/// still a spec-valid subject.
 ///
 /// `file_counter`, when `Some((filenum, total_files))`, prepends a
 /// `[filenum/total_files] ` release-wide file counter — `filenum` is this
@@ -236,11 +248,7 @@ pub fn default_subject(
     total: u32,
     file_counter: Option<(u32, u32)>,
 ) -> String {
-    let base = if total > 1 {
-        format!("\"{name}\" yEnc ({part}/{total})")
-    } else {
-        format!("\"{name}\" yEnc")
-    };
+    let base = format!("\"{name}\" yEnc ({part}/{total})");
     match file_counter {
         Some((filenum, total_files)) => format!("[{filenum}/{total_files}] - {base}"),
         None => base,
@@ -335,7 +343,10 @@ mod tests {
 
     #[test]
     fn default_subject_handles_single_and_multi_part() {
-        assert_eq!(default_subject("file.bin", 1, 1, None), "\"file.bin\" yEnc");
+        assert_eq!(
+            default_subject("file.bin", 1, 1, None),
+            "\"file.bin\" yEnc (1/1)"
+        );
         assert_eq!(
             default_subject("file.bin", 2, 5, None),
             "\"file.bin\" yEnc (2/5)"
@@ -350,7 +361,7 @@ mod tests {
         );
         assert_eq!(
             default_subject("file.bin", 1, 1, Some((1, 1))),
-            "[1/1] - \"file.bin\" yEnc"
+            "[1/1] - \"file.bin\" yEnc (1/1)"
         );
     }
 
@@ -427,10 +438,14 @@ mod tests {
     }
 
     #[test]
-    fn default_subject_single_part_has_no_parens() {
+    fn default_subject_single_part_still_carries_1_of_1() {
+        // Regression for issue #68: a single-segment file (e.g. the bare
+        // PAR2 index) must carry the same `(part/total)` shape as every
+        // multi-segment sibling in the release, or some indexers' subject
+        // parsing hashes it into a separate collection instead of grouping
+        // it with the rest — confirmed live against Binsearch.
         let s = default_subject("movie.mkv", 1, 1, None);
-        assert!(!s.contains("(1/1)"));
-        assert_eq!(s, "\"movie.mkv\" yEnc");
+        assert_eq!(s, "\"movie.mkv\" yEnc (1/1)");
     }
 
     #[test]

--- a/crates/pesto/src/nzb.rs
+++ b/crates/pesto/src/nzb.rs
@@ -648,7 +648,7 @@ mod tests {
         };
         let xml = generate(&["alt.test".into()], &[segment], &no_meta());
         // The wire subject is obfuscated; the NZB always carries the real filename.
-        assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc\""));
+        assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc (1/1)\""));
         assert!(xml.contains("name=\"secret-movie.mkv\""));
         assert!(!xml.contains("subject=\"secret-movie.mkv\""));
     }
@@ -673,7 +673,7 @@ mod tests {
         };
         let xml = generate(&["alt.test".into()], &[segment], &no_meta());
         // Subject on the wire is obfuscated; NZB name= always uses the real filename.
-        assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc\""));
+        assert!(xml.contains("subject=\"&quot;deadbeefcafe0000&quot; yEnc (1/1)\""));
         assert!(xml.contains("name=\"secret-movie.mkv\""));
         assert!(!xml.contains("name=\"deadbeefcafe0000\""));
     }
@@ -753,14 +753,17 @@ mod tests {
     }
 
     #[test]
-    fn single_part_subject_has_no_part_indicator() {
+    fn single_part_subject_still_carries_1_of_1() {
+        // Regression for issue #68: a single-segment file's subject must
+        // have the same `(part/total)` shape as multi-segment siblings, or
+        // some indexers hash it into a separate collection instead of
+        // grouping it with the rest of the release.
         let xml = generate(
             &["alt.test".into()],
             &[seg("file.bin", 1, 1, "<id@x>")],
             &no_meta(),
         );
-        assert!(xml.contains("subject=\"&quot;file.bin&quot; yEnc\""));
-        assert!(!xml.contains("(1/1)"));
+        assert!(xml.contains("subject=\"&quot;file.bin&quot; yEnc (1/1)\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `default_subject()` used to omit the `(part/total)` trailer for a single-segment file, per the yEnc spec's own allowance — leaving that file's subject shaped differently from every multi-segment sibling in the same release (`.rar`, each `.volNNN+MMM.par2`). The bare PAR2 index file is the common case that hits this (small enough to fit in one article).
- Confirmed live against Binsearch: some indexers' "collection cleaning" regexes key off that trailer to recover a release's shared base name, so the differently-shaped subject hashed the file into its own collection instead of grouping it with the rest.
- Fix: `default_subject()` now always emits `(part/total)`, including `(1/1)`. A real `--compress`/`--par2` test release went from 8 of 9 files grouped (bare `.par2` excluded) to 9 of 9 once every file's subject had the same shape.
- No downside: `(1/1)` is still spec-valid, and `nzb::strip_part_suffix` already parses subjects with or without the trailer, so reading older NZBs/other tools' subjects is unaffected.
- Also updates `ROADMAP.md`'s "Subject file counter" section, which had the previous (now superseded) conclusion that this grouping gap was purely indexer-side and unrelated to anything pesto controls.

Fixes #68.

## Test plan
- [x] Updated `article::tests` (`default_subject_handles_single_and_multi_part`, `default_subject_with_file_counter_prefixes_release_position`, renamed `default_subject_single_part_has_no_parens` → `default_subject_single_part_still_carries_1_of_1`) for the new subject shape
- [x] Updated `nzb::tests` (`obfuscated_subject_keeps_real_name_in_attribute`, `full_obfuscation_preserves_real_name_in_nzb`, renamed `single_part_subject_has_no_part_indicator` → `single_part_subject_still_carries_1_of_1`)
- [x] Two live end-to-end test posts to `alt.binaries.test` (before/after), checked against Binsearch — see issue #68 for the full before/after grouping comparison
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsPWHDfRzZVGRSENf2HDJ3