### PR TITLE
pesto: add --tmdb-id, --imdb, --tvdb, --mal aliases

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -283,10 +283,10 @@ groups = ["alt.binaries.test"]
 #   PESTO_OBFUSCATE    — obfuscation mode in use: none, full, or paranoid
 #   PESTO_PAR2         — PAR2 redundancy percentage (e.g. 10)
 #   PESTO_TAGS         — space-separated list of NZB tags (empty when none)
-#   PESTO_TMDB_ID      — value of --tmdb (empty when not set)
-#   PESTO_IMDB_ID      — value of --imdb-id (empty when not set)
-#   PESTO_TVDB_ID      — value of --tvdb-id (empty when not set)
-#   PESTO_MAL_ID       — value of --mal-id (empty when not set)
+#   PESTO_TMDB_ID      — value of --tmdb / --tmdb-id (empty when not set)
+#   PESTO_IMDB_ID      — value of --imdb-id / --imdb (empty when not set)
+#   PESTO_TVDB_ID      — value of --tvdb-id / --tvdb (empty when not set)
+#   PESTO_MAL_ID       — value of --mal-id / --mal (empty when not set)
 #
 # Use case: query NZBHydra2 or Prowlarr before uploading to avoid duplicates.
 # Example (abort if the release is already indexed):

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,12 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Added
+- **`--tmdb-id`, `--imdb`, `--tvdb`, `--mal` aliases** for `--tmdb`,
+  `--imdb-id`, `--tvdb-id`, and `--mal-id` respectively: the `-id` suffix
+  was inconsistent across the four flags (only `--tmdb` lacked it), so both
+  spellings now work for all of them.
+
 ## [0.5.4] — 2026-08-04
 
 ### Added

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -767,10 +767,10 @@ Environment variables available to the pre-hook:
 | `PESTO_OBFUSCATE` | Obfuscation mode in use: `none`, `full`, or `paranoid` |
 | `PESTO_PAR2` | PAR2 redundancy percentage (e.g. `10`) |
 | `PESTO_TAGS` | Space-separated list of NZB tags (empty when none) |
-| `PESTO_TMDB_ID` | Value of `--tmdb` (empty when not set) |
-| `PESTO_IMDB_ID` | Value of `--imdb-id` (empty when not set) |
-| `PESTO_TVDB_ID` | Value of `--tvdb-id` (empty when not set) |
-| `PESTO_MAL_ID` | Value of `--mal-id` (empty when not set) |
+| `PESTO_TMDB_ID` | Value of `--tmdb` / `--tmdb-id` (empty when not set) |
+| `PESTO_IMDB_ID` | Value of `--imdb-id` / `--imdb` (empty when not set) |
+| `PESTO_TVDB_ID` | Value of `--tvdb-id` / `--tvdb` (empty when not set) |
+| `PESTO_MAL_ID` | Value of `--mal-id` / `--mal` (empty when not set) |
 
 > `PESTO_NZB`, `PESTO_NFO`, and `PESTO_PASSWORD` are **not** available in the
 > pre-hook — the NZB and NFO don't exist yet, and the archive password is only
@@ -798,10 +798,10 @@ following environment variables:
 | `PESTO_OBFUSCATE` | Obfuscation mode in use: `none`, `full`, or `paranoid` |
 | `PESTO_PAR2` | PAR2 redundancy percentage (e.g. `10`) |
 | `PESTO_TAGS` | Space-separated list of NZB tags (empty when none) |
-| `PESTO_TMDB_ID` | Value of `--tmdb` (empty when not set) |
-| `PESTO_IMDB_ID` | Value of `--imdb-id` (empty when not set) |
-| `PESTO_TVDB_ID` | Value of `--tvdb-id` (empty when not set) |
-| `PESTO_MAL_ID` | Value of `--mal-id` (empty when not set) |
+| `PESTO_TMDB_ID` | Value of `--tmdb` / `--tmdb-id` (empty when not set) |
+| `PESTO_IMDB_ID` | Value of `--imdb-id` / `--imdb` (empty when not set) |
+| `PESTO_TVDB_ID` | Value of `--tvdb-id` / `--tvdb` (empty when not set) |
+| `PESTO_MAL_ID` | Value of `--mal-id` / `--mal` (empty when not set) |
 
 Scripts must have the executable bit set on Unix (`chmod +x`). On Windows,
 files with `.exe`, `.cmd`, `.bat`, `.ps1`, or `.py` extensions are recognised

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -274,25 +274,27 @@ struct Cli {
     /// `movie/<id>` or `tv/<id>` (`movie:<id>` / `tv:<id>` also accepted).
     /// When `--nzb-category` is not set, the category defaults to `movies`
     /// or `tv` accordingly. Also added as a line in the `.nfo` when `--nfo`
-    /// is set.
-    #[arg(long, value_name = "TYPE/ID")]
+    /// is set. Aliased as `--tmdb-id`.
+    #[arg(long, alias = "tmdb-id", value_name = "TYPE/ID")]
     tmdb: Option<String>,
 
     /// IMDb ID written to `<meta type="imdbid">` in the `.nzb`, e.g.
     /// `tt1234567`. The `tt` prefix is optional and added automatically
     /// (`133093` normalizes to `tt0133093`). Also added as a line in the
-    /// `.nfo` when `--nfo` is set.
-    #[arg(long, value_name = "ID")]
+    /// `.nfo` when `--nfo` is set. Aliased as `--imdb`.
+    #[arg(long, alias = "imdb", value_name = "ID")]
     imdb_id: Option<String>,
 
     /// TheTVDB ID written to `<meta type="tvdbid">` in the `.nzb`, e.g.
     /// `81189`. Also added as a line in the `.nfo` when `--nfo` is set.
-    #[arg(long, value_name = "ID")]
+    /// Aliased as `--tvdb`.
+    #[arg(long, alias = "tvdb", value_name = "ID")]
     tvdb_id: Option<String>,
 
     /// MyAnimeList ID written to `<meta type="malid">` in the `.nzb`, e.g.
     /// `1535`. Also added as a line in the `.nfo` when `--nfo` is set.
-    #[arg(long, value_name = "ID")]
+    /// Aliased as `--mal`.
+    #[arg(long, alias = "mal", value_name = "ID")]
     mal_id: Option<String>,
 
     /// `Date:` header for each article: `now` (current time), `random`


### PR DESCRIPTION
## Summary
- `--tmdb` was the only one of the four metadata flags without the `-id` suffix (`--imdb-id`, `--tvdb-id`, `--mal-id` already had it) — a recurring point of confusion.
- Adds the missing alias in both directions via clap's `alias`, so `--tmdb`/`--tmdb-id`, `--imdb-id`/`--imdb`, `--tvdb-id`/`--tvdb`, and `--mal-id`/`--mal` all work interchangeably. No flag was renamed, so this is fully backward compatible.
- Matches the short-form naming used by `Upload-Assistant` (wastaken7/Upload-Assistant).
- Updated `--help` (auto-generated from doc comments), `crates/pesto/README.md` hook env-var tables, and `config.example.toml`, plus a CHANGELOG entry.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p pesto-poster --all-targets -- -D warnings`
- [x] `cargo test -p pesto-poster`
- [x] `cargo run -p pesto-poster --bin pesto -- --help` shows the aliases in each flag's description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTwUawD3rpWWZDoVevm11