### PR TITLE
fix(penne): distinguish unreachable segments from confirmed-missing ones in check

### DIFF
--- a/crates/penne/CHANGELOG.md
+++ b/crates/penne/CHANGELOG.md
@@ -50,6 +50,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `--mode` still overrides it per run; omitting both falls back to
   `unpack`, unchanged from before this field existed.
 
+### Fixed
+
+- **`penne check` no longer reports a connection failure the same way it
+  reports a confirmed-missing article — BREAKING.** Prompted by an external
+  caller (a private indexer embedding `penne check` to decide whether a
+  release is still fully grabbable before declaring it dead) pointing out
+  that `CheckOutcome::missing` mixed two very different things: a segment a
+  server explicitly denied via `430`/`423`/`420`, and a segment no server
+  ever actually answered for at all (connection refused, reset mid-handshake,
+  retries exhausted). The latter used to land in `missing` regardless — a
+  provider hiccup or a firewall blip was indistinguishable from confirmed
+  data loss. `CheckOutcome` now has a separate `unreachable: Vec<
+  UnreachableSegment>` field alongside `missing: Vec<MissingSegment>`, plus
+  `CheckOutcome::is_conclusive()` (`true` only when every segment got a real
+  present/absent answer from some server). A tier's definitive `430` still
+  wins as the final verdict even if a *later* tier in the fallback chain is
+  unreachable — only a segment nobody, across every configured tier, ever
+  got a real answer for counts as `unreachable`
+  (`WorkItem::confirmed_missing`, carried across tiers). `CheckOutcome::
+  is_complete()` now also requires `unreachable` to be empty, so a check
+  that never got a conclusive answer is no longer reported as "complete"
+  just because nothing was confirmed missing. `penne check --json` gains
+  `unreachable`/`unreachable_pct`/`unreachable_articles`/`conclusive`
+  fields; the CLI gains exit code `3` ("inconclusive": no confirmed-missing
+  segment, but at least one unreachable one), alongside the existing `0`
+  (complete), `1` (confirmed missing — still wins over inconclusive when
+  both are present), and `2` (fatal error).
+
 ## [0.1.0] — 2026-07-20
 
 First tagged release. `penne` is a fast, `.nzb`-driven NZB downloader for

