### PR TITLE
pesto: give --par2-before-upload back its RAM budget, fix nfo hang perception

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -570,14 +570,25 @@ before, NZBIndex/Binsearch's own codebase is unconfirmed (proprietary) — this 
 indexer in the same family, not proof for those two specifically.
 
 Rather than ask users to tune `--memory-limit` per release, `--par2-before-upload` (`posting.par2_before_upload`,
-default off) makes pesto avoid the gap itself: when set, `producer` suppresses all data-article and PAR2-file
-posting during the encode pass(es) — every pass just reads and encodes — then posts the data files followed by the
-already-generated index/volumes once generation is fully done, so the whole release goes out back to back with no
-gap regardless of how many passes generation needed. The default (interleaved) pipeline is unchanged for the common
-single-pass case. No special `--resume` handling was needed: `producer` already regenerates PAR2 deterministically
-from scratch on every resumed run (same bytes, given the same input/config and the already-reused `archive_stem`/
-`release_prefix`), and the existing per-article resume check at the worker level — not `producer` — is what skips
-already-posted segments, generically, regardless of when in the run they get queued.
+default off) makes pesto avoid the gap itself: when set, `post_files_with_progress_and_cancel` runs `producer` once
+with `tx_opt: None` to generate every PAR2 file first — no connection pool exists yet at this point, nothing is
+posted — then spins up the real connection pool and calls `post_pregenerated_release` to post the data files
+followed by the already-generated index/volumes, back to back with no gap regardless of how many read passes
+generation needed. The default (interleaved) pipeline, where `producer` computes PAR2 concurrently with posting in
+a single pass, is unchanged for the common case. No special `--resume` handling was needed: PAR2 generation is
+already redone deterministically on every resumed run (same bytes, given the same input/config and the
+already-reused `archive_stem`/`release_prefix`), and the existing per-article resume check at the worker level —
+not `producer` — is what skips already-posted segments, generically, regardless of when in the run they get queued.
+
+**Follow-up — the generation phase also stopped reserving RAM (and opening connections) for a pool that doesn't
+exist yet.** `producer`'s PAR2 memory-budget calculation reserves ~8 MiB per configured connection
+(`connection_overhead_reserve`) to leave room for their TLS/article buffers under load — a real cost when
+connections are actively posting, but dead weight during `--par2-before-upload`'s generation phase, where nothing
+is posted yet. Worse, the connection pool used to get created *before* generation started at all, so those
+connections sat open and idle (needing keepalives) for however long generation took. `producer` now takes an
+explicit `active_connections` parameter instead of reading `shared.config.total_connections()` directly, and
+`post_files_with_progress_and_cancel` passes `0` for the generation-only call — real budget back for PAR2, one
+fewer read pass on RAM-constrained hosts — and only builds the actual connection pool once generation is done.
 
 References:
 - yEnc draft v1.3: <http://www.yenc.org/yenc-draft.1.3.txt>

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,24 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Fixed
+- **`--nfo` no longer looks hung while `bdinfo` scans a large Blu-ray disc.**
+  NFO generation ran `bdinfo`/`mediainfo` synchronously with no output in
+  between, which on a big disc could sit silent long enough to look like the
+  process had frozen. Prints a message before starting and a heartbeat every
+  10 seconds while it works.
+
+### Changed
+- **`--par2-before-upload` no longer reserves PAR2 memory budget for
+  connections that aren't open yet, and no longer opens them during
+  generation at all.** Previously the connection pool was created (and its
+  8 MiB/connection overhead reserved against `--memory-limit`) before PAR2
+  generation started, even though nothing gets posted until generation is
+  fully done — wasted budget that could otherwise mean fewer read passes,
+  and idle connections sitting open (and needing keepalives) for however
+  long generation takes. The pool now spins up only once generation has
+  finished.
+
 ## [0.5.5] — 2026-08-04
 
 ### Added

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -1448,7 +1448,26 @@ async fn run_single_upload(
                     .map(|d| d.join(format!("{entry_label}.nfo")))
             });
         if let Some(ref nfo_out) = base {
-            match pesto::nfo::generate(entry_paths) {
+            // `nfo::generate` blocks on `bdinfo`/`mediainfo`, which can take
+            // a while on a large Blu-ray disc — long enough that, with no
+            // output in between, it looks like the process hung. Run it on
+            // a blocking-pool thread and print a heartbeat every 10s so
+            // there's always something on screen while it works.
+            println!(
+                "generating nfo (running bdinfo — this can take a while on large Blu-ray discs)..."
+            );
+            let nfo_paths = entry_paths.to_vec();
+            let nfo_handle = tokio::task::spawn_blocking(move || pesto::nfo::generate(&nfo_paths));
+            tokio::pin!(nfo_handle);
+            let nfo_content = loop {
+                tokio::select! {
+                    res = &mut nfo_handle => break res.context("nfo generation task panicked")?,
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                        println!("... still generating nfo, please wait");
+                    }
+                }
+            };
+            match nfo_content {
                 Some(content) => match pesto::nfo::write(
                     nfo_out,
                     &format!("{}{content}", nfo_metadata_header(config)),

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -765,6 +765,13 @@ pub async fn post_files_with_progress_and_cancel(
     static RUN_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let run_id = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
 
+    // Computed once, unconditionally, and reused below for `total_files`,
+    // `par2_bytes_hint`, and the `--par2-before-upload` decision.
+    // `par2_geometry` is metadata-only (file sizes + config, no I/O — see
+    // its doc comment) so this is exact, not an estimate, and safe to
+    // compute before `producer` actually runs the encoder.
+    let (par2_slice_size, _total_slices, recovery_count) = par2_geometry(&metas, config);
+
     // Total release file count for `--file-counter`: data files, plus (when
     // there's any recovery data to write) the index file and every volume
     // `plan_volumes` will produce. Gated on `recovery_count > 0`, exactly
@@ -772,12 +779,8 @@ pub async fn post_files_with_progress_and_cancel(
     // `config.par2 > 0` directly, since `par2_geometry` can still land on
     // zero recovery blocks with PAR2 "on" (e.g. a tiny release where
     // `total_slices * pct / 100` floors to 0), in which case `producer`
-    // never writes an index or volumes at all. `par2_geometry` is
-    // metadata-only (file sizes + config, no I/O — see its doc comment) so
-    // this is exact, not an estimate, and safe to compute before `producer`
-    // actually runs the encoder.
+    // never writes an index or volumes at all.
     let total_files: u32 = if config.file_counter {
-        let (_, _, recovery_count) = par2_geometry(&metas, config);
         let par2_file_count = if recovery_count > 0 {
             1 + layout::plan_volumes(recovery_count as u32).len()
         } else {
@@ -835,8 +838,7 @@ pub async fn post_files_with_progress_and_cancel(
                      // once PAR2 encoding finishes and its volumes get queued for posting.
     let (par2_bytes_hint, par2_segments_hint) =
         if config.par2 > 0 && !config.par2_only && !config.dry_run {
-            let (slice_size, _total_slices, recovery_count) = par2_geometry(&metas, config);
-            let recovery_bytes = recovery_count as u64 * slice_size as u64;
+            let recovery_bytes = recovery_count as u64 * par2_slice_size as u64;
             let packet_overhead = recovery_count as u64 * packet::HEADER_LEN as u64;
             // Small fixed overhead for the index file's Main/FileDesc/IFSC
             // packets — negligible next to recovery_bytes, not worth
@@ -905,6 +907,31 @@ pub async fn post_files_with_progress_and_cancel(
         })
     };
 
+    // `--par2-before-upload`: when there's real recovery data to generate,
+    // run PAR2 generation to completion *before* opening any NNTP
+    // connection. `producer(.., None, .., 0)` writes every index/volume
+    // file to `par2_dir` without posting (the `tx_opt: None` path already
+    // used by `--par2-only`), and `active_connections: 0` means the PAR2
+    // memory budget isn't shrunk to make room for connections that don't
+    // exist yet — the connection pool and its workers only spin up further
+    // down, once this is done. `post_pregenerated_release` then posts the
+    // data files followed by the files this call already wrote, back to
+    // back with no gap. See `ROADMAP.md` and GitHub issue #68.
+    let will_defer = config.par2_before_upload && recovery_count > 0 && worker_count > 0;
+    let par2_dir = par2_temp_dir(config.par2_temp_dir.as_deref(), run_id);
+    let mut failure_reason: Option<String> = None;
+    if will_defer {
+        if let Err(e) = producer(metas.clone(), None, shared.clone(), 0).await {
+            let description = format!("producer error: {e:#}");
+            error!(error = %e, "producer error");
+            shared.cancelled.store(true, Ordering::Relaxed);
+            shared.emit(ProgressEvent::Failed {
+                description: description.clone(),
+            });
+            failure_reason = Some(description);
+        }
+    }
+
     // Streaming check: every segment that gets a clean `240` is queued here
     // and STAT-checked a few seconds later, concurrently with the rest of
     // the upload, instead of waiting for the whole run to finish.
@@ -942,20 +969,41 @@ pub async fn post_files_with_progress_and_cancel(
         None
     };
 
-    // Producer runs in this thread
-    let mut failure_reason: Option<String> = None;
-    if let Err(e) = producer(metas, tx_opt, shared.clone()).await {
-        let description = format!("producer error: {e:#}");
-        // `Failed` alone only reaches `--output-format json` consumers; log
-        // it too so the reason survives in the session log file even when
-        // the human-readable renderer (which only shows it via `Failed`,
-        // see `ui::terminal`) is what's on screen.
-        error!(error = %e, "producer error");
-        shared.cancelled.store(true, Ordering::Relaxed);
-        shared.emit(ProgressEvent::Failed {
-            description: description.clone(),
-        });
-        failure_reason = Some(description);
+    // Producer (or, when PAR2 was already generated above, the
+    // already-generated-files poster) runs in this thread. Skipped entirely
+    // if the generation phase above already failed — nothing valid to post.
+    if failure_reason.is_none() {
+        let result = if will_defer {
+            let result = match tx_opt.as_ref() {
+                Some(tx) => {
+                    post_pregenerated_release(&metas, &par2_dir, recovery_count, tx, &shared).await
+                }
+                None => Ok(()),
+            };
+            // Unlike `producer`, which owns (and so drops) `tx_opt` itself,
+            // `post_pregenerated_release` only borrows `tx` — drop the real
+            // owner explicitly now that posting is done. Without this the
+            // channel never closes, `rx.recv()` in each worker never sees
+            // the end of the stream, and the join loop below hangs forever
+            // waiting for workers that are just idling.
+            drop(tx_opt);
+            result
+        } else {
+            producer(metas, tx_opt, shared.clone(), total_conns).await
+        };
+        if let Err(e) = result {
+            let description = format!("producer error: {e:#}");
+            // `Failed` alone only reaches `--output-format json` consumers; log
+            // it too so the reason survives in the session log file even when
+            // the human-readable renderer (which only shows it via `Failed`,
+            // see `ui::terminal`) is what's on screen.
+            error!(error = %e, "producer error");
+            shared.cancelled.store(true, Ordering::Relaxed);
+            shared.emit(ProgressEvent::Failed {
+                description: description.clone(),
+            });
+            failure_reason = Some(description);
+        }
     }
 
     for handle in handles {
@@ -1505,6 +1553,14 @@ async fn producer(
     metas: Vec<Arc<FileMeta>>,
     tx_opt: Option<tokio::sync::mpsc::Sender<PostTask>>,
     shared: Arc<Shared>,
+    // Connections actually competing for RAM *right now*, used to size the
+    // PAR2 memory budget (see `connection_overhead_reserve`) — normally
+    // `shared.config.total_connections()`, but the caller passes `0` for a
+    // `--par2-before-upload` generation-only call (`tx_opt: None`), since no
+    // connection pool exists yet at that point (see
+    // `post_files_with_progress_and_cancel`): reserving RAM for connections
+    // that aren't open yet would just force more read passes than necessary.
+    active_connections: usize,
 ) -> Result<()> {
     let article_size = shared.config.article_size;
 
@@ -1543,19 +1599,6 @@ async fn producer(
         "PAR2 geometry"
     );
 
-    // `--par2-before-upload`: when there's actual recovery data to generate,
-    // suppress data-article and PAR2-file posting during the encode pass(es)
-    // below — every pass just reads/encodes, nothing goes out over the wire —
-    // then post everything (data files, then the already-written index and
-    // volumes) back to back once generation is fully done. With
-    // `recovery_count == 0` there's nothing to defer around, so posting stays
-    // interleaved as usual (matches the no-PAR2 case already being a no-op
-    // for the interleaved path). Also gated on `tx_opt` actually being a
-    // posting channel — `--par2-only` already never posts (`tx_opt` is
-    // `None`), so there is nothing to defer there either.
-    let defer_data_posting =
-        shared.config.par2_before_upload && recovery_count > 0 && tx_opt.is_some();
-
     // Auto-detect safe RAM limit if not specified (70% of available RAM).
     // `available_memory()` reports the host's RAM and ignores cgroup/container
     // limits, so on a memory-limited container it can report far more than is
@@ -1574,8 +1617,7 @@ async fn producer(
     } else {
         parmesan::performance_core_count()
     };
-    let overhead_reserve =
-        connection_overhead_reserve(shared.config.total_connections(), reserve_threads);
+    let overhead_reserve = connection_overhead_reserve(active_connections, reserve_threads);
     let as_budget = address_space_budget(overhead_reserve);
     let memory_limit = match shared.config.par2_memory_limit {
         Some(limit) => {
@@ -1591,7 +1633,7 @@ async fn producer(
                         crate::progress::format_size(address_space_limit().unwrap_or_default()),
                         crate::progress::format_size(budget),
                         crate::progress::format_size(overhead_reserve),
-                        shared.config.total_connections(),
+                        active_connections,
                         reserve_threads,
                     );
                 }
@@ -1812,7 +1854,7 @@ async fn producer(
                     }
 
                     i += 1;
-                    if pass_idx == 0 && !defer_data_posting {
+                    if pass_idx == 0 {
                         if let Some(tx) = &tx_opt {
                             // Send buf to the worker; the worker will return it to
                             // the pool (Phase 12b) after encoding the article.
@@ -1845,10 +1887,7 @@ async fn producer(
                             });
                         }
                     } else {
-                        // Subsequent pass, or `--par2-before-upload` deferring
-                        // pass 0's data articles until PAR2 is fully generated
-                        // (posted afterward by `post_data_files`): buffer no
-                        // longer needed here, return it to the pool.
+                        // Subsequent pass: buffer no longer needed; return to pool.
                         shared.release_buffer(buf);
                     }
                 }
@@ -1977,31 +2016,23 @@ async fn producer(
                 let index_name = layout::index_name(par2_base(&metas[0].real_name));
                 let index_path = par2_dir.as_ref().unwrap().join(&index_name);
                 tokio::fs::write(&index_path, &base_packets).await?;
-                // `defer_data_posting`: don't queue the index file yet — it
-                // (and every volume below) gets posted after the fact by the
-                // `post_data_files` + pre-generated-file block at the end of
-                // this function, once every pass has finished and PAR2
-                // generation is fully done.
                 if let Some(tx) = &tx_opt {
-                    if !defer_data_posting {
-                        // In `FullShared` mode, root the wire name at the release
-                        // prefix instead of the (possibly real) on-disk base name,
-                        // so this index file groups with the rest of the release.
-                        let wire_override =
-                            shared.release_prefix.as_deref().map(layout::index_name);
-                        // The index file is the release's first file after the
-                        // data files — see `Shared::total_files`'s doc comment.
-                        let file_index = metas.len() as u32 + 1;
-                        push_par2_file(
-                            &index_path,
-                            index_name,
-                            wire_override,
-                            file_index,
-                            &shared,
-                            tx,
-                        )
-                        .await?;
-                    }
+                    // In `FullShared` mode, root the wire name at the release
+                    // prefix instead of the (possibly real) on-disk base name,
+                    // so this index file groups with the rest of the release.
+                    let wire_override = shared.release_prefix.as_deref().map(layout::index_name);
+                    // The index file is the release's first file after the
+                    // data files — see `Shared::total_files`'s doc comment.
+                    let file_index = metas.len() as u32 + 1;
+                    push_par2_file(
+                        &index_path,
+                        index_name,
+                        wire_override,
+                        file_index,
+                        &shared,
+                        tx,
+                    )
+                    .await?;
                 }
             }
 
@@ -2036,24 +2067,15 @@ async fn producer(
 
                 if slice.exponent == vol.first + vol.count - 1 {
                     if let Some(tx) = &tx_opt {
-                        if !defer_data_posting {
-                            let wire_override = shared
-                                .release_prefix
-                                .as_deref()
-                                .map(|prefix| layout::volume_name(prefix, *vol));
-                            // Volumes follow the data files and the index file
-                            // (+1), in `plan_volumes`' order (+vol_idx).
-                            let file_index = metas.len() as u32 + 2 + vol_idx as u32;
-                            push_par2_file(
-                                &vol_path,
-                                vol_name,
-                                wire_override,
-                                file_index,
-                                &shared,
-                                tx,
-                            )
+                        let wire_override = shared
+                            .release_prefix
+                            .as_deref()
+                            .map(|prefix| layout::volume_name(prefix, *vol));
+                        // Volumes follow the data files and the index file
+                        // (+1), in `plan_volumes`' order (+vol_idx).
+                        let file_index = metas.len() as u32 + 2 + vol_idx as u32;
+                        push_par2_file(&vol_path, vol_name, wire_override, file_index, &shared, tx)
                             .await?;
-                        }
                     }
                 }
             }
@@ -2065,50 +2087,56 @@ async fn producer(
         }
     }
 
-    // `--par2-before-upload`: PAR2 generation (every pass, above) is now
-    // fully done and every index/volume file sits on disk in `par2_dir` —
-    // post the data files, then those already-generated PAR2 files, back to
-    // back. Nothing above this point put anything on the wire for this
-    // release.
-    if defer_data_posting {
-        if let Some(tx) = tx_opt.as_ref() {
-            if shared.cancelled.load(Ordering::Relaxed) {
-                return Ok(());
-            }
-            post_data_files(&metas, tx, &shared).await?;
+    Ok(())
+}
 
-            let par2_dir = par2_dir.as_ref().expect(
-                "par2_dir is set whenever recovery_count > 0, which defer_data_posting requires",
-            );
-
-            let index_name = layout::index_name(par2_base(&metas[0].real_name));
-            let index_path = par2_dir.join(&index_name);
-            let wire_override = shared.release_prefix.as_deref().map(layout::index_name);
-            let file_index = metas.len() as u32 + 1;
-            push_par2_file(
-                &index_path,
-                index_name,
-                wire_override,
-                file_index,
-                &shared,
-                tx,
-            )
-            .await?;
-
-            let volumes = layout::plan_volumes(recovery_count as u32);
-            for (vol_idx, vol) in volumes.iter().enumerate() {
-                let vol_name = layout::volume_name(par2_base(&metas[0].real_name), *vol);
-                let vol_path = par2_dir.join(&vol_name);
-                let wire_override = shared
-                    .release_prefix
-                    .as_deref()
-                    .map(|prefix| layout::volume_name(prefix, *vol));
-                let file_index = metas.len() as u32 + 2 + vol_idx as u32;
-                push_par2_file(&vol_path, vol_name, wire_override, file_index, &shared, tx).await?;
-            }
-        }
+/// Posts a release whose PAR2 index/volumes were already fully generated by
+/// an earlier `producer(metas, None, shared, 0)` call — see
+/// `--par2-before-upload` in `post_files_with_progress_and_cancel`: that call
+/// writes every index/volume file to `par2_dir` without posting anything
+/// (`tx_opt: None` takes the `par2_only_ingest` path). This posts the data
+/// files, then reads back and posts the already-written index and every
+/// volume, so the whole release goes out back to back with no gap. Volume
+/// file names/`file_index`es are recomputed from `recovery_count` alone
+/// (via `layout::plan_volumes`), matching exactly what the generation call
+/// already wrote — no I/O needed to know what's there.
+async fn post_pregenerated_release(
+    metas: &[Arc<FileMeta>],
+    par2_dir: &Path,
+    recovery_count: usize,
+    tx: &tokio::sync::mpsc::Sender<PostTask>,
+    shared: &Arc<Shared>,
+) -> Result<()> {
+    if shared.cancelled.load(Ordering::Relaxed) {
+        return Ok(());
     }
+    post_data_files(metas, tx, shared).await?;
 
+    let index_name = layout::index_name(par2_base(&metas[0].real_name));
+    let index_path = par2_dir.join(&index_name);
+    let wire_override = shared.release_prefix.as_deref().map(layout::index_name);
+    let file_index = metas.len() as u32 + 1;
+    push_par2_file(
+        &index_path,
+        index_name,
+        wire_override,
+        file_index,
+        shared,
+        tx,
+    )
+    .await?;
+
+    let volumes = layout::plan_volumes(recovery_count as u32);
+    for (vol_idx, vol) in volumes.iter().enumerate() {
+        let vol_name = layout::volume_name(par2_base(&metas[0].real_name), *vol);
+        let vol_path = par2_dir.join(&vol_name);
+        let wire_override = shared
+            .release_prefix
+            .as_deref()
+            .map(|prefix| layout::volume_name(prefix, *vol));
+        let file_index = metas.len() as u32 + 2 + vol_idx as u32;
+        push_par2_file(&vol_path, vol_name, wire_override, file_index, shared, tx).await?;
+    }
     Ok(())
 }
 
@@ -2152,13 +2180,13 @@ fn spawn_double_buffered_reader(
     (read_rx, reader_handle)
 }
 
-/// Posts every data file's articles with no PAR2 involvement. Used by
-/// `--par2-before-upload` after PAR2 generation has already fully completed
-/// (see the `defer_data_posting` branch in `producer`), to post the data
-/// files immediately before the already-generated PAR2 index/volumes so the
-/// whole release goes out back to back with no gap. Mirrors the data-posting
-/// half of `producer`'s interleaved per-file loop, minus the PAR2
-/// accumulation, which is unnecessary here since PAR2 is already on disk.
+/// Posts every data file's articles with no PAR2 involvement. Called from
+/// `post_pregenerated_release` (`--par2-before-upload`, after PAR2
+/// generation has already fully completed) to post the data files
+/// immediately before the already-generated PAR2 index/volumes so the whole
+/// release goes out back to back with no gap. Mirrors the data-posting half
+/// of `producer`'s interleaved per-file loop, minus the PAR2 accumulation,
+/// which is unnecessary here since PAR2 is already on disk.
 async fn post_data_files(
     metas: &[Arc<FileMeta>],
     tx: &tokio::sync::mpsc::Sender<PostTask>,

--- a/crates/pesto/tests/par2_before_upload.rs
+++ b/crates/pesto/tests/par2_before_upload.rs
@@ -377,3 +377,92 @@ async fn par2_before_upload_resume_skips_already_posted_segments() {
     let _ = std::fs::remove_dir_all(&resumed.par2_temp_dir);
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Extract `(filenum, total_files)` from a `--file-counter` subject's
+/// `[filenum/total_files] - "name" ...` prefix.
+fn parse_counter(subject: &str) -> Option<(u32, u32)> {
+    let rest = subject.strip_prefix('[')?;
+    let (nums, _) = rest.split_once(']')?;
+    let (n, m) = nums.split_once('/')?;
+    Some((n.parse().ok()?, m.parse().ok()?))
+}
+
+/// `--file-counter`'s `[filenum/total]` numbering must stay a clean bijection
+/// over every file in the release — no gaps, no duplicates, one consistent
+/// `total` — regardless of whether PAR2 generation needed multiple read
+/// passes (forced here via a tiny `--memory-limit`) and regardless of
+/// `--par2-before-upload`. Multi-pass generation only changes *when* a
+/// volume's bytes get produced (a volume's recovery blocks can even span two
+/// passes — see the `append` open mode on the volume file), never *which*
+/// file-index/total any file gets: both come from `layout::plan_volumes`
+/// applied to the release's total recovery-block count, computed once up
+/// front, independent of how many passes it takes to actually fill it in.
+#[tokio::test(flavor = "multi_thread")]
+async fn file_counter_numbering_is_a_clean_bijection_under_multi_pass() {
+    for defer in [false, true] {
+        let subjects = Arc::new(Mutex::new(Vec::new()));
+        let addr = spawn_recording_server(subjects.clone());
+        let dir = std::env::temp_dir().join(format!(
+            "pesto_par2_before_upload_counter_{}_{defer}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("movie.bin");
+        std::fs::write(&input, content(3, 8192 * 40)).unwrap();
+
+        let mut cfg = config(addr, defer);
+        cfg.file_counter = true;
+        let inputs = expand_inputs(std::slice::from_ref(&input)).unwrap();
+        let outcome = post_files(&cfg, &inputs).await.unwrap();
+        assert!(
+            outcome.failures.is_empty(),
+            "defer={defer}: failures: {:?}",
+            outcome.failures
+        );
+
+        let wire_subjects = subjects.lock().unwrap().clone();
+        let parsed: Vec<(u32, u32)> = wire_subjects
+            .iter()
+            .map(|s| {
+                parse_counter(s)
+                    .unwrap_or_else(|| panic!("defer={defer}: no [N/M] prefix in subject: {s}"))
+            })
+            .collect();
+        assert!(
+            !parsed.is_empty(),
+            "defer={defer}: mock server recorded no posted subjects"
+        );
+
+        // Every segment of the same file repeats that file's `filenum`, so
+        // dedupe by (filenum) to get the actual per-file numbering.
+        let mut per_file: Vec<u32> = parsed.iter().map(|(n, _)| *n).collect();
+        per_file.sort_unstable();
+        per_file.dedup();
+
+        let totals: std::collections::HashSet<u32> = parsed.iter().map(|(_, m)| *m).collect();
+        assert_eq!(
+            totals.len(),
+            1,
+            "defer={defer}: inconsistent total across subjects: {totals:?}"
+        );
+        let total = *totals.iter().next().unwrap();
+
+        assert_eq!(
+            per_file,
+            (1..=total).collect::<Vec<u32>>(),
+            "defer={defer}: file-index numbering isn't a clean 1..=total bijection: {per_file:?}"
+        );
+
+        // At least one data file and at least one PAR2 file, or this test
+        // isn't actually exercising the interesting part of the release.
+        let has_par2 = outcome
+            .segments
+            .iter()
+            .any(|s| s.file_name.ends_with(".par2"));
+        assert!(has_par2, "defer={defer}: expected PAR2 segments");
+
+        let _ = std::fs::remove_dir_all(&outcome.par2_temp_dir);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Summary
- **`--par2-before-upload` memory fix**: the PAR2 memory-budget calculation was reserving RAM for connections that weren't even open yet during the generation-only phase, and the connection pool itself was being created (and sitting idle) before generation started. `producer()` now takes an explicit `active_connections` parameter; the generation-only call passes `0`, and the real connection pool only spins up once generation is done — real budget back for PAR2, fewer read passes on RAM-constrained hosts, no idle connections during generation.
- **Fixes a hang** introduced while building the above: `post_pregenerated_release` only borrows the channel `Sender`, so the caller's `tx_opt` was never dropped after posting completed — the channel never closed, so each worker's `rx.recv()` waited forever and the run hung. Fixed with an explicit `drop(tx_opt)`.
- **Separate, unrelated UX fix**: `--nfo` generation blocked synchronously on `bdinfo`/`mediainfo` with zero output in between, which on a large Blu-ray disc could look like the process had frozen. Now prints a message before starting and a heartbeat every 10s while it runs on a blocking-pool thread.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (full suite, including `crates/pesto/tests/par2_before_upload.rs`)
- [x] Manually verified with `-v` that the PAR2 memory-budget line reflects 0 reserved connections during the generation phase (704 MiB vs. 728 MiB with 3 connections reserved as before)
- [x] Manually reproduced and fixed the channel-drop hang (confirmed via targeted debug instrumentation, since removed)

See `ROADMAP.md` and `crates/pesto/CHANGELOG.md` for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTwUawD3rpWWZDoVevm11