### PR TITLE
fix: stop leaking the season PAR2-only NZB to disk

### DIFF
--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -2044,10 +2044,17 @@ async fn post_season_par2_volumes(
     par2_config.par2 = 0; // Disable PAR2 for PAR2 volumes themselves
     par2_config.no_hooks = true; // Disable hooks for PAR2 volumes (no NZB to upload)
 
-    // Write PAR2 NZB to a temp file (will be discarded, not sent to indexers)
-    let par2_nzb_temp =
-        tempfile::NamedTempFile::new().context("creating temp file for PAR2 NZB")?;
-    let par2_nzb_path = par2_nzb_temp.path().to_path_buf();
+    // Write the PAR2 NZB inside `par2_output_dir` rather than a lone
+    // `NamedTempFile`. `run_upload` never writes to the exact path it's
+    // given — `versioned_nzb_path` normalizes the extension and picks a
+    // fresh, non-colliding `{stem}.nzb` sibling — so a standalone
+    // `NamedTempFile` (deleted on drop) tracks a *different* path than the
+    // one actually holding the NZB content, leaking a PAR2-only NZB that
+    // nothing ever cleans up (it was found and mistakenly submitted to an
+    // indexer ahead of the real season NZB). Placing it in `par2_output_dir`
+    // guarantees whatever path is actually chosen is removed when that
+    // `TempDir` drops at the end of this function.
+    let par2_nzb_path = par2_dir_path.join("season-par2.nzb");
 
     let outcome = pesto::upload::run_upload(
         &par2_config,


### PR DESCRIPTION
## Summary
- `post_season_par2_volumes` wrote its internal, meant-to-be-discarded PAR2-only NZB to a lone `NamedTempFile`, but `run_upload` never writes to the exact path it's given — `versioned_nzb_path()` normalizes the extension and creates a sibling `{stem}.nzb` file instead.
- The `NamedTempFile` (empty) was cleaned up on drop, but the sibling holding the real NZB content was never deleted — leaking a PAR2-only NZB onto disk that could be picked up and sent to an indexer before the real season NZB existed. Reported by zoaro, reproduced with a leaked `tmpXXXXXX.nzb` containing only `.par2` file entries.
- Fix: write the temp NZB inside `par2_output_dir` (a `TempDir` already scoped to the function) instead, so whatever exact path `versioned_nzb_path()` picks is removed when that directory drops.

## Test plan
- [x] `cargo fmt --check -p pesto-poster`
- [x] `cargo clippy -p pesto-poster --all-targets -- -D warnings`
- [x] `cargo test -p pesto-poster`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRySgGax7pnkAmLwLByrSj