### PR TITLE
fix: --season's global PAR2 now matches what was actually posted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Season NZB consolidation now correctly filters out per-episode PAR2 sets to avoid multiple rsids
 - PAR2 volume posting no longer generates recursive PAR2 for the volume files themselves
 - The internal PAR2-only NZB used to post the season's global PAR2 volumes no longer leaks onto disk as an orphaned temp file — it used to be written to a path distinct from the one actually cleaned up on drop, so it could persist and get submitted to an indexer ahead of the real season NZB
+- That same internal PAR2-only upload no longer runs the user's configured `post_hooks` — `no_hooks` only ever suppressed the hooks-directory scan, so a configured indexer-submission hook still fired against it
+- The season's global PAR2 now covers the files actually posted (the compressed archive, under `--compress`/`--password`) instead of the original, never-posted episode files, whose temp archive used to be deleted before the season PAR2 step could read it
+- The season's own PAR2 volumes no longer get wrapped in a password-protected archive themselves when `--compress`/`--password` is active — they're posted as raw, readable `.par2` files like any other PAR2 set
 
 ### Tested
 

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -21,6 +21,27 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
   PAR2-only NZB content was never deleted, so it could sit on disk and get picked up and submitted to an
   indexer ahead of the real season NZB. The temp NZB is now written inside the same `TempDir` already used for
   the PAR2 volumes, so it's removed along with everything else in that directory when the function returns.
+- **`--season`'s internal PAR2-only upload no longer runs the user's configured `post_hooks`.** Setting
+  `no_hooks = true` for this internal upload only ever suppressed the `~/.config/pesto/hooks/` directory scan —
+  `hooks::run_hooks` documents that explicit `post_hooks` entries "still run regardless". A configured
+  post-hook (e.g. an indexer-submission script) fired against this PAR2-only NZB mid-batch, submitting it to
+  an indexer before the real season NZB existed — the same leaked-artifact problem as above, reachable even
+  once the disk leak itself is fixed. Both `post_hooks` and the directory scan are now disabled for this
+  upload.
+- **`--season`'s global PAR2 now covers what was actually posted, not the original episode files.** Under
+  `--compress`/`--password`, each episode is compressed into an archive that's segmented and posted — the
+  archive, not the source file — and its temp dir is deleted right after that episode finishes. The season's
+  global PAR2 step ran afterward against the original `entries` paths regardless, producing a recovery set
+  whose File Description packets named data (filename, size, hash) that was never on the wire at all — useless
+  for verification or repair against what a downloader actually receives. Each episode's upload now optionally
+  keeps its compressed archive on disk (`keep_compress_temp`) until the season PAR2 step has read the real
+  posted bytes, then a `Drop` guard cleans it up regardless of how the batch exits.
+- **`--season`'s PAR2 volumes no longer get compressed/encrypted themselves under `--compress`/`--password`.**
+  The internal upload that posts the season's own `.par2` volumes cloned the season `Config` — including
+  `compress_password`/`compress_format` — so `run_upload`'s independent compression step wrapped each already-
+  generated `.par2` volume in its own password-protected archive before posting it. The result was a season
+  "PAR2" set that was really an encrypted blob no downloader could read as PAR2 at all. Compression is now
+  explicitly disabled for this upload, alongside the PAR2-generation and hook settings already cleared above.
 
 ## [0.6.0] — 2026-08-07
 

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -1006,6 +1006,17 @@ struct UploadResult {
     had_failures: bool,
     total_bytes: u64,
     nzb_path: Option<PathBuf>,
+    /// The files actually posted for this entry — post-compression when
+    /// `--compress`/`--password` replaced the original input with an
+    /// archive. A `--season` batch needs these (not the original episode
+    /// paths) to compute a global PAR2 set that matches what's really on
+    /// the wire; see `keep_compress_temp` on [`run_single_upload`].
+    posted_paths: Vec<PathBuf>,
+    /// Set when `keep_compress_temp` was requested and this entry actually
+    /// compressed its input: the temp dir holding `posted_paths`, left on
+    /// disk (instead of being cleaned up inline) for the caller to remove
+    /// once it's done reading those files.
+    compress_temp_dir: Option<PathBuf>,
 }
 
 /// Per-phase wall-clock timing accumulated during a single upload (26g).
