### PR TITLE
chore: bump pesto-poster to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,8 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-08-07
+
 ### Fixed
 - **`--season`'s internal PAR2-only NZB no longer leaks onto disk.** `post_season_par2_volumes` posted the
   season's global PAR2 volumes through the normal upload pipeline and wrote the resulting NZB to a

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pesto-poster"
 # pesto is versioned, published, and released independently of the rest of
 # the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."


### PR DESCRIPTION
## Summary
- Bugfix release covering the `--season` fixes merged in #98 and #99: the internal PAR2-only NZB no longer leaks onto disk or triggers configured `post_hooks`, and the season's global PAR2 now describes the files actually posted (the compressed archive under `--compress`/`--password`, not the original never-posted episode files) without getting wrapped in its own archive.
- `crates/pesto/CHANGELOG.md`: `[Unreleased]` → `[0.6.1] — 2026-08-07`, fresh empty `[Unreleased]` above.
- `crates/pesto/Cargo.toml`: `0.6.0` → `0.6.1` (patch bump — pre-1.0, backwards-compatible bug fixes only, per `RELEASING.md`'s semver rules).
- Verified with a real-world manual run (`--season --obfuscate --password` against 3 real episodes): the season NZB was inspected and validated — 3 obfuscated episode archives + 7 season PAR2 volumes, all 4762 segments with unique message-IDs and contiguous numbering, single shared newsgroup, correct `<meta password>`/`<meta tag>` — and de-obfuscation on download/extraction confirmed working correctly.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all crates green)
- [x] `cargo doc --no-deps -p pesto-poster` (1 pre-existing, unrelated doc-link warning in `memory` module, present on `main`/0.6.0 too — not introduced by this change)
- [x] Manual real-world `--season --obfuscate --password` run, output NZB structurally validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRySgGax7pnkAmLwLByrSj