### PR TITLE
docs: rewritten roadmap from the workspace audit

### DIFF
--- a/ROADMAP.new.md
+++ b/ROADMAP.new.md
@@ -1,0 +1,267 @@
+# Roadmap
+
+Development plan for the `pesto` workspace: **pesto** (poster + core library),
+**parmesan** (PAR2 engine), **penne** (NZB downloader), **sugo** (SABnzbd-compatible
+web UI) and **upapasta** (TUI).
+
+This file supersedes the phase-by-phase historical roadmap. Completed work is
+recorded in each crate's `CHANGELOG.md`; what follows is only what is *left*.
+
+Principles (from `CLAUDE.md`, unchanged): `pesto` stays lean and fast on the hot
+path; complex UX lives in `upapasta`; crates integrate as libraries, never as
+subprocesses; shared types live in `pesto` and are reused, not redefined.
+
+---
+
+## Current status
+
+**Solid.** The posting pipeline is mature and heavily exercised. yEnc encoding has
+scalar/SSSE3/AVX2 backends with byte-for-byte differential tests on x86-64; the
+NNTP layer has pipelining, keepalive, multi-server failover, adaptive pipeline
+depth and bounded connect/handshake timeouts; PAR2 generation is memory-budgeted
+with multi-pass splitting and verified against real `par2cmdline`. Release file
+ordering, obfuscation modes, the streaming STAT check with repost/recovery, and
+season-mode global PAR2 with proper File Description packets are all done and
+tested. `cargo clippy --all-targets` is clean across the workspace.
+
+**Main remaining risk.** The audit that produced this roadmap found that the
+guarantees are unevenly distributed:
+
+- **Untrusted input is trusted in places.** PAR2-supplied file names become
+  filesystem paths with no sanitization on the read, write and rename paths
+  (#109). File names become NNTP header values and yEnc control lines with no
+  validation (#115). `penne` already solved this class for NZB-supplied names;
+  the other sources were missed.
+- **Guarantees hold on x86-64 and are unverified elsewhere.** Every yEnc SIMD
+  differential test is `#[cfg(target_arch = "x86_64")]`, so the NEON encoder that
+  produces every article on ARM has no test at all (#111) — and the NNTP layer
+  depends on the encoder's `.`-at-line-start escape without asserting it (#114).
+- **The engineered-for path and the newer path diverge.** `producer` has a full
+  memory budget with pass splitting; season PAR2 has none (#110). `par2_geometry`
+  honours three geometry flags; the season path honours one (#117). `RunFingerprint`
+  guards five parameters; six more change the posted bytes (#112).
+- **Resume is fragile at the edges.** A corrupt state file aborts the run rather
+  than starting fresh, and `save` is not atomic (#113); `--resume` silently does
+  nothing at all under `--compress` (#119).
+- **The decode side has no memory story.** `RecoverySet::load` holds the entire
+  recovery set in RAM regardless of size (#118), and `verify` never checks file
+  length or `md5_full` (#116).
+
+Phase 1 below closes the correctness and safety gaps. Everything after it is
+feature and polish work.
+
+---
+
+## Phase 1 — Correctness, safety and input hardening
+
+**The gate for a 1.0-shaped release.** Nothing here is speculative; every item has
+a filed issue with a location and a failure mode.
+
+### 1a — Untrusted input boundaries *(highest priority)*
+
+- [ ] **#109 — Sanitize PAR2-supplied file names before they become paths.**
+      Do it once in `RecoverySet::load` so `parmesan::verify`, `parmesan::repair`
+      and `penne::deobfuscate` all inherit it. Reject absolute paths, drive/UNC
+      prefixes and `..` components; decide explicitly whether legitimate PAR2
+      subdirectories are kept (scoped under the base) or flattened. Add a
+      post-join containment assert as belt and braces, plus a regression test per
+      call site.
+- [ ] **#115 — Validate published file names at the `walk::InputFile` chokepoint.**
+      Reject or replace CR, LF, NUL and C0 controls before a name can reach a
+      header, a `=ybegin` line or the NZB. Independently harden both sinks:
+      `Article::build_headers` must refuse line terminators in any header value,
+      and `nzb::escape` must handle XML-illegal control characters. Handle `"` in
+      `default_subject` while there.
+- [ ] **#116 — Reject inconsistent PAR2 metadata at load time.** Validate that a
+      `FileEntry`'s IFSC slice count matches `length.div_ceil(slice_size)`, and
+      make `repair::slice_write_len` saturating, so a crafted `.par2` cannot abort
+      the process.
+
+### 1b — Cross-architecture verification
+
+- [ ] **#111 — Test the NEON yEnc encoder.** Mirror the existing x86 differential
+      macros for aarch64, covering the same vectors (all byte values, critical
+      bytes, positional bytes at short `line_len`s, single byte, empty, large
+      payload). Pin `encoded_size_neon` to `encode_neon` output length. Fix the
+      `# Safety` doc on `encoded_size_neon` (it underflows on empty input).
+- [ ] **Replace hand-written SIMD vectors with a property test.** One proptest over
+      arbitrary `(data, line_len)` asserting every available backend against
+      `encode_scalar` covers all architectures at once and does not need a new
+      list per backend. `proptest` is already a workspace dependency.
+- [ ] **Add an aarch64 CI job** (GitHub ARM runners or `cross`/QEMU) so 1b actually
+      runs. Without it these tests only pass on developer machines that have the
+      hardware.
+- [ ] **#114 — Assert the no-leading-dot invariant where it is relied on.**
+      `debug_assert!` in `post_parts_inner`/`enqueue_post`, a comment explaining
+      why the body is deliberately not dot-stuffed, and one test that a crafted
+      payload never yields a body line starting with `.`. Keeping the body
+      unstuffed is the right call for the hot path — this is about making the
+      dependency explicit.
+
+### 1c — PAR2 memory and geometry consistency
+
+- [ ] **#110 — Give season PAR2 the same memory budget as `producer`.** Compute a
+      budget from `Ceiling::discover` + `budget::share_of` + `address_space_budget`
+      and split into multiple read passes using the `exponent_start` parameter
+      `try_new_smart` already takes. Pass `0` for the connection reserve during
+      generation, as `--par2-before-upload` already does.
+- [ ] **Factor the budget and pass-splitting logic out of `producer`** into a
+      helper both paths call. Three copies of the geometry/budget logic is how they
+      drifted in the first place.
+- [ ] **#117 — Route season geometry through `par2_geometry`** so
+      `--par2-slice-count` and `--par2-recovery-count` behave identically in both
+      paths. Fix the append-mode volume writes (`truncate` on first touch, reuse
+      the handle), sort or assert recovery-slice exponent order, and correct the
+      volume-naming example in the doc comment.
+- [ ] **#118 — Split `RecoverySet::load` into metadata-only and block-loading
+      paths.** `verify`, `health` and `deobfuscate` provably need no recovery
+      blocks. For `repair`, index blocks by `(path, offset, len)` and stream them,
+      or at minimum load only `total_bad_slices()` of them — Reed-Solomon is MDS,
+      so any `m` blocks reconstruct `m` missing inputs.
+
+### 1d — Resume robustness
+
+- [ ] **#112 — Derive `RunFingerprint` from `Config`.** Add `par2_slice_size`,
+      `par2_slice_count`, `par2_recovery_count`, `compress_volume_size`,
+      `compress_password` (hashed — the state file is plaintext) and `line_length`.
+      Build it in one `RunFingerprint::from_config` used by both construction
+      sites, generate `resume_flags_string` from the same source, and add a test
+      asserting each field changes the fingerprint.
+- [ ] **#113 — Make resume state robust.** `load` returns an empty state on a parse
+      error (as its doc already promises), keeping hard errors only for genuine
+      I/O failures; `save` writes to a temp file and renames. This is also the
+      migration path for the new fingerprint fields.
+- [ ] **#119 — Decide `--resume` + `--compress` explicitly.** Preferred: keep the
+      generated archive keyed by `archive_stem` and reuse it when its recorded
+      `{size, mtime}` still match, which makes the existing `archive_stem`
+      persistence pay off. Otherwise document the incompatibility, warn once up
+      front rather than mid-run, and drop the dead machinery.
+
+### 1e — Documentation truth
+
+- [ ] Refresh `parmesan/src/recovery_set.rs` and `repair.rs` module docs — both
+      still describe the pre-Phase-48 ordering situation and point at roadmap
+      phases that have moved on.
+- [ ] Audit `docs/memory-management.md` against what `--memory-limit` actually
+      bounds once #110 lands.
+
+---
+
+## Phase 2 — `pesto` engine work
+
+- [ ] **Connection pool reuse across `--each` episodes.** *(Carried over; still the
+      largest single performance win available.)* Each episode currently builds a
+      fresh pool — ~60 TLS+AUTH cycles per episode, ~1,560 for a 26-episode run
+      (~18% of runtime). Requires decoupling pool lifecycle from episode lifecycle
+      so workers hold connections and receive a new work channel per episode.
+      Complications: `--jobs N` runs episodes in parallel with independent pools,
+      and each episode builds its own `Shared`. A connection-broker layer is the
+      likely shape. Note that Phase 35 keepalive already removed the *spurious*
+      reconnect bursts; this is the intentional teardown that remains.
+- [ ] **Real pause/resume in the poster.** `upapasta` has the UI for it and can
+      only freeze stats today. Needs a public `pesto` API that suspends workers at
+      a segment boundary and resumes without tearing down connections — closely
+      related to the broker work above.
+- [ ] **Server-side queue limit detection** (`441 Too many articles`) to cap
+      pipeline depth adaptively. Previously deferred; revisit if reports appear.
+- [ ] **Season PAR2 from spooled slices** *(deferred, low priority)*. Avoids one
+      full re-read pass over the season (~5–10% on large seasons). Requires
+      `FileHasher` state serialization alongside slices. Only worth doing if
+      real-world feedback says the re-read hurts; Phase 1c's pass-splitting work
+      may make this cheaper to land.
+
+---
+
+## Phase 3 — `upapasta` to feature parity
+
+The remaining gap against the legacy Python version.
+
+- [ ] **Watch mode** with smart rules and move-to-done logic — the single largest
+      missing feature.
+- [ ] **Metadata enrichment**: TMDb lookup, improved NFO generation.
+- [ ] **First-run setup wizard.**
+- [ ] Directory-level queuing (Space on a directory marks its files recursively).
+- [ ] Auto-switch to Dashboard when an upload starts.
+- [ ] Real pause (blocked on Phase 2's pesto API).
+- [ ] Theme support (dark/light, user-configurable colors).
+- [ ] TUI performance tuning during long uploads.
+- [ ] Comprehensive error handling and user feedback.
+- [ ] Migration path from the Python version, then retire/archive it.
+
+---
+
+## Phase 4 — `penne` and `sugo`
+
+`penne` first — `sugo` builds on it.
+
+- [ ] Multi-`.nzb` batch input (a queue of queues).
+- [ ] Exit codes distinguishing "fully complete", "complete after repair" and
+      "incomplete"; `--verbose`/`--quiet` matching `pesto`'s conventions.
+- [ ] On-demand extra-volume fetching: today every `.par2` volume in the NZB is
+      downloaded whether or not repair needs it.
+- [ ] Parallel `verify()` — currently single-threaded and sequential; pairs
+      naturally with #118's streaming rework.
+- [ ] Double-buffered writer / buffer pool on the assembly path.
+- [ ] Incremental extraction (`DirectUnpack`-style).
+- [ ] Benchmark against a real indexer/provider pair.
+- [ ] Add `penne` to the release workflow once its CLI surface is stable.
+
+---
+
+## Phase 5 — API stability and release engineering
+
+Prerequisite for anything resembling 1.0.
+
+- [ ] **Freeze the `pesto` public API surface.** `lib.rs` currently re-exports
+      nearly every module. Decide what is genuinely public (`post`,
+      `post_cancelable`, `upload::run_upload`, `config`, `progress`, `walk`) versus
+      what is public only because `upapasta`/`penne` needed it, and mark the rest
+      `#[doc(hidden)]` or move it behind a `internals` feature. Season PAR2
+      (`generate_and_write_season_par2`) is public API today with a
+      caller-supplied output directory and no contract about it — see #117.
+- [ ] **`#![deny(missing_docs)]` on `parmesan`**, with runnable `# Examples` in
+      `lib.rs`; `cargo doc --no-deps` clean.
+- [ ] **Test strategy.** Property tests for the encoders (Phase 1b), a fixture
+      corpus of real third-party `.par2` files (varying slice sizes, Unicode
+      names, packet orders), an optional non-blocking CI job running the real
+      `par2cmdline`, and a `cargo-fuzz` harness for `packet_reader.rs`.
+- [ ] **Packaging.** Portable binaries for Linux (glibc + musl), Windows and
+      macOS (including aarch64, which Phase 1b makes safe to ship); man pages via
+      `clap_mangen`; confirm the release workflow publishes every artifact.
+- [ ] **Documentation.** Complete flag tables and documented exit codes per crate;
+      an `INTERNALS.md` for parmesan covering GF(2¹⁶) Reed-Solomon, the PAR2
+      packet subset implemented, and the volume layout algorithm.
+
+---
+
+## Deferred / intentionally not implemented
+
+Recorded so they are not re-litigated:
+
+- **Posting order stays File-ID order** when `--par2 > 0` with multiple files. The
+  PAR2 spec numbers input blocks by File-ID order and the producer streams slices
+  in `metas` order; decoupling them would cost a second full read pass for no
+  user-visible gain. Indexers group and sort by Subject, which Phase 48 already
+  fixed independently. See `--file-counter`.
+- **`--file-counter` stays off by default under `--obfuscate=full`/`paranoid`.** A
+  stable release-wide `[N/M]` is exactly the correlation vector those modes exist
+  to deny. On by default for `none`/`full-shared`, which already accept that
+  correlation.
+- **`DEFAULT_LINE_LENGTH` stays 128.** Raising to 256 was benchmarked and rejected.
+- **The AVX2 yEnc encoder is not preferred over SSSE3** by the dispatcher —
+  investigated and closed; SSSE3 wins on the measured hardware.
+- **yEnc SIMD escaping / multi-line encoding** (PSHUFB in-place escape insertion,
+  AVX2/AVX-512 multi-line) remain unscheduled ideas, not commitments.
+- **Issue #68's indexer grouping** is closed as indexer-side. NZBIndex/Binsearch
+  key "complete set" grouping off the `.volNNN+MMM.par2` filename pattern, not the
+  subject counter. The subject-shape fix (always emit `(part/total)`) and
+  `--par2-before-upload` both landed and are the actionable parts.
+
+---
+
+## References
+
+- yEnc draft v1.3: <http://www.yenc.org/yenc-draft.1.3.txt>
+  ([mirror](https://github.com/caronc/newsreap/blob/master/docs/yenc-draft.1.3.txt))
+- RFC 3977 (NNTP), RFC 4643 (NNTP AUTHINFO)
+- PAR2 specification: <https://parchive.sourceforge.net/docs/specifications/parity-volume-spec/article-spec.html>


### PR DESCRIPTION
Replaces the phase-by-phase historical roadmap with a forward-looking one:
a current-status summary, then five ordered phases covering only remaining
work. Completed work stays recorded in each crate's `CHANGELOG.md`.

Added as `ROADMAP.new.md` rather than overwriting `ROADMAP.md`, so dropping
the old 811-line file stays a deliberate call. Swap with
`git mv ROADMAP.new.md ROADMAP.md` when ready.

## Phases

**Phase 1 — Correctness, safety and input hardening.** The gate for a
1.0-shaped release. Every item tracks an issue opened by the audit
(#109–#119), grouped into: untrusted-input boundaries, cross-architecture
verification, PAR2 memory/geometry consistency, resume robustness, and
documentation truth.

**Phase 2 — `pesto` engine.** Connection pool reuse across `--each`, real
worker pause, server-side queue limit detection, season PAR2 from spooled
slices.

**Phase 3 — `upapasta` parity.** Watch mode, metadata enrichment, setup
wizard, and the remaining TUI polish items.

**Phase 4 — `penne` / `sugo`.** Batch NZB input, exit codes, on-demand
volume fetching, parallel verify, incremental extraction.

**Phase 5 — API stability and release engineering.** Freezing the `pesto`
public surface, `#![deny(missing_docs)]` on parmesan, test strategy,
packaging, documentation.

A closing section records intentionally deferred decisions (File-ID posting
order, `--file-counter` defaults per obfuscation mode, `DEFAULT_LINE_LENGTH`
staying 128, SSSE3 over AVX2, issue #68 as indexer-side) so they are not
re-litigated.

## Audit findings this is built on

The three themes behind Phase 1:

- **Untrusted input is trusted in places.** PAR2-supplied file names become
  filesystem paths with no sanitization on the read, write and rename paths
  (#109) — `penne` already solved this class for NZB-supplied names in
  `queue.rs::sanitize_file_name`, but the PAR2 source was missed. File names
  also reach NNTP header values and yEnc control lines unvalidated (#115).
- **Guarantees hold on x86-64 and are unverified elsewhere.** Every yEnc SIMD
  differential test is `#[cfg(target_arch = "x86_64")]`, so the NEON encoder
  producing every article on ARM has no test at all (#111); the NNTP layer
  depends on the encoder's `.`-at-line-start escape without asserting it
  (#114).
- **The engineered path and the newer path diverged.** `producer` has a full
  memory budget with pass splitting, season PAR2 has none (#110);
  `par2_geometry` honours three geometry flags, the season path one (#117);
  `RunFingerprint` guards five parameters, six more change posted bytes
  (#112).

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --workspace -- -D warnings` — exit 0
- `cargo test --workspace` — exit 0, 0 failed across every target

Docs-only change; no source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR4BoNpwBRRvViEhypFjsE