@@ -1047,12 +1058,24 @@ fn resolve_entry_password(
 /// Run one complete upload: expand `entry_paths`, compress, post, write NZB.
 ///
 /// Returns the posted segments so the caller can build a consolidated season NZB.
+///
+/// `keep_compress_temp`: when this entry compresses its input, the archive
+/// normally lives only in a per-entry temp dir that's deleted before this
+/// function returns — fine for a standalone upload, since nothing needs the
+/// archive bytes afterward. A `--season` batch does: `post_season_par2_volumes`
+/// runs after every episode has posted, and must compute the season's global
+/// PAR2 over the *actual posted bytes* (the archive), not the original
+/// episode file, or the resulting PAR2 set describes data that was never put
+/// on the wire. Setting this to `true` skips that inline cleanup and reports
+/// the temp dir back via `UploadResult::compress_temp_dir` instead, so the
+/// caller can defer deletion until after it's done reading `posted_paths`.
 async fn run_single_upload(
     params: &UploadParams,
     entry_paths: &[PathBuf],
     entry_label: &str,
     cancel: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     forced_password: Option<&str>,
+    keep_compress_temp: bool,
 ) -> Result<UploadResult> {
     let config = &params.config;
     // Resolved once, used for the pre-upload summary, the archive itself,
@@ -1400,6 +1423,11 @@ async fn run_single_upload(
         compress_temp_dir = None;
     }
     // ─────────────────────────────────────────────────────────────────────────
+
+    // Captured now, after `inputs` has taken its final (possibly compressed)
+    // form and before posting: the exact set of files that are about to be
+    // put on the wire, for a `--season` batch's later global PAR2 step.
+    let posted_paths: Vec<PathBuf> = inputs.iter().map(|f| f.path.clone()).collect();
 
     let t_post = std::time::Instant::now();
     let outcome = pesto::poster::post_files_with_progress_and_cancel(
@@ -1839,10 +1867,18 @@ async fn run_single_upload(
         run_all_hooks(config, &hook_env);
     }
 
-    // Cleanup temp dirs.
-    if let Some(dir) = compress_temp_dir {
-        let _ = std::fs::remove_dir_all(&dir);
-    }
+    // Cleanup temp dirs. When `keep_compress_temp` is set, the caller still
+    // needs `posted_paths` on disk (a `--season` batch's global PAR2 step
+    // reads them after every episode has finished) — leave the archive in
+    // place and let the caller remove it once done.
+    let compress_temp_dir = if keep_compress_temp {
+        compress_temp_dir
+    } else {
+        if let Some(dir) = &compress_temp_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+        None
+    };
     // Only now — after the --check repost pass and the end-of-run failed-task
     // retry above have both had every chance to re-read a PAR2 file's bytes —
     // is it safe to remove the PAR2 temp dir. See `par2_temp_dir`'s doc
@@ -1890,6 +1926,8 @@ async fn run_single_upload(
             || has_unrecoverable_failures,
         total_bytes,
         nzb_path: nzb_reported_path,
+        posted_paths,
+        compress_temp_dir,
     })
 }
 
@@ -2042,7 +2080,27 @@ async fn post_season_par2_volumes(
     // Create a config copy with PAR2 disabled to prevent recursive PAR2 generation.
     let mut par2_config = (*params.config).clone();
     par2_config.par2 = 0; // Disable PAR2 for PAR2 volumes themselves
-    par2_config.no_hooks = true; // Disable hooks for PAR2 volumes (no NZB to upload)
+
+    // Disable compression too. `run_upload` (the library pipeline this call
+    // goes through) re-derives `compress_format_str` from `compress_password`
+    // independently of anything the caller already did — so leaving a
+    // `--compress`/`--password` season config in place here would wrap each
+    // *already-generated* `.par2` volume in its own password-protected
+    // archive before posting it. The result is a season "PAR2" set that's
+    // really an encrypted blob no downloader can read as PAR2 at all,
+    // defeating the entire point of posting recovery data.
+    par2_config.compress_format = None;
+    par2_config.compress_password = None;
+    par2_config.compress_volume_size = None;
+
+    // `no_hooks` only suppresses the `~/.config/pesto/hooks/` directory scan —
+    // per `hooks::run_hooks`, explicit `post_hooks` entries "still run
+    // regardless". A configured post-hook (e.g. one of the indexer-submission
+    // scripts under `examples/hooks/`) would otherwise fire against this
+    // internal, PAR2-only NZB and submit it to an indexer ahead of the real
+    // season NZB, so both hook paths must be disabled here.
+    par2_config.no_hooks = true;
+    par2_config.post_hooks = Vec::new();
 
     // Write the PAR2 NZB inside `par2_output_dir` rather than a lone
     // `NamedTempFile`. `run_upload` never writes to the exact path it's
@@ -2132,6 +2190,24 @@ fn force_season_group(params: Arc<UploadParams>, is_season: bool) -> Arc<UploadP
 ///
 /// Returns all collected segments (for season NZB consolidation) and whether
 /// any upload was cancelled or had failures.
+/// Removes every collected directory on drop.
+///
+/// A `--season` batch defers each episode's compress-temp cleanup (see
+/// `run_single_upload`'s `keep_compress_temp`) so the archive bytes are
+/// still on disk when the season's global PAR2 step reads them afterward.
+/// Wrapping the collected dirs in this guard means they're still removed —
+/// via `Drop` — even if `run_batch` returns early (e.g. the season NZB
+/// write's `?`) before reaching the end of the season-merge block.
+struct CompressTempCleanup(Vec<PathBuf>);
+
+impl Drop for CompressTempCleanup {
+    fn drop(&mut self) {
+        for dir in &self.0 {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+}
+
 async fn run_batch(
     params: Arc<UploadParams>,
     dirs: &[PathBuf],
@@ -2173,6 +2249,15 @@ async fn run_batch(
 
     let params = force_season_group(params, season_nzb.is_some());
 
+    // Whether each episode should keep its compressed archive on disk
+    // (instead of deleting it right after posting) so the season's global
+    // PAR2 step below can compute recovery data over the *actual posted
+    // bytes* rather than the original, never-compressed episode file — see
+    // `run_single_upload`'s `keep_compress_temp` doc comment. Mirrors the
+    // exact gate `post_season_par2_volumes` is called under further down, so
+    // nothing is retained when there's no season PAR2 step to read it.
+    let keep_compress_temp = season_nzb.is_some() && params.config.par2 > 0 && entries.len() > 1;
+
     let effective_jobs = if jobs == 0 {
         parmesan::performance_core_count()
     } else {
@@ -2184,6 +2269,8 @@ async fn run_batch(
     let mut all_groups: Vec<String> = Vec::new();
     let mut any_cancelled = false;
     let mut any_failures = false;
+    let mut posted_episode_paths: Vec<PathBuf> = Vec::new();
+    let mut compress_temp_cleanup = CompressTempCleanup(Vec::new());
 
     let total_entries = entries.len();
     let mut handles = Vec::new();
@@ -2222,6 +2309,7 @@ async fn run_batch(
                 &label,
                 Some(&task_cancel),
                 task_password.as_deref(),
+                keep_compress_temp,
             )
             .await
         });
@@ -2242,6 +2330,10 @@ async fn run_batch(
                 }
                 if result.had_failures {
                     any_failures = true;
+                }
+                posted_episode_paths.extend(result.posted_paths);
+                if let Some(dir) = result.compress_temp_dir {
+                    compress_temp_cleanup.0.push(dir);
                 }
             }
             Ok(Err(e)) => {
@@ -2273,10 +2365,19 @@ async fn run_batch(
             // Generate and post global PAR2 for the entire season (Phase 47b).
             // This produces a single, coherent recovery set covering all episodes
             // instead of multiple independent rsids for each episode.
+            //
+            // Uses `posted_episode_paths` — the files each episode actually put
+            // on the wire (an archive, under `--compress`/`--password`) — not
+            // the original `entries`. The two can differ in content, name, and
+            // even count (one archive can split into several `--compress-
+            // volume-size` volumes); computing recovery data against the
+            // original, never-posted file would produce a PAR2 set that
+            // doesn't describe anything actually on Usenet (`keep_compress_temp`
+            // above is what keeps these archives alive long enough to read here).
             let mut season_par2_segments = Vec::new();
-            if config.par2 > 0 && entries.len() > 1 {
+            if config.par2 > 0 && posted_episode_paths.len() > 1 {
                 match post_season_par2_volumes(
-                    &entries,
+                    &posted_episode_paths,
                     &season_name.clone().unwrap_or_else(|| "season".to_string()),
                     &params,
                     &cancel,
@@ -2734,6 +2835,7 @@ async fn run_watch(
                                 &label,
                                 Some(&task_cancel),
                                 None,
+                                false,
                             )
                             .await
                             {
@@ -3368,7 +3470,7 @@ async fn run(tuning: pesto::memory::ThreadTuning) -> Result<()> {
             }
         })
         .unwrap_or_else(|| format!("{}", std::process::id()));
-    let result = run_single_upload(&params, &cli.files, &label, Some(&cancel), None).await?;
+    let result = run_single_upload(&params, &cli.files, &label, Some(&cancel), None, false).await?;
 
     if let Some(ref p) = session_log {
         write_session_summary(

--- a/crates/pesto/tests/season_par2_matches_compressed_archive.rs
+++ b/crates/pesto/tests/season_par2_matches_compressed_archive.rs
@@ -1,0 +1,265 @@
+//! Regression test: `--season` combined with `--password` (compression) must
+//! generate the season's global PAR2 recovery set over the files actually
+//! posted to Usenet — the per-episode archives — not the original,
+//! never-posted episode files.
+//!
+//! `post_season_par2_volumes` used to be handed `entries`, the season
+//! directory's original top-level file paths. But under `--compress`/
+//! `--password`, each episode is compressed into an archive in a per-entry
+//! temp dir, *that* archive is what's segmented and posted, and the temp
+//! dir is deleted right after — before the season's global PAR2 step even
+//! runs. The season PAR2 therefore described data (name, size, hash) that
+//! was never on the wire at all, making it useless for verification/repair
+//! against what a downloader actually receives.
+//!
+//! This test runs the real `pesto` binary end-to-end against a mock NNTP
+//! server, reconstructs every posted file exactly as a downloader would
+//! (yEnc-decoding the captured articles), and checks the season PAR2 volume
+//! against *that* reconstructed directory with the real `par2` CLI. Before
+//! the fix this fails, because the described files (original `.mkv` names)
+//! don't exist anywhere in what was actually posted.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+use pesto::yenc::decode::decode_part;
+
+/// A mock NNTP server that accepts every `POST` with `240` and records the
+/// full raw article body (headers + yEnc data), as exact bytes — a lossy
+/// `String` capture (as some other tests use, since they only grep for
+/// ASCII control lines) would corrupt the binary yEnc payload this test
+/// needs to decode back into real archive/PAR2 bytes.
+fn spawn_capturing_server() -> (SocketAddr, Arc<Mutex<Vec<Vec<u8>>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let captured: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = Arc::clone(&captured);
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            let captured = Arc::clone(&captured_clone);
+            std::thread::spawn(move || handle_connection(stream, captured));
+        }
+    });
+
+    (addr, captured)
+}
+
+fn handle_connection(stream: TcpStream, captured: Arc<Mutex<Vec<Vec<u8>>>>) {
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+    let mut reader = BufReader::new(stream);
+    if writer.write_all(b"200 pesto mock ready\r\n").is_err() {
+        return;
+    }
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+        let command = line.trim_end().to_string();
+
+        if command == "POST" {
+            if writer.write_all(b"340 send article\r\n").is_err() {
+                return;
+            }
+            let mut article = Vec::new();
+            let mut raw = Vec::new();
+            loop {
+                raw.clear();
+                match reader.read_until(b'\n', &mut raw) {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+                if raw == b".\r\n" {
+                    break;
+                }
+                article.extend_from_slice(&raw);
+            }
+            captured.lock().unwrap().push(article);
+            if writer
+                .write_all(b"240 <article@pesto.test> article received\r\n")
+                .is_err()
+            {
+                return;
+            }
+        } else if command.starts_with("MODE READER") {
+            if writer.write_all(b"200 reader mode\r\n").is_err() {
+                return;
+            }
+        } else if command == "QUIT" {
+            let _ = writer.write_all(b"205 bye\r\n");
+            return;
+        } else if writer.write_all(b"500 unknown command\r\n").is_err() {
+            return;
+        }
+    }
+}
+
+/// Deterministic, mutually independent pseudo-random bytes — incompressible
+/// enough that 7z can't shrink episode content away to nothing.
+fn content(seed: u8, len: usize) -> Vec<u8> {
+    (0..len as u64)
+        .map(|i| {
+            let mut z = i.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                ^ (seed as u64).wrapping_mul(0xD1B5_4A32_D192_ED03);
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            (z >> 33) as u8
+        })
+        .collect()
+}
+
+fn which_7z_missing() -> bool {
+    pesto::compress::find_binary("7z").is_none()
+}
+
+#[test]
+fn season_par2_describes_the_posted_archive_not_the_original_episode() {
+    if which_7z_missing() {
+        eprintln!("skipping: 7z not found in PATH");
+        return;
+    }
+    let par2_missing = Command::new("par2").arg("--version").output().is_err();
+    if par2_missing {
+        eprintln!("skipping: par2 (par2cmdline) not found in PATH");
+        return;
+    }
+
+    let (addr, captured) = spawn_capturing_server();
+
+    let root = tempfile::tempdir().unwrap();
+    let season_dir = root.path().join("Season01");
+    std::fs::create_dir_all(&season_dir).unwrap();
+    std::fs::write(season_dir.join("S01E01.mkv"), content(0, 20_000)).unwrap();
+    std::fs::write(season_dir.join("S01E02.mkv"), content(1, 20_000)).unwrap();
+
+    let nzb_dir = root.path().join("nzbs");
+    std::fs::create_dir_all(&nzb_dir).unwrap();
+
+    let xdg_home = tempfile::tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pesto"))
+        .env("XDG_CONFIG_HOME", xdg_home.path())
+        .arg("--season")
+        .arg(&season_dir)
+        .arg("--no-ssl")
+        .args(["-s", "127.0.0.1"])
+        .args(["-P", &addr.port().to_string()])
+        .args(["-g", "alt.binaries.test"])
+        .args(["-n", "1"])
+        .args(["--jobs", "1"])
+        .args(["--par2", "40"])
+        // A small article size (rather than a manual --slice-size, which has
+        // its own unrelated pre-existing divide-by-zero when set below the
+        // article size — see poster::mod's `articles_per_slice` computation)
+        // gives the auto slice-size logic enough articles-per-episode to
+        // produce real recovery data even for these tiny test files.
+        .args(["--article-size", "2000"])
+        // Bare `--password` (no explicit value) makes pesto generate and
+        // print a random archive password at runtime — this test never
+        // needs to know it (PAR2 verification only sees the encrypted
+        // archive as opaque bytes), and it keeps no credential-shaped
+        // literal in source for secret scanners to (rightly, in general)
+        // flag.
+        .arg("--password")
+        .args(["--nzb-name", "Season01"])
+        .args(["--nzb-dir", nzb_dir.to_str().unwrap()])
+        .output()
+        .expect("failed to run pesto");
+
+    assert!(
+        output.status.success(),
+        "pesto exited with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Reconstruct every posted file exactly as a downloader would: yEnc-decode
+    // each captured article and reassemble by name (parts sorted by offset).
+    let mut parts_by_name: HashMap<String, Vec<(u64, Vec<u8>)>> = HashMap::new();
+    for article in captured.lock().unwrap().iter() {
+        let sep = b"\r\n\r\n";
+        let body_start = article
+            .windows(sep.len())
+            .position(|w| w == sep)
+            .map(|i| i + sep.len())
+            .expect("article missing header/body separator");
+        let decoded = decode_part(&article[body_start..]).expect("failed to decode yEnc article");
+        parts_by_name
+            .entry(decoded.name.clone())
+            .or_default()
+            .push((decoded.begin, decoded.data));
+    }
+    assert!(
+        !parts_by_name.is_empty(),
+        "no articles were captured — the mock server never saw a POST"
+    );
+
+    let download_dir = root.path().join("downloaded");
+    std::fs::create_dir_all(&download_dir).unwrap();
+    let mut downloaded_names: Vec<String> = Vec::new();
+    for (name, mut parts) in parts_by_name {
+        parts.sort_by_key(|(begin, _)| *begin);
+        let mut bytes = Vec::new();
+        for (_, data) in parts {
+            bytes.extend_from_slice(&data);
+        }
+        std::fs::write(download_dir.join(&name), &bytes).unwrap();
+        downloaded_names.push(name);
+    }
+
+    // Sanity check: only the compressed archive was ever posted, never the
+    // plaintext episode — otherwise this test wouldn't exercise the bug at
+    // all (it would trivially pass with either the old or new behaviour).
+    assert!(
+        !downloaded_names.iter().any(|n| n.ends_with(".mkv")),
+        "a plaintext .mkv episode was posted directly — --password should \
+         have replaced it with a compressed archive; got: {downloaded_names:?}"
+    );
+    assert!(
+        downloaded_names.iter().any(|n| n.ends_with(".7z")),
+        "expected at least one posted .7z archive; got: {downloaded_names:?}"
+    );
+
+    let season_par2: Vec<&String> = downloaded_names
+        .iter()
+        .filter(|n| n.starts_with("Season01") && n.ends_with(".par2"))
+        .collect();
+    assert!(
+        !season_par2.is_empty(),
+        "no season PAR2 volumes were posted; got: {downloaded_names:?}"
+    );
+
+    // The decisive check: verify the season PAR2 against exactly what was
+    // downloaded. This only succeeds if the PAR2's File Description packets
+    // name the real, actually-posted archive(s) with matching size/hash —
+    // which is only true once the season PAR2 step reads the compressed
+    // archive bytes instead of the original (never-posted) episode files.
+    let verify = Command::new("par2")
+        .arg("verify")
+        .arg("-q")
+        .arg(season_par2[0])
+        .current_dir(&download_dir)
+        .output()
+        .expect("failed to run par2 verify");
+
+    assert!(
+        verify.status.success(),
+        "par2 verify failed against the actually-posted archive — the season \
+         PAR2 set doesn't describe what was really posted.\nstdout:\n{}\nstderr:\n{}\n\
+         downloaded files: {downloaded_names:?}",
+        String::from_utf8_lossy(&verify.stdout),
+        String::from_utf8_lossy(&verify.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- `post_season_par2_volumes` computed the season's global PAR2 recovery set from the original episode file paths, not the files each episode actually posted. Under `--compress`/`--password`, each episode posts a compressed archive (its temp dir deleted right after that episode finishes) — so the season PAR2's File Description packets ended up naming data that was never on the wire at all, useless for verification/repair against what a downloader actually receives.
- Also disable compression for the internal upload that posts the season's own PAR2 volumes: it inherited `compress_password`/`compress_format` from the season config, so each already-generated `.par2` volume got wrapped in its own password-protected archive before posting — an encrypted blob no downloader could read as PAR2 at all.
- Clear `post_hooks` (not just `no_hooks`, which only suppresses the hooks-directory scan) so a configured indexer-submission hook can't fire against this internal PAR2-only upload.
- `run_single_upload` gains `keep_compress_temp`: when set, an episode's compressed archive is left on disk instead of deleted inline, reported back via `UploadResult` so `run_batch` can read the real posted bytes for the season PAR2 step. A `Drop` guard (`CompressTempCleanup`) removes every deferred temp dir once the batch is done, on every exit path.
- Added an end-to-end regression test (`season_par2_matches_compressed_archive.rs`) that runs the real `pesto` binary against a mock NNTP server, reconstructs every posted file exactly as a downloader would (yEnc-decoding the captured articles), and verifies the season PAR2 with the real `par2cmdline` binary against that reconstructed tree. Confirmed it fails without this fix (`par2` reports the described episodes missing) and passes with it.
- Follow-up to #98 (same `--season`/PAR2 area): also confirmed `no_hooks` there only suppresses the hooks-directory scan, not `post_hooks` — extended that fix's reasoning here too.

## Test plan
- [x] `cargo fmt --check -p pesto-poster`
- [x] `cargo clippy -p pesto-poster --all-targets -- -D warnings`
- [x] `cargo test -p pesto-poster` (129 tests, incl. 43 unit tests in the `pesto` binary)
- [x] Verified the new regression test fails without the fix (reverted the one-line `episode_paths` change locally, confirmed `par2 verify` reports the episodes missing) and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRySgGax7pnkAmLwLByrSj