--- a/crates/penne/README.md
+++ b/crates/penne/README.md
@@ -41,7 +41,9 @@ cargo run --bin penne -- check path/to/release.nzb
 cargo run --bin penne -- check path/to/release1.nzb path/to/release2.nzb
 ```
 
-`penne check` verifies if every article is still present on the configured servers without downloading the bodies or writing anything to disk. It's a high-performance availability check that can pipeline hundreds of STAT commands at once, emitting JSON if asked (`--json`) and exiting with meaningful codes (0 = all present, 1 = missing, 2 = fatal error). It natively supports checking multiple `.nzb` files sequentially while reusing the same active connection pool, avoiding reconnection overhead.
+`penne check` verifies if every article is still present on the configured servers without downloading the bodies or writing anything to disk. It's a high-performance availability check that can pipeline hundreds of STAT commands at once, emitting JSON if asked (`--json`) and exiting with meaningful codes (0 = all present, 1 = confirmed missing, 2 = fatal error, 3 = inconclusive). It natively supports checking multiple `.nzb` files sequentially while reusing the same active connection pool, avoiding reconnection overhead.
+
+A confirmed-missing article (a server returned a definitive `430`/`423`/`420`) is reported separately from an unreachable one (every tried server failed to connect or timed out before ever answering) — `missing` vs `unreachable` in the JSON output, `conclusive: false` when any segment falls in the latter bucket. This distinction matters for callers that act on a check's result (e.g. deciding whether to declare a release dead): a transient network hiccup must never be read as confirmed data loss.
 
 ## Configuration
 

--- a/crates/penne/src/bin/penne.rs
+++ b/crates/penne/src/bin/penne.rs
@@ -114,7 +114,10 @@ enum Command {
     },
     /// Check article availability across one or more `.nzb` files without
     /// downloading. Exits 0 if all articles are present, 1 if any are
-    /// missing, 2 on fatal error.
+    /// confirmed missing (a server returned a definitive "not present"),
+    /// 2 on fatal error, 3 if inconclusive (no confirmed-missing article,
+    /// but at least one segment never got a real answer from any
+    /// configured server — a connection failure, not a `430`).
     Check {
         /// One or more `.nzb` files to check.
         #[arg(required = true)]
@@ -550,6 +553,12 @@ async fn check_availability(
     for seg in &outcome.missing {
         println!("    missing: {} part {}", seg.file_name, seg.part);
     }
+    for seg in &outcome.unreachable {
+        println!(
+            "    unreachable: {} part {} (no server gave a definitive answer)",
+            seg.file_name, seg.part
+        );
+    }
 
     let present_pct = if outcome.total_checked > 0 {
         outcome.total_present as f64 / outcome.total_checked as f64 * 100.0
@@ -587,14 +596,19 @@ async fn check_availability(
 
     anyhow::ensure!(
         outcome.is_complete(),
-        "{incomplete_files} file(s) have missing segments"
+        "{incomplete_files} file(s) incomplete: {} confirmed-missing segment(s), \
+         {} unreachable segment(s) (no server gave a definitive answer)",
+        outcome.missing.len(),
+        outcome.unreachable.len()
     );
     Ok(())
 }
 
 /// `penne check`: first-class article availability checker with JSON output,
-/// exit codes (0=all present, 1=missing, 2=fatal error), multi-NZB support,
-/// configurable pipeline depth, and quiet mode.
+/// exit codes (0=all present, 1=confirmed missing, 2=fatal error,
+/// 3=inconclusive — no confirmed-missing segment, but at least one
+/// unreachable), multi-NZB support, configurable pipeline depth, and quiet
+/// mode.
 #[allow(clippy::too_many_arguments)]
 async fn check(
     nzb_paths: &[PathBuf],
@@ -644,7 +658,8 @@ async fn check(
         .map(penne::config::ServerTier::solo)
         .collect();
 
-    let mut all_complete = true;
+    let mut any_missing = false;
+    let mut any_unreachable = false;
 
     let mut queues = Vec::new();
     let mut nzb_names = Vec::new();
@@ -715,7 +730,15 @@ async fn check(
                 let nzb_name = &nzb_names_clone[q_idx];
                 let mut json_val = serde_json::json!({
                     "nzb": nzb_name,
+                    // `complete` requires every segment be confirmed present —
+                    // false if any is confirmed missing OR merely unreachable.
+                    // Check `conclusive` before trusting `missing`/`missing_pct`
+                    // as a final verdict: if `conclusive` is false, at least one
+                    // segment never got a real answer from any server, and
+                    // treating that as confirmed absence is the false positive
+                    // this field split exists to prevent.
                     "complete": outcome.is_complete(),
+                    "conclusive": outcome.is_conclusive(),
                     "total_articles": outcome.total_checked,
                     "present": outcome.total_present,
                     "missing": outcome.missing_count(),
@@ -724,8 +747,15 @@ async fn check(
                     } else {
                         0.0
                     },
+                    "unreachable": outcome.unreachable_count(),
+                    "unreachable_pct": if outcome.total_checked > 0 {
+                        outcome.unreachable_count() as f64 / outcome.total_checked as f64 * 100.0
+                    } else {
+                        0.0
+                    },
                     "files": outcome.files,
                     "missing_articles": outcome.missing,
+                    "unreachable_articles": outcome.unreachable,
                     "bytes_used": outcome.bytes_used,
                     "elapsed_secs": outcome.elapsed.as_secs_f64(),
                     "articles_per_second": outcome.articles_per_second(),
@@ -822,6 +852,12 @@ async fn check(
                     for seg in &outcome.missing {
                         println!("    missing: {} part {}", seg.file_name, seg.part);
                     }
+                    for seg in &outcome.unreachable {
+                        println!(
+                            "    unreachable: {} part {} (no server gave a definitive answer)",
+                            seg.file_name, seg.part
+                        );
+                    }
                 }
 
                 let present_pct = if outcome.total_checked > 0 {
@@ -841,6 +877,17 @@ async fn check(
                     "  articles present: {}/{} ({:.1}%)",
                     outcome.total_present, outcome.total_checked, present_pct
                 );
+                if !outcome.unreachable.is_empty() {
+                    let unreachable_pct = outcome.unreachable.len() as f64
+                        / outcome.total_checked.max(1) as f64
+                        * 100.0;
+                    println!(
+                        "  unreachable:       {} ({:.1}%) — no server gave a definitive answer; \
+                         not counted as missing, but this check is inconclusive",
+                        outcome.unreachable.len(),
+                        unreachable_pct
+                    );
+                }
                 println!(
                     "  files complete:   {}/{}",
                     complete_files,
@@ -864,11 +911,23 @@ async fn check(
                 );
             }
 
-            if !outcome.is_complete() {
-                all_complete = false;
+            if !outcome.missing.is_empty() {
+                any_missing = true;
+            }
+            if !outcome.unreachable.is_empty() {
+                any_unreachable = true;
             }
         }
     }
 
-    Ok(if all_complete { 0 } else { 1 })
+    // A confirmed-missing article always wins over "merely inconclusive" —
+    // once we know for certain the release is broken, that's more
+    // actionable than "we couldn't fully confirm it".
+    Ok(if any_missing {
+        1
+    } else if any_unreachable {
+        3
+    } else {
+        0
+    })
 }

--- a/crates/penne/src/check.rs
+++ b/crates/penne/src/check.rs
@@ -152,9 +152,33 @@ pub fn channel() -> (CheckProgressSender, CheckProgressReceiver) {
     tokio::sync::mpsc::unbounded_channel()
 }
 
-/// A segment no configured server confirmed via `STAT`.
+/// A segment at least one tried server gave a definitive "not present"
+/// answer for (`430`/`423`/`420`) and no server ever confirmed present —
+/// as opposed to [`UnreachableSegment`], where nobody ever gave a real
+/// answer at all. This is the only case that should ever be treated as
+/// confirmed data loss.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct MissingSegment {
+    pub file_name: String,
+    pub part: u32,
+    pub message_id: String,
+}
+
+/// A segment whose fate was never actually resolved: every server tried
+/// for it either failed to connect or exhausted its `STAT`/`HEAD`/`BODY`
+/// retries (see [`CheckConfig::retries`]) before returning a definitive
+/// present/absent verdict. Deliberately kept out of [`CheckOutcome::missing`]
+/// — folding this in would turn a transient network hiccup (a provider
+/// timing out, a connection reset) into what looks like confirmed data
+/// loss, which is exactly the false positive a caller deciding whether to
+/// declare a release dead must not act on. A segment only ever lands here
+/// if *no* tried server, across every configured tier, ever managed to say
+/// yes or no to it — a single tier's definitive `430` for a segment still
+/// counts as [`MissingSegment`] even if another tier later failed to
+/// connect (see `WorkItem::confirmed_missing`, carried across tiers for
+/// exactly this reason).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct UnreachableSegment {
     pub file_name: String,
     pub part: u32,
     pub message_id: String,
@@ -179,8 +203,15 @@ impl FileCheck {
 pub struct CheckOutcome {
     /// One entry per file, in `.nzb` queue order.
     pub files: Vec<FileCheck>,
-    /// Segments no configured server confirmed present.
+    /// Segments at least one server definitively denied and none confirmed
+    /// present — the only segments that should be treated as confirmed
+    /// data loss. See [`MissingSegment`].
     pub missing: Vec<MissingSegment>,
+    /// Segments no tried server ever gave a real present/absent answer for
+    /// — connection failures and exhausted retries, never a `430`. See
+    /// [`UnreachableSegment`]; a non-empty list here means `missing` is not
+    /// yet a trustworthy final verdict for the release as a whole.
+    pub unreachable: Vec<UnreachableSegment>,
     /// Total bytes actually sent/received over the wire to perform this
     /// check (every `STAT <id>` command and its response, across every
     /// connection opened) — the whole point of `STAT` over a real fetch is
@@ -197,8 +228,19 @@ pub struct CheckOutcome {
 }
 
 impl CheckOutcome {
+    /// True only when every segment was confirmed present by some server —
+    /// `false` for both confirmed-missing segments and merely-unreachable
+    /// ones, since neither case means the release is safely grabbable.
     pub fn is_complete(&self) -> bool {
-        self.missing.is_empty()
+        self.missing.is_empty() && self.unreachable.is_empty()
+    }
+
+    /// True when every segment got a definitive answer (present or
+    /// confirmed absent) from some server. `false` means at least one
+    /// segment's fate is still unknown, so `missing` — even if empty —
+    /// cannot yet be read as "this release is fully present".
+    pub fn is_conclusive(&self) -> bool {
+        self.unreachable.is_empty()
     }
 
     /// Articles checked per second, based on wall-clock elapsed time.
@@ -212,10 +254,16 @@ impl CheckOutcome {
         }
     }
 
-    /// Number of missing segments — convenience alias for
+    /// Number of confirmed-missing segments — convenience alias for
     /// `self.missing.len()`.
     pub fn missing_count(&self) -> usize {
         self.missing.len()
+    }
+
+    /// Number of unreachable segments — convenience alias for
+    /// `self.unreachable.len()`.
+    pub fn unreachable_count(&self) -> usize {
+        self.unreachable.len()
     }
 }
 
@@ -227,6 +275,7 @@ impl Default for CheckOutcome {
         Self {
             files: Vec::new(),
             missing: Vec::new(),
+            unreachable: Vec::new(),
             bytes_used: 0,
             elapsed: Duration::ZERO,
             total_checked: 0,
@@ -239,6 +288,7 @@ impl Default for CheckOutcome {
 enum ItemResolution {
     Found(WorkItem),
     Missing(WorkItem),
+    Unreachable(WorkItem),
 }
 
 /// One segment still needing to be checked.
@@ -248,6 +298,12 @@ struct WorkItem {
     file_name: String,
     part: u32,
     message_id: String,
+    /// Set the instant any tried server gives a definitive `430`/`423`/
+    /// `420` for this item. Carried across tiers so a *later* tier's mere
+    /// connection failure never downgrades an earlier tier's conclusive
+    /// denial into [`UnreachableSegment`] — only an item nobody ever
+    /// managed to get a real answer for should end up there.
+    confirmed_missing: bool,
 }
 
 /// Check every segment in `queue` against `tiers`, tried in priority order;
@@ -299,6 +355,7 @@ pub async fn check_nzbs(
                     file_name: file.name.clone(),
                     part: seg.part,
                     message_id: seg.message_id.clone(),
+                    confirmed_missing: false,
                 });
             }
         }
@@ -326,11 +383,13 @@ pub async fn check_nzbs(
             let mut resolved = vec![0u32; qs.len()];
             let mut present = vec![HashMap::<String, u32>::new(); qs.len()];
             let mut missing = vec![Vec::<MissingSegment>::new(); qs.len()];
+            let mut unreachable = vec![Vec::<UnreachableSegment>::new(); qs.len()];
 
             while let Some(res) = item_rx.recv().await {
                 let q_idx = match &res {
                     ItemResolution::Found(item) => item.queue_idx,
                     ItemResolution::Missing(item) => item.queue_idx,
+                    ItemResolution::Unreachable(item) => item.queue_idx,
                 };
 
                 match res {
@@ -344,13 +403,21 @@ pub async fn check_nzbs(
                             message_id: item.message_id,
                         });
                     }
+                    ItemResolution::Unreachable(item) => {
+                        unreachable[q_idx].push(UnreachableSegment {
+                            file_name: item.file_name,
+                            part: item.part,
+                            message_id: item.message_id,
+                        });
+                    }
                 }
 
                 resolved[q_idx] += 1;
 
                 if resolved[q_idx] == total_items_per_q_clone[q_idx] {
                     let total_items = total_items_per_q_clone[q_idx];
-                    let total_present = total_items - missing[q_idx].len() as u32;
+                    let total_present =
+                        total_items - missing[q_idx].len() as u32 - unreachable[q_idx].len() as u32;
 
                     let files = qs[q_idx]
                         .files
@@ -365,6 +432,7 @@ pub async fn check_nzbs(
                     let outcome = CheckOutcome {
                         files,
                         missing: std::mem::take(&mut missing[q_idx]),
+                        unreachable: std::mem::take(&mut unreachable[q_idx]),
                         bytes_used: 0,
                         elapsed: start_time.elapsed(),
                         total_checked: total_items,
@@ -405,12 +473,26 @@ pub async fn check_nzbs(
     }
 
     let mut missing_per_q: Vec<Vec<MissingSegment>> = vec![Vec::new(); queues.len()];
+    let mut unreachable_per_q: Vec<Vec<UnreachableSegment>> = vec![Vec::new(); queues.len()];
     for item in pending {
-        missing_per_q[item.queue_idx].push(MissingSegment {
-            file_name: item.file_name,
-            part: item.part,
-            message_id: item.message_id,
-        });
+        // `confirmed_missing` was set the instant any tried tier returned a
+        // definitive 430/423/420 for this item (see `WorkItem`'s doc
+        // comment) — a later tier merely failing to connect never clears
+        // it, so this is a true final verdict, not just "the last tier we
+        // happened to try".
+        if item.confirmed_missing {
+            missing_per_q[item.queue_idx].push(MissingSegment {
+                file_name: item.file_name,
+                part: item.part,
+                message_id: item.message_id,
+            });
+        } else {
+            unreachable_per_q[item.queue_idx].push(UnreachableSegment {
+                file_name: item.file_name,
+                part: item.part,
+                message_id: item.message_id,
+            });
+        }
     }
 
     drop(item_tx_opt);
@@ -426,7 +508,8 @@ pub async fn check_nzbs(
 
     for (q_idx, queue) in queues.iter().enumerate() {
         let total_items = total_items_per_q[q_idx];
-        let total_present = total_items - missing_per_q[q_idx].len() as u32;
+        let total_present =
+            total_items - missing_per_q[q_idx].len() as u32 - unreachable_per_q[q_idx].len() as u32;
 
         let files = queue
             .files
@@ -441,6 +524,7 @@ pub async fn check_nzbs(
         outcomes.push(CheckOutcome {
             files,
             missing: std::mem::take(&mut missing_per_q[q_idx]),
+            unreachable: std::mem::take(&mut unreachable_per_q[q_idx]),
             bytes_used: bytes_per_q,
             elapsed: start.elapsed(),
             total_checked: total_items,
@@ -537,13 +621,20 @@ async fn drain_one_tier(
     }
 
     // Any items left in the shared queue were abandoned by workers that exited
-    // early (e.g., due to fatal connection errors). They belong in leftover.
+    // early (e.g., due to fatal connection errors) — never a definitive
+    // 430/423/420, so these are unreachable unless an earlier tier already
+    // confirmed them missing (`WorkItem::confirmed_missing`).
     let mut q = queue.lock().unwrap();
     while let Some(item) = q.pop_front() {
         if is_last_tier {
             emit(progress, false);
             if let Some(tx) = &item_tx {
-                let _ = tx.send(ItemResolution::Missing(item.clone()));
+                let resolution = if item.confirmed_missing {
+                    ItemResolution::Missing(item.clone())
+                } else {
+                    ItemResolution::Unreachable(item.clone())
+                };
+                let _ = tx.send(resolution);
             }
         }
         leftover.push(item);
@@ -653,7 +744,7 @@ async fn stat_worker_loop(
         match stat_batch_with_retry(&mut client, &server, &batch, retries, &mut bytes_used).await {
             Ok(results) => {
                 breaker.store(0, std::sync::atomic::Ordering::Relaxed);
-                for (item, present) in batch.into_iter().zip(results) {
+                for (mut item, present) in batch.into_iter().zip(results) {
                     if present {
                         emit(&progress, true);
                         if let Some(tx) = &item_tx {
@@ -661,6 +752,10 @@ async fn stat_worker_loop(
                         }
                         found.push(item);
                     } else {
+                        // A real `430`/`423`/`420` — a definitive answer,
+                        // never downgraded by a later tier's connection
+                        // failure (see `WorkItem::confirmed_missing`).
+                        item.confirmed_missing = true;
                         if is_last_server {
                             emit(&progress, false);
                             if let Some(tx) = &item_tx {
@@ -672,12 +767,20 @@ async fn stat_worker_loop(
                 }
             }
             Err(_) => {
+                // The whole batch failed to connect/transfer — no server
+                // actually answered, so this is unreachable, not missing,
+                // unless an earlier tier already confirmed it.
                 breaker.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 if is_last_server {
                     for item in &batch {
                         emit(&progress, false);
                         if let Some(tx) = &item_tx {
-                            let _ = tx.send(ItemResolution::Missing(item.clone()));
+                            let resolution = if item.confirmed_missing {
+                                ItemResolution::Missing(item.clone())
+                            } else {
+                                ItemResolution::Unreachable(item.clone())
+                            };
+                            let _ = tx.send(resolution);
                         }
                     }
                 }
@@ -727,7 +830,7 @@ async fn single_item_worker_loop(
             let mut q = queue.lock().expect("queue mutex poisoned");
             q.pop_front()
         };
-        let Some(item) = item else { break };
+        let Some(mut item) = item else { break };
 
         let present = single_item_with_retry(
             &mut client,
@@ -749,7 +852,10 @@ async fn single_item_worker_loop(
                 found.push(item);
             }
             Ok(false) => {
+                // A real `423`/`430` — definitive, never downgraded by a
+                // later tier's connection failure.
                 breaker.store(0, std::sync::atomic::Ordering::Relaxed);
+                item.confirmed_missing = true;
                 if is_last_server {
                     emit(&progress, false);
                     if let Some(tx) = &item_tx {
@@ -759,11 +865,19 @@ async fn single_item_worker_loop(
                 leftover.push(item);
             }
             Err(_) => {
+                // Connection/transport failure after exhausting retries —
+                // nobody actually answered, so unreachable, not missing,
+                // unless an earlier tier already confirmed it.
                 breaker.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 if is_last_server {
                     emit(&progress, false);
                     if let Some(tx) = &item_tx {
-                        let _ = tx.send(ItemResolution::Missing(item.clone()));
+                        let resolution = if item.confirmed_missing {
+                            ItemResolution::Missing(item.clone())
+                        } else {
+                            ItemResolution::Unreachable(item.clone())
+                        };
+                        let _ = tx.send(resolution);
                     }
                 }
                 leftover.push(item);

--- a/crates/penne/tests/check.rs
+++ b/crates/penne/tests/check.rs
@@ -632,3 +632,182 @@ async fn body_method_bytes_used_reflects_a_real_fetch_not_a_cheap_check() {
         stat_outcome.bytes_used
     );
 }
+
+// ── missing vs unreachable ──────────────────────────────────────────────
+//
+// A real report from a caller embedding `penne` as a library: it treats
+// `missing` as "confirmed data loss" (e.g. deciding whether to declare a
+// release dead). Before this, a connection failure — a provider timing out
+// or resetting mid-handshake — landed in `missing` exactly the same as a
+// real `430`, because nothing distinguished "no server ever answered" from
+// "a server said no". These tests reproduce that failure mode directly.
+
+/// Spawn a listener that accepts a connection and closes it immediately,
+/// without ever writing the NNTP greeting — unlike [`spawn_fake_server`],
+/// this never gets far enough to answer `STAT`/`HEAD`/`BODY` at all.
+/// `DownloadClient::connect` must fail against this the same way it would
+/// against a server that's down or resetting connections.
+fn spawn_dead_server() -> SocketAddr {
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    std_listener.set_nonblocking(true).unwrap();
+    let addr = std_listener.local_addr().unwrap();
+    let listener = TcpListener::from_std(std_listener).unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            drop(stream); // closed before any greeting is written
+        }
+    });
+
+    addr
+}
+
+/// The core regression: a segment nobody ever actually answered for must
+/// never be reported the same way as one a server explicitly denied.
+#[tokio::test]
+async fn connection_failure_is_reported_as_unreachable_not_missing() {
+    let addr = spawn_dead_server();
+    let queue = queue_with(&[("movie.bin", &["a1@x"])]);
+
+    let outcome = check_queue(
+        &queue,
+        &[ServerTier::solo(server_entry(addr))],
+        &CheckConfig::new(CheckMethod::Stat, 0),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        outcome.missing.is_empty(),
+        "a connection failure must never be reported as confirmed-missing — \
+         no server ever actually answered `STAT` for this segment"
+    );
+    assert_eq!(outcome.unreachable.len(), 1);
+    assert_eq!(outcome.unreachable[0].message_id, "a1@x");
+    assert!(!outcome.is_conclusive());
+    assert!(!outcome.is_complete());
+}
+
+/// Same regression via `CheckMethod::Head`/`Body`, which run through
+/// `single_item_worker_loop` — a separate code path from `Stat`'s pipelined
+/// batches, so it needs its own coverage.
+#[tokio::test]
+async fn head_and_body_connection_failure_is_unreachable_not_missing() {
+    let queue = queue_with(&[("movie.bin", &["a1@x"])]);
+
+    for method in [CheckMethod::Head, CheckMethod::Body] {
+        let addr = spawn_dead_server();
+        let outcome = check_queue(
+            &queue,
+            &[ServerTier::solo(server_entry(addr))],
+            &CheckConfig::new(method, 0),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            outcome.missing.is_empty(),
+            "{method}: connection failure must not be reported as confirmed-missing"
+        );
+        assert_eq!(outcome.unreachable.len(), 1, "{method}");
+    }
+}
+
+/// A tier that definitively denies a segment (`430`) must have that verdict
+/// stick even when a *later* tier in the fallback chain is unreachable —
+/// otherwise a working provider's confirmed absence would be masked by an
+/// unrelated backup provider being down, hiding a segment we already know
+/// for certain is gone.
+#[tokio::test]
+async fn confirmed_missing_survives_a_later_tiers_connection_failure() {
+    let tier1_addr = spawn_fake_server(HashSet::new()); // answers, doesn't have it: 430
+    let tier2_addr = spawn_dead_server(); // never answers at all
+
+    let queue = queue_with(&[("movie.bin", &["a1@x"])]);
+    let servers = vec![
+        ServerTier::solo(server_entry(tier1_addr)),
+        ServerTier::solo(server_entry(tier2_addr)),
+    ];
+
+    let outcome = check_queue(
+        &queue,
+        &servers,
+        &CheckConfig::new(CheckMethod::Stat, 0),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        outcome.missing.len(),
+        1,
+        "tier1's definitive 430 must be the final verdict"
+    );
+    assert!(
+        outcome.unreachable.is_empty(),
+        "tier2 merely being unreachable must not downgrade tier1's confirmed \
+         absence into 'we don't know' — we DO know, tier1 said so"
+    );
+    assert!(outcome.is_conclusive());
+}
+
+/// Mirror of the above with the order reversed: an unreachable tier tried
+/// first must not stop a later tier's definitive `430` from being the final
+/// answer.
+#[tokio::test]
+async fn confirmed_missing_from_a_later_tier_after_an_earlier_unreachable_one() {
+    let tier1_addr = spawn_dead_server();
+    let tier2_addr = spawn_fake_server(HashSet::new());
+
+    let queue = queue_with(&[("movie.bin", &["a1@x"])]);
+    let servers = vec![
+        ServerTier::solo(server_entry(tier1_addr)),
+        ServerTier::solo(server_entry(tier2_addr)),
+    ];
+
+    let outcome = check_queue(
+        &queue,
+        &servers,
+        &CheckConfig::new(CheckMethod::Stat, 0),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.missing.len(), 1);
+    assert!(outcome.unreachable.is_empty());
+    assert!(outcome.is_conclusive());
+}
+
+/// When *every* configured tier is unreachable, the segment's fate really
+/// is unknown — this is the one case where `unreachable` (not `missing`)
+/// is the correct final answer.
+#[tokio::test]
+async fn every_tier_unreachable_reports_unreachable_not_missing() {
+    let tier1_addr = spawn_dead_server();
+    let tier2_addr = spawn_dead_server();
+
+    let queue = queue_with(&[("movie.bin", &["a1@x"])]);
+    let servers = vec![
+        ServerTier::solo(server_entry(tier1_addr)),
+        ServerTier::solo(server_entry(tier2_addr)),
+    ];
+
+    let outcome = check_queue(
+        &queue,
+        &servers,
+        &CheckConfig::new(CheckMethod::Stat, 0),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(outcome.missing.is_empty());
+    assert_eq!(outcome.unreachable.len(), 1);
+    assert!(!outcome.is_conclusive());
+}


### PR DESCRIPTION
## Summary

- `CheckOutcome.missing` used to mix two very different things: a segment a server explicitly denied via `430`/`423`/`420`, and a segment no server ever actually answered for at all (connection refused, reset mid-handshake, retries exhausted). The latter landed in `missing` exactly the same as the former.
- Adds `CheckOutcome.unreachable: Vec<UnreachableSegment>` and `CheckOutcome::is_conclusive()`. A tier's definitive `430` still wins as the final verdict even if a *later* tier in the fallback chain is unreachable — only a segment nobody, across every configured tier, ever got a real answer for counts as `unreachable` (`WorkItem::confirmed_missing` carried across tiers).
- `is_complete()` now also requires `unreachable` to be empty — a check that never got a conclusive answer is no longer reported as "complete" just because nothing was confirmed missing.
- `penne check --json` gains `unreachable`/`unreachable_pct`/`unreachable_articles`/`conclusive`. CLI gains exit code `3` ("inconclusive"), alongside the existing `0`/`1`/`2`.
- **Breaking**: callers reading `CheckOutcome.missing`/`is_complete()` directly will see fewer false positives — a connection hiccup no longer inflates `missing`.

## Why

An external caller ([curupirashare](https://curupira.cc), a private Usenet indexer) wants to use `penne check --independent-servers --json` in batch instead of its own per-article NNTP client, to cut check latency and VPS load. It currently can't do that safely: its own client goes out of its way to never mark an article absent on a connection error (a past incident sent healthy releases to its "graveyard" over a transient network blip), and `penne check`'s `missing` field couldn't make that same distinction. This PR closes that gap without changing anything about `Stat`/`Head`/`Body`'s wire behavior.

## Test plan

- [x] `cargo fmt -p penne --check`
- [x] `cargo clippy -p penne --all-targets -- -D warnings`
- [x] `cargo test -p penne` (128 tests, incl. 6 new: connection failure → unreachable for `Stat` and `Head`/`Body`, confirmed-missing survives a later tier's connection failure in both orderings, every-tier-unreachable, is_conclusive/is_complete)
- [x] `cargo check --workspace` (sugo/upapasta unaffected — neither uses `penne::check`)
- [x] Manual: `penne check --help` reflects new exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLwNVqxJg1RoN33q8xEis5