### PR TITLE
pesto: fix --par2-before-upload progress double-counting data segments

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -590,6 +590,16 @@ explicit `active_connections` parameter instead of reading `shared.config.total_
 `post_files_with_progress_and_cancel` passes `0` for the generation-only call — real budget back for PAR2, one
 fewer read pass on RAM-constrained hosts — and only builds the actual connection pool once generation is done.
 
+**Follow-up — the generation phase's `tx_opt: None` call also double-counted progress for real uploads.** That
+same `tx_opt: None` path is shared with `--par2-only`, which fakes a `SegmentDone` per data article via
+`par2_only_ingest` since a `--par2-only` run never posts anything for real — that fake progress is the *only*
+source of data-file progress in that mode, so it's correct there. `--par2-before-upload`'s generation pre-pass took
+the same path, but the data files *do* get posted for real afterward (`post_pregenerated_release`), so every data
+segment got counted twice: once fake during generation, once real during posting. Visible on screen as the upload
+bar's segment count and percentage running past 100% (upload and NZB output were unaffected — this was a display
+bug only). `par2_only_ingest`'s `SegmentDone` emission is now gated on `shared.config.par2_only` specifically,
+rather than firing whenever `tx_opt` is `None`.
+
 References:
 - yEnc draft v1.3: <http://www.yenc.org/yenc-draft.1.3.txt>
 - Mirror: <https://github.com/caronc/newsreap/blob/master/docs/yenc-draft.1.3.txt>

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,17 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Fixed
+- **`--par2-before-upload` progress display double-counted data segments,
+  running the percentage/segment count past 100%.** The generation-only
+  pre-pass (`producer(.., None, .., 0)`) reused the same code path
+  `--par2-only` takes, which fakes a `SegmentDone` per data article since
+  `--par2-only` never posts anything for real. Under `--par2-before-upload`
+  the data files *do* get posted for real afterward, so every data segment
+  was counted twice — once fake during generation, once real during
+  posting — while the actual upload and NZB output were unaffected. Fake
+  progress is now gated on `--par2-only` specifically.
+
 ## [0.5.6] — 2026-08-04
 
 ### Fixed

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -1319,8 +1319,16 @@ fn feed_par2_slice(
 /// independently (slice boundaries reset at every file boundary), matching the
 /// behaviour of the standard path.
 ///
-/// Emits `SegmentDone` events in `article_size` increments so the progress bar
-/// advances at the same cadence as the standard path.
+/// Emits `SegmentDone` events in `article_size` increments so the progress
+/// bar advances at the same cadence as the standard path — but only for a
+/// genuine `--par2-only` run (`shared.config.par2_only`), where this is the
+/// *only* source of data-file progress since nothing is ever posted. This
+/// same `tx_opt: None` path is also used by `--par2-before-upload`'s
+/// generation-only pre-pass (`producer(.., None, .., 0)` in
+/// `post_files_with_progress_and_cancel`), where the data files *do* get
+/// posted for real afterward (`post_pregenerated_release`) — faking their
+/// progress here too would double-count every data segment once the real
+/// `SegmentDone` events arrive later.
 async fn par2_only_ingest(
     metas: &[Arc<FileMeta>],
     worker: &Par2Worker,
@@ -1379,14 +1387,18 @@ async fn par2_only_ingest(
             unsafe { slice_buf.set_len(base + to_read) };
             remaining -= to_read;
 
-            // Emit SegmentDone for each complete article worth of bytes consumed.
+            // Emit SegmentDone for each complete article worth of bytes
+            // consumed — only when this data will never actually be posted
+            // (see the doc comment above).
             let consumed = meta.size as usize - remaining;
             while credited + article_size <= consumed {
-                shared.emit(ProgressEvent::SegmentDone {
-                    file: meta.real_name.clone(),
-                    bytes: article_size as u64,
-                    ok: true,
-                });
+                if shared.config.par2_only {
+                    shared.emit(ProgressEvent::SegmentDone {
+                        file: meta.real_name.clone(),
+                        bytes: article_size as u64,
+                        ok: true,
+                    });
+                }
                 credited += article_size;
             }
 
@@ -1403,7 +1415,7 @@ async fn par2_only_ingest(
 
         // Credit the last partial article of this file.
         let leftover = meta.size as usize - credited;
-        if leftover > 0 {
+        if leftover > 0 && shared.config.par2_only {
             shared.emit(ProgressEvent::SegmentDone {
                 file: meta.real_name.clone(),
                 bytes: leftover as u64,

--- a/crates/pesto/tests/par2_before_upload.rs
+++ b/crates/pesto/tests/par2_before_upload.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use pesto::config::{Config, ObfuscateMode};
 use pesto::poster::{post_files, post_files_with_progress};
+use pesto::progress::ProgressEvent;
 use pesto::walk::expand_inputs;
 
 /// Accept-all mock NNTP server that records the `Subject:` header of every
@@ -465,4 +466,59 @@ async fn file_counter_numbering_is_a_clean_bijection_under_multi_pass() {
         let _ = std::fs::remove_dir_all(&outcome.par2_temp_dir);
         let _ = std::fs::remove_dir_all(&dir);
     }
+}
+
+/// Regression test for a progress-tracking bug: the generation-only
+/// `producer(.., None, .., 0)` pre-pass (see `post_files_with_progress_and_cancel`)
+/// reuses the same `tx_opt: None` path `--par2-only` takes, which fakes a
+/// `SegmentDone` per data article since `--par2-only` never posts anything
+/// for real. Under `--par2-before-upload` the data *does* get posted for
+/// real afterward (`post_pregenerated_release`), so without a fix each data
+/// segment would get double-counted — visible on screen as `done_segments`
+/// (and the progress percentage) running past `total_segments`.
+#[tokio::test(flavor = "multi_thread")]
+async fn par2_before_upload_does_not_double_count_data_segment_progress() {
+    let addr = spawn_recording_server(Arc::new(Mutex::new(Vec::new())));
+    let dir = std::env::temp_dir().join(format!(
+        "pesto_par2_before_upload_progress_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let input = dir.join("movie.bin");
+    std::fs::write(&input, content(4, 8192 * 40)).unwrap();
+
+    let cfg = config(addr, true);
+    let expected_data_segments = (8192u64 * 40).div_ceil(cfg.article_size as u64);
+    let inputs = expand_inputs(std::slice::from_ref(&input)).unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ProgressEvent>();
+    let handle =
+        tokio::spawn(
+            async move { post_files_with_progress(&cfg, &inputs, Some(tx), None, None).await },
+        );
+
+    let mut data_segment_done_count: u64 = 0;
+    while let Some(ev) = rx.recv().await {
+        if let ProgressEvent::SegmentDone { file, .. } = ev {
+            if file == "movie.bin" {
+                data_segment_done_count += 1;
+            }
+        }
+    }
+
+    let outcome = handle.await.unwrap().unwrap();
+    assert!(
+        outcome.failures.is_empty(),
+        "failures: {:?}",
+        outcome.failures
+    );
+    assert_eq!(
+        data_segment_done_count, expected_data_segments,
+        "movie.bin should get exactly one SegmentDone per real segment, not double-counted \
+         by the generation-only pre-pass's fake --par2-only-style progress reporting"
+    );
+
+    let _ = std::fs::remove_dir_all(&outcome.par2_temp_dir);
+    let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- Fixes a display-only bug reported live: with `--par2-before-upload`, the upload progress bar's segment count and percentage could run past 100% (e.g. `4527/4288`).
- Root cause: the generation-only pre-pass (`producer(.., None, .., 0)`) reuses the same `tx_opt: None` path `--par2-only` takes, which fakes a `SegmentDone` per data article since a `--par2-only` run never posts anything for real. `--par2-before-upload`'s data files *do* get posted for real afterward, so every data segment was counted twice.
- Fix: `par2_only_ingest`'s fake `SegmentDone` emission is now gated on `shared.config.par2_only` specifically, instead of firing whenever `tx_opt` is `None`.
- The actual upload and generated NZB were never affected — this was purely a progress-display bug.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Reproduced with a standalone harness replaying `ui/terminal.rs`'s own hint-reconciliation logic against real captured progress events — confirmed the mismatch before the fix, confirmed it's gone after
- [x] New regression test `par2_before_upload_does_not_double_count_data_segment_progress` in `crates/pesto/tests/par2_before_upload.rs`

See `ROADMAP.md` and `crates/pesto/CHANGELOG.md` for full details. Reported against GitHub issue #68 (comment posted acknowledging the bug and pointing to this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTwUawD3rpWWZDoVevm11