### PR TITLE
fix: Phase 1 correctness, safety and resume hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,23 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: Test
         run: cargo test --all
+
+  # Phase 1b: NEON yEnc encoder + aarch64 unit tests never run on x86-64.
+  test-aarch64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup toolchain install stable --component rustfmt --component clippy
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-arm-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - name: Clippy (pesto + parmesan)
+        run: cargo clippy -p pesto-poster -p parmesan-par2 --all-targets -- -D warnings
+      - name: Test (pesto + parmesan)
+        run: cargo test -p pesto-poster -p parmesan-par2 --lib

--- a/crates/parmesan/src/encoder.rs
+++ b/crates/parmesan/src/encoder.rs
@@ -102,8 +102,15 @@ type Avx2Table = (
 pub(super) enum RecoveryBufferSet {
     Normal(Vec<Vec<u16>>),
     /// Each inner `Vec<u8>` has length `altmap_size(slice_words)` = `slice_words * 2`.
+    /// Only ever constructed on x86_64 (see `new_altmap`); matched against
+    /// generically elsewhere so it can't be `#[cfg(target_arch = "x86_64")]`
+    /// itself without breaking those match arms on other targets.
+    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
     Altmap(Vec<Vec<u8>>),
     /// Each inner `Vec<u8>` has length `shuffle2x_buffer_size(slice_words)` = `slice_words * 2`.
+    /// Only ever constructed on x86_64 (see `new_shuffle2x`); same reasoning
+    /// as `Altmap` above.
+    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
     Shuffle2x(Vec<Vec<u8>>),
 }
 

--- a/crates/parmesan/src/gf16_mac.rs
+++ b/crates/parmesan/src/gf16_mac.rs
@@ -78,6 +78,10 @@ fn mac_scalar(gf: &Gf16, dst: &mut [u8], src: &[u8], coeff: u16) {
 /// `tl_*`/`th_*` come from the low byte's two nibbles (weights 1 and 16);
 /// `hl_*`/`hh_*` come from the high byte's two nibbles (weights 256 and
 /// 4096); `_l`/`_h` suffixes select the low/high output byte.
+///
+/// Only ever built by `mac_ssse3`/`mac_avx2` below, both x86_64-only —
+/// gated the same way so it isn't flagged as dead code on other targets.
+#[cfg(target_arch = "x86_64")]
 struct NibbleTables {
     tl_l: [u8; 16],
     tl_h: [u8; 16],
@@ -94,6 +98,7 @@ struct NibbleTables {
     byte_high: [u16; 256],
 }
 
+#[cfg(target_arch = "x86_64")]
 impl NibbleTables {
     fn build(gf: &Gf16, coeff: u16) -> Self {
         let mut t = NibbleTables {

--- a/crates/parmesan/src/main.rs
+++ b/crates/parmesan/src/main.rs
@@ -446,7 +446,7 @@ async fn run_create(cli: CreateArgs) -> Result<()> {
 }
 
 fn run_verify(args: VerifyArgs) -> Result<()> {
-    let set = RecoverySet::load(&args.index)
+    let set = RecoverySet::load_metadata(&args.index)
         .with_context(|| format!("loading recovery set from `{}`", args.index.display()))?;
     let base_dir = args
         .index
@@ -496,7 +496,7 @@ fn run_verify(args: VerifyArgs) -> Result<()> {
 }
 
 fn run_repair(args: RepairArgs) -> Result<()> {
-    let set = RecoverySet::load(&args.index)
+    let mut set = RecoverySet::load_metadata(&args.index)
         .with_context(|| format!("loading recovery set from `{}`", args.index.display()))?;
     let base_dir = args
         .index
@@ -537,6 +537,7 @@ fn run_repair(args: RepairArgs) -> Result<()> {
         out_dir: args.out_dir.clone(),
         dry_run: args.dry_run,
     };
+    set.load_recovery_blocks(Some(report.total_bad_slices()))?;
     let plan = repair::repair(&set, &report, &base_dir, &options)?;
 
     if args.json {

--- a/crates/parmesan/src/packet_reader.rs
+++ b/crates/parmesan/src/packet_reader.rs
@@ -31,6 +31,16 @@ pub struct RawPacket {
 /// of input content — every position is inspected at most once, so a file
 /// full of near-miss magic sequences cannot force quadratic behaviour.
 pub fn read_packets(data: &[u8]) -> Vec<RawPacket> {
+    read_packets_with_offsets(data)
+        .into_iter()
+        .map(|(p, _)| p)
+        .collect()
+}
+
+/// Same as [`read_packets`], but each packet is paired with its byte offset
+/// in `data` (start of the 64-byte header). Used by [`crate::recovery_set`]
+/// to index recovery blocks without retaining their bodies.
+pub fn read_packets_with_offsets(data: &[u8]) -> Vec<(RawPacket, usize)> {
     let mut packets = Vec::new();
     let mut pos = 0usize;
 
@@ -41,7 +51,7 @@ pub fn read_packets(data: &[u8]) -> Vec<RawPacket> {
         }
         match try_parse_one(&data[pos..]) {
             Some((raw, consumed)) => {
-                packets.push(raw);
+                packets.push((raw, pos));
                 pos += consumed;
             }
             None => pos += 1,

--- a/crates/parmesan/src/recovery_set.rs
+++ b/crates/parmesan/src/recovery_set.rs
@@ -5,18 +5,15 @@
 //! Reed-Solomon coefficients is the *numeric order of File IDs as listed in
 //! the Main packet*, not the order files happen to appear on disk or on the
 //! command line. [`RecoverySet::files`] always reflects that canonical
-//! order. Note that as of this writing the encoder in [`crate::ops`] /
-//! `main.rs` feeds slices to [`crate::encoder::RecoveryEncoder`] in
-//! command-line order instead — see the Phase 22 notes in `ROADMAP.md` for
-//! why that must be reconciled before repair (Phase 22d) can be correct
-//! against third-party PAR2 tools. Verification does not depend on
-//! Reed-Solomon coefficients at all, so it is unaffected.
+//! order. The encoder in [`crate::ops`] sorts the same way (`sort_files_by_file_id`)
+//! before feeding slices to [`crate::encoder::RecoveryEncoder`], so encode,
+//! verify and repair share one File-ID order.
 
 use crate::packet::{self, SliceChecksum};
-use crate::packet_reader::{read_packets, RawPacket};
-use anyhow::{Context, Result};
+use crate::packet_reader::{read_packets, read_packets_with_offsets};
+use anyhow::{bail, Context, Result};
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 /// Fields parsed from one File Description packet.
 struct FileDescFields {
@@ -45,6 +42,16 @@ pub struct FileEntry {
     pub slice_checksums: Vec<SliceChecksum>,
 }
 
+/// On-disk location of one recovery block. The body is not held in RAM
+/// until [`RecoverySet::load_recovery_blocks`] reads it.
+#[derive(Debug, Clone)]
+pub struct RecoveryBlockLoc {
+    pub path: PathBuf,
+    /// Byte offset of the recovery *data* (after the 4-byte exponent).
+    pub offset: u64,
+    pub len: usize,
+}
+
 /// A fully assembled PAR2 recovery set: the Main packet's file list plus
 /// every recovery block found across the index and volume files on disk.
 #[derive(Debug, Clone)]
@@ -56,8 +63,11 @@ pub struct RecoverySet {
     /// Files in the canonical order used for Reed-Solomon coefficients
     /// (numeric order of File ID, per the PAR2 spec).
     pub files: Vec<FileEntry>,
-    /// Recovery blocks found on disk, keyed by exponent.
+    /// Recovery blocks loaded into memory, keyed by exponent. Empty after
+    /// [`Self::load_metadata`] until [`Self::load_recovery_blocks`].
     pub recovery_blocks: BTreeMap<u32, Vec<u8>>,
+    /// Every recovery block on disk, whether or not its body is loaded.
+    pub recovery_index: BTreeMap<u32, RecoveryBlockLoc>,
 }
 
 impl RecoverySet {
@@ -65,7 +75,19 @@ impl RecoverySet {
     /// directory for every `.par2` file that belongs to the same recovery
     /// set — matched by recovery-set ID, not by file name, so any naming
     /// scheme (this encoder's or another tool's) is picked up.
+    ///
+    /// This loads every recovery block into RAM. Prefer
+    /// [`Self::load_metadata`] when the caller only needs the file list
+    /// (`verify`, `health`, deobfuscation).
     pub fn load(index_path: impl AsRef<Path>) -> Result<Self> {
+        let mut set = Self::load_metadata(index_path)?;
+        set.load_recovery_blocks(None)?;
+        Ok(set)
+    }
+
+    /// Load Main / File Description / IFSC metadata and index recovery
+    /// blocks by `(path, offset, len)` without retaining their bodies.
+    pub fn load_metadata(index_path: impl AsRef<Path>) -> Result<Self> {
         let index_path = index_path.as_ref();
         let dir = index_path
             .parent()
@@ -83,7 +105,12 @@ impl RecoverySet {
         let recovery_set_id = main_raw.recovery_set_id;
         let (slice_size, recovery_file_ids) = parse_main_body(&main_raw.body)?;
 
-        let mut all_packets: Vec<RawPacket> = Vec::new();
+        let mut file_desc: BTreeMap<[u8; 16], FileDescFields> = BTreeMap::new();
+        let mut ifsc: BTreeMap<[u8; 16], Vec<SliceChecksum>> = BTreeMap::new();
+        let mut recovery_index: BTreeMap<u32, RecoveryBlockLoc> = BTreeMap::new();
+        let mut seen_packets: std::collections::HashSet<([u8; 16], [u8; 16])> =
+            std::collections::HashSet::new();
+
         for entry in std::fs::read_dir(dir)
             .with_context(|| format!("reading directory `{}`", dir.display()))?
         {
@@ -102,31 +129,29 @@ impl RecoverySet {
             let Ok(bytes) = std::fs::read(&path) else {
                 continue; // unreadable file (permissions, race) — skip, not fatal
             };
-            all_packets.extend(
-                read_packets(&bytes)
-                    .into_iter()
-                    .filter(|p| p.recovery_set_id == recovery_set_id),
-            );
-        }
-
-        dedup_packets(&mut all_packets);
-
-        let mut file_desc: BTreeMap<[u8; 16], FileDescFields> = BTreeMap::new();
-        let mut ifsc: BTreeMap<[u8; 16], Vec<SliceChecksum>> = BTreeMap::new();
-        let mut recovery_blocks: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
-
-        for p in &all_packets {
-            if p.packet_type == packet::TYPE_FILE_DESC {
-                if let Ok(fields) = parse_file_desc_body(&p.body) {
-                    file_desc.insert(fields.file_id, fields);
+            for (p, offset) in read_packets_with_offsets(&bytes) {
+                if p.recovery_set_id != recovery_set_id {
+                    continue;
                 }
-            } else if p.packet_type == packet::TYPE_IFSC {
-                if let Ok((fid, slices)) = parse_ifsc_body(&p.body) {
-                    ifsc.insert(fid, slices);
+                if !seen_packets.insert((p.packet_type, packet::md5(&p.body))) {
+                    continue;
                 }
-            } else if p.packet_type == packet::TYPE_RECOVERY {
-                if let Ok((exponent, data)) = parse_recovery_body(&p.body) {
-                    recovery_blocks.entry(exponent).or_insert(data);
+                if p.packet_type == packet::TYPE_FILE_DESC {
+                    if let Ok(fields) = parse_file_desc_body(&p.body) {
+                        file_desc.insert(fields.file_id, fields);
+                    }
+                } else if p.packet_type == packet::TYPE_IFSC {
+                    if let Ok((fid, slices)) = parse_ifsc_body(&p.body) {
+                        ifsc.insert(fid, slices);
+                    }
+                } else if p.packet_type == packet::TYPE_RECOVERY && p.body.len() >= 4 {
+                    let exponent = u32::from_le_bytes(p.body[0..4].try_into().unwrap());
+                    let data_len = p.body.len() - 4;
+                    recovery_index.entry(exponent).or_insert(RecoveryBlockLoc {
+                        path: path.clone(),
+                        offset: (offset + packet::HEADER_LEN + 4) as u64,
+                        len: data_len,
+                    });
                 }
             }
         }
@@ -136,10 +161,22 @@ impl RecoverySet {
             let fields = file_desc.get(fid).with_context(|| {
                 "recovery set references a File ID with no matching File Description packet"
             })?;
+            let name = sanitize_par2_name(&fields.name)?;
             let slice_checksums = ifsc.get(fid).cloned().unwrap_or_default();
+            if !slice_checksums.is_empty() && slice_size > 0 {
+                let expected = fields.length.div_ceil(slice_size);
+                if slice_checksums.len() as u64 != expected {
+                    bail!(
+                        "PAR2 File Description for `{name}` has {} IFSC slices, expected {expected} \
+                         (length {} / slice size {slice_size})",
+                        slice_checksums.len(),
+                        fields.length
+                    );
+                }
+            }
             files.push(FileEntry {
                 file_id: fields.file_id,
-                name: fields.name.clone(),
+                name,
                 length: fields.length,
                 md5_full: fields.md5_full,
                 md5_16k: fields.md5_16k,
@@ -151,19 +188,118 @@ impl RecoverySet {
             recovery_set_id,
             slice_size,
             files,
-            recovery_blocks,
+            recovery_blocks: BTreeMap::new(),
+            recovery_index,
         })
+    }
+
+    /// How many distinct recovery blocks exist on disk (whether loaded or not).
+    pub fn available_recovery_blocks(&self) -> usize {
+        self.recovery_index.len().max(self.recovery_blocks.len())
+    }
+
+    /// Read recovery-block bodies into [`Self::recovery_blocks`].
+    ///
+    /// `max_blocks` limits how many are loaded (lowest exponents first).
+    /// Reed-Solomon over GF(2¹⁶) is MDS, so any `m` blocks reconstruct `m`
+    /// missing inputs — repair only needs `total_bad_slices()` of them.
+    pub fn load_recovery_blocks(&mut self, max_blocks: Option<usize>) -> Result<()> {
+        let limit = max_blocks.unwrap_or(self.recovery_index.len());
+        for (exponent, loc) in self.recovery_index.iter().take(limit) {
+            if self.recovery_blocks.contains_key(exponent) {
+                continue;
+            }
+            let mut file = std::fs::File::open(&loc.path).with_context(|| {
+                format!("opening `{}` to read a recovery block", loc.path.display())
+            })?;
+            use std::io::{Read, Seek, SeekFrom};
+            file.seek(SeekFrom::Start(loc.offset))?;
+            let mut data = vec![0u8; loc.len];
+            file.read_exact(&mut data).with_context(|| {
+                format!(
+                    "reading recovery block exponent {exponent} from `{}`",
+                    loc.path.display()
+                )
+            })?;
+            self.recovery_blocks.insert(*exponent, data);
+        }
+        Ok(())
     }
 }
 
-/// Drop duplicate packets — the same packet often appears in more than one
-/// volume file — keeping the first occurrence. Keyed by a hash of the body
-/// rather than the body itself so large Recovery Slice packets aren't
-/// cloned just to check membership.
-fn dedup_packets(packets: &mut Vec<RawPacket>) {
-    let mut seen: std::collections::HashSet<([u8; 16], [u8; 16])> =
-        std::collections::HashSet::new();
-    packets.retain(|p| seen.insert((p.packet_type, packet::md5(&p.body))));
+/// Sanitize a PAR2 File Description name before it is used as a path.
+///
+/// Rejects empty names, absolute paths, Windows drive/UNC prefixes and any
+/// `..` component. Legitimate relative subdirectories are kept (`dir/file.bin`)
+/// so a recovery set that stored a tree can still be verified and repaired
+/// under `base`. Backslashes are treated as separators.
+pub fn sanitize_par2_name(name: &str) -> Result<String> {
+    let normalized = name.replace('\\', "/");
+    let trimmed = normalized.trim();
+    if trimmed.is_empty() {
+        bail!("PAR2 file name is empty");
+    }
+    let bytes = trimmed.as_bytes();
+    if trimmed.starts_with('/') {
+        bail!("PAR2 file name `{name}` is an absolute path");
+    }
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        bail!("PAR2 file name `{name}` has a drive prefix");
+    }
+    let mut parts = Vec::new();
+    for comp in trimmed.split('/') {
+        if comp.is_empty() || comp == "." {
+            continue;
+        }
+        if comp == ".." {
+            bail!("PAR2 file name `{name}` contains a `..` component");
+        }
+        parts.push(comp);
+    }
+    if parts.is_empty() {
+        bail!("PAR2 file name `{name}` has no usable path components");
+    }
+    Ok(parts.join("/"))
+}
+
+/// Join `name` onto `base` and assert the result stays under `base`.
+///
+/// `name` must already have been through [`sanitize_par2_name`]. The extra
+/// check is belt-and-braces against a future caller that skips sanitization.
+pub fn contained_path(base: &Path, name: &str) -> Result<PathBuf> {
+    let joined = base.join(name);
+    if !path_is_under(base, &joined) {
+        bail!(
+            "PAR2 file name `{name}` escapes base directory `{}`",
+            base.display()
+        );
+    }
+    Ok(joined)
+}
+
+fn path_is_under(base: &Path, candidate: &Path) -> bool {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let abs = |p: &Path| {
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            cwd.join(p)
+        }
+    };
+    fn normalize(p: &Path) -> PathBuf {
+        let mut out = PathBuf::new();
+        for c in p.components() {
+            match c {
+                Component::ParentDir => {
+                    out.pop();
+                }
+                Component::CurDir => {}
+                other => out.push(other.as_os_str()),
+            }
+        }
+        out
+    }
+    normalize(&abs(candidate)).starts_with(normalize(&abs(base)))
 }
 
 fn parse_main_body(body: &[u8]) -> Result<(u64, Vec<[u8; 16]>)> {
@@ -232,12 +368,6 @@ fn parse_ifsc_body(body: &[u8]) -> Result<([u8; 16], Vec<SliceChecksum>)> {
     Ok((file_id, slices))
 }
 
-fn parse_recovery_body(body: &[u8]) -> Result<(u32, Vec<u8>)> {
-    anyhow::ensure!(body.len() >= 4, "Recovery Slice packet body too short");
-    let exponent = u32::from_le_bytes(body[0..4].try_into().unwrap());
-    Ok((exponent, body[4..].to_vec()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,6 +415,7 @@ mod tests {
 
         let set = RecoverySet::load(&index).unwrap();
         assert_eq!(set.recovery_blocks.len(), 5);
+        assert_eq!(set.recovery_index.len(), 5);
         assert_eq!(set.files.len(), 1);
         let expected_slices = 1000usize.div_ceil(128);
         assert_eq!(set.files[0].slice_checksums.len(), expected_slices);
@@ -294,8 +425,62 @@ mod tests {
     }
 
     #[test]
+    fn load_metadata_indexes_blocks_without_holding_them() {
+        let (dir, index) = build_fixture_set(
+            "recovery-set-meta",
+            &[FixtureFile {
+                name: "only.bin",
+                data: vec![7u8; 1000],
+            }],
+            128,
+            5,
+        );
+
+        let mut set = RecoverySet::load_metadata(&index).unwrap();
+        assert_eq!(set.recovery_index.len(), 5);
+        assert!(set.recovery_blocks.is_empty());
+        assert_eq!(set.available_recovery_blocks(), 5);
+
+        set.load_recovery_blocks(Some(2)).unwrap();
+        assert_eq!(set.recovery_blocks.len(), 2);
+        set.load_recovery_blocks(None).unwrap();
+        assert_eq!(set.recovery_blocks.len(), 5);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn missing_index_file_is_a_clean_error() {
         let result = RecoverySet::load("/nonexistent/path/movie.mkv.par2");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_par2_name_keeps_relative_subdirectories() {
+        assert_eq!(
+            sanitize_par2_name("extras/behind.bin").unwrap(),
+            "extras/behind.bin"
+        );
+        assert_eq!(
+            sanitize_par2_name(r"extras\behind.bin").unwrap(),
+            "extras/behind.bin"
+        );
+    }
+
+    #[test]
+    fn sanitize_par2_name_rejects_traversal_and_absolute() {
+        assert!(sanitize_par2_name("../secret").is_err());
+        assert!(sanitize_par2_name("/etc/passwd").is_err());
+        assert!(sanitize_par2_name("C:\\windows\\system32").is_err());
+        assert!(sanitize_par2_name("foo/../../etc/passwd").is_err());
+        assert!(sanitize_par2_name("").is_err());
+    }
+
+    #[test]
+    fn contained_path_stays_under_base() {
+        let base = Path::new("/tmp/release");
+        let p = contained_path(base, "a.bin").unwrap();
+        assert_eq!(p, Path::new("/tmp/release/a.bin"));
+        assert!(contained_path(base, "../escape.bin").is_err());
     }
 }

--- a/crates/parmesan/src/repair.rs
+++ b/crates/parmesan/src/repair.rs
@@ -7,12 +7,12 @@
 //! Reconstruction assumes the global order of input slices matches the
 //! order [`RecoverySet::files`] presents them in — ascending File ID, per
 //! spec (see that module's docs). `parmesan create` has fed slices to the
-//! encoder in that order since the fix noted in `ROADMAP.md` Phase 22;
-//! multi-file `.par2` sets created by older `parmesan` builds do not
-//! satisfy this and **will silently reconstruct incorrect bytes** if
-//! repaired here, because the wrong Reed-Solomon coefficients get applied
-//! to the wrong slices. There is no way to detect this after the fact from
-//! the PAR2 data alone — the per-slice checksum re-verification this module
+//! encoder in that order (see `ops::sort_files_by_file_id`). Multi-file
+//! `.par2` sets created by older `parmesan` builds may not satisfy this
+//! and **will silently reconstruct incorrect bytes** if repaired here,
+//! because the wrong Reed-Solomon coefficients get applied to the wrong
+//! slices. There is no way to detect this after the fact from the PAR2
+//! data alone — the per-slice checksum re-verification this module
 //! performs before writing anything is the safety net: a mismatch there
 //! aborts the repair for that file instead of writing corrupted data.
 //! Single-file recovery sets are never affected by the ordering issue.
@@ -160,7 +160,7 @@ pub fn repair(
         }
 
         let dest_dir = options.out_dir.as_deref().unwrap_or(base_dir);
-        let dest_path = dest_dir.join(&entry.name);
+        let dest_path = crate::recovery_set::contained_path(dest_dir, &entry.name)?;
 
         if !options.dry_run {
             write_repaired_file(entry, status, base_dir, &dest_path, slice_size, &slices)?;
@@ -198,7 +198,10 @@ impl SliceReader<'_> {
         let slice_size = self.set.slice_size as usize;
 
         if self.open.as_ref().map(|(fi, _)| *fi) != Some(file_index) {
-            let path = self.base_dir.join(&self.set.files[file_index].name);
+            let path = crate::recovery_set::contained_path(
+                self.base_dir,
+                &self.set.files[file_index].name,
+            )?;
             let file = std::fs::File::open(&path)
                 .with_context(|| format!("opening `{}` to read a known slice", path.display()))?;
             self.open = Some((file_index, file));
@@ -245,9 +248,10 @@ fn write_repaired_file(
                 let write_len = slice_write_len(*li, total_slices, entry.length, slice_size);
                 out.write_all(&data[..write_len])?;
             }
+            out.set_len(entry.length)?;
         }
         FileStatus::Damaged => {
-            let original = base_dir.join(&entry.name);
+            let original = crate::recovery_set::contained_path(base_dir, &entry.name)?;
             if dest_path != original {
                 std::fs::copy(&original, dest_path).with_context(|| {
                     format!(
@@ -266,6 +270,7 @@ fn write_repaired_file(
                 out.seek(SeekFrom::Start((*li * slice_size) as u64))?;
                 out.write_all(&data[..write_len])?;
             }
+            out.set_len(entry.length)?;
         }
         FileStatus::Ok => {
             unreachable!("write_repaired_file is only called for files with bad slices")
@@ -284,7 +289,9 @@ fn slice_write_len(
     slice_size: usize,
 ) -> usize {
     if local_index + 1 == total_slices {
-        (file_length - local_index as u64 * slice_size as u64) as usize
+        file_length
+            .saturating_sub(local_index as u64 * slice_size as u64)
+            .min(slice_size as u64) as usize
     } else {
         slice_size
     }

--- a/crates/parmesan/src/verify.rs
+++ b/crates/parmesan/src/verify.rs
@@ -114,7 +114,7 @@ pub fn verify_with_progress(
     let mut files = Vec::with_capacity(set.files.len());
 
     for entry in &set.files {
-        let path = base_dir.join(&entry.name);
+        let path = crate::recovery_set::contained_path(base_dir, &entry.name)?;
         let total_file_slices = entry.slice_checksums.len();
 
         if !path.is_file() {
@@ -137,6 +137,9 @@ pub fn verify_with_progress(
         let mut file = File::open(&path)
             .with_context(|| format!("opening `{}` for verification", path.display()))?;
 
+        let on_disk_len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        let length_mismatch = on_disk_len != entry.length;
+
         let mut bad_slice_indices = Vec::new();
         let mut buf = vec![0u8; slice_size];
         for (i, expected) in entry.slice_checksums.iter().enumerate() {
@@ -155,7 +158,7 @@ pub fn verify_with_progress(
 
         files.push(FileReport {
             name: entry.name.clone(),
-            status: if bad_slice_indices.is_empty() {
+            status: if bad_slice_indices.is_empty() && !length_mismatch {
                 FileStatus::Ok
             } else {
                 FileStatus::Damaged
@@ -168,7 +171,7 @@ pub fn verify_with_progress(
 
     Ok(VerifyReport {
         files,
-        available_recovery_blocks: set.recovery_blocks.len(),
+        available_recovery_blocks: set.available_recovery_blocks(),
     })
 }
 
@@ -222,6 +225,31 @@ mod tests {
         assert_eq!(report.exit_code(), 0);
         assert_eq!(report.total_bad_slices(), 0);
         assert!(report.files.iter().all(|f| f.status == FileStatus::Ok));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn trailing_bytes_past_recorded_length_are_damaged() {
+        let (dir, index) = build_fixture_set(
+            "verify-trailing",
+            &[FixtureFile {
+                name: "a.bin",
+                data: vec![1u8; 300],
+            }],
+            128,
+            2,
+        );
+
+        let path = dir.join("a.bin");
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes.extend_from_slice(b"TRAILINGJUNK");
+        std::fs::write(&path, &bytes).unwrap();
+
+        let set = RecoverySet::load(&index).unwrap();
+        let report = verify(&set, &dir).unwrap();
+        assert_eq!(report.files[0].status, FileStatus::Damaged);
+        assert!(!report.is_ok());
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/penne/src/deobfuscate.rs
+++ b/crates/penne/src/deobfuscate.rs
@@ -150,7 +150,7 @@ fn run_blocking(
     let (par2_paths, mut rest) = tag_par2_content(dest_dir, candidates, &mut report);
 
     let recovery_files: Vec<FileEntry> = match par2_paths.first() {
-        Some(index) => match RecoverySet::load(index) {
+        Some(index) => match RecoverySet::load_metadata(index) {
             Ok(set) => set.files,
             Err(e) => {
                 warn!(
@@ -222,7 +222,9 @@ fn match_against_recovery_set(
     report: &mut RenameReport,
 ) {
     for entry in recovery_files {
-        let target = dest_dir.join(&entry.name);
+        let Ok(target) = pesto::par2::recovery_set::contained_path(dest_dir, &entry.name) else {
+            continue;
+        };
         if target.exists() {
             // Already correctly named, or a genuine name collision either
             // way — never overwrite.

--- a/crates/penne/src/health.rs
+++ b/crates/penne/src/health.rs
@@ -7,7 +7,7 @@
 //!
 //! Originally scoped (see `ROADMAP.md` Phase 15) as a check *before* any
 //! download starts, mirroring `nzbget`'s `QueueCoordinator::CheckHealth`.
-//! Not feasible in that form: [`pesto::par2::recovery_set::RecoverySet::load`]
+//! Not feasible in that form: [`pesto::par2::recovery_set::RecoverySet::load_metadata`]
 //! needs the `.par2` index and its recovery volumes already sitting on
 //! disk to know how much recovery data exists at all, and nothing is on
 //! disk before a download begins. `nzbget`'s own version has the identical
@@ -103,10 +103,10 @@ pub fn evaluate(
     let Some(index_path) = find_par2_index(dest_dir, known_files)? else {
         return Ok(None);
     };
-    let recovery_set = RecoverySet::load(&index_path)
+    let recovery_set = RecoverySet::load_metadata(&index_path)
         .with_context(|| format!("loading PAR2 recovery set from {}", index_path.display()))?;
     let available_recovery_bytes =
-        recovery_set.recovery_blocks.len() as u64 * recovery_set.slice_size;
+        recovery_set.available_recovery_blocks() as u64 * recovery_set.slice_size;
     Ok(Some(HealthCheck {
         damaged_bytes,
         available_recovery_bytes,

--- a/crates/penne/src/queue.rs
+++ b/crates/penne/src/queue.rs
@@ -196,6 +196,10 @@ mod tests {
     #[test]
     fn a_slash_in_the_file_name_is_flattened_not_left_to_split_into_a_directory() {
         let groups = vec!["alt.test".to_string()];
+        // The embedded `"` exercises `default_subject`'s own quote handling
+        // (`"` -> `'`, see `article.rs`): a raw `"` would break the
+        // `"{name}" yEnc (n/m)` subject format indexers parse, so it's
+        // deliberately not the same character round-trip as the slash below.
         let segments = vec![seg("[01/14] - \"real.mkv\"", 1, 1, "<a1@x>")];
         let xml = pesto::nzb::generate(
             &groups,
@@ -208,7 +212,7 @@ mod tests {
         let queue = build(&parsed);
         assert_eq!(queue.files.len(), 1);
         assert!(!queue.files[0].name.contains('/'));
-        assert_eq!(queue.files[0].name, "[01_14] - \"real.mkv\"");
+        assert_eq!(queue.files[0].name, "[01_14] - 'real.mkv'");
     }
 
     #[test]

--- a/crates/penne/src/repair.rs
+++ b/crates/penne/src/repair.rs
@@ -159,7 +159,7 @@ fn verify_and_repair_blocking(
         return Ok(RepairOutcome::NoRecoveryData);
     };
 
-    let set = RecoverySet::load(&index)
+    let mut set = RecoverySet::load_metadata(&index)
         .with_context(|| format!("loading PAR2 recovery set from {}", index.display()))?;
 
     if quick_check_all(&set, assembled) {
@@ -183,6 +183,9 @@ fn verify_and_repair_blocking(
     if !report.is_repairable() {
         return Ok(RepairOutcome::NotRepairable(report));
     }
+
+    set.load_recovery_blocks(Some(report.total_bad_slices()))
+        .context("loading recovery blocks for repair")?;
 
     let plan = par2_repair(&set, &report, dir, &RepairOptions::default())
         .with_context(|| format!("repairing files under {}", dir.display()))?;

--- a/crates/pesto/src/article.rs
+++ b/crates/pesto/src/article.rs
@@ -110,20 +110,36 @@ pub struct Article {
     pub no_archive: bool,
 }
 
+/// Neutralize CR/LF (and other C0) in a header value so a file name cannot
+/// inject extra header lines. Space is the replacement so the line stays one
+/// token-ish field rather than vanishing.
+fn sanitize_header_value(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c == '\r' || c == '\n' || c == '\0' {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
 impl Article {
     /// Build the RFC 2822 header block (including the trailing blank line).
     /// The returned bytes are ready to be written directly to the NNTP stream.
     pub fn build_headers(&self) -> Vec<u8> {
         let mut h = format!(
             "From: {}\r\nNewsgroups: {}\r\nSubject: {}\r\nMessage-ID: {}\r\n",
-            self.from,
-            self.newsgroups.join(","),
-            self.subject,
-            self.message_id,
+            sanitize_header_value(&self.from),
+            sanitize_header_value(&self.newsgroups.join(",")),
+            sanitize_header_value(&self.subject),
+            sanitize_header_value(&self.message_id),
         );
         if let Some(date) = &self.date {
             h.push_str("Date: ");
-            h.push_str(date);
+            h.push_str(&sanitize_header_value(date));
             h.push_str("\r\n");
         }
         if self.no_archive {
@@ -261,6 +277,7 @@ pub fn default_subject(
     total: u32,
     file_counter: Option<(u32, u32)>,
 ) -> String {
+    let name = name.replace('"', "'");
     let base = format!("\"{name}\" yEnc ({part}/{total})");
     match file_counter {
         Some((filenum, total_files)) => format!("[{filenum}/{total_files}] - {base}"),
@@ -459,6 +476,29 @@ mod tests {
         // it with the rest — confirmed live against Binsearch.
         let s = default_subject("movie.mkv", 1, 1, None);
         assert_eq!(s, "\"movie.mkv\" yEnc (1/1)");
+    }
+
+    #[test]
+    fn default_subject_replaces_embedded_quotes() {
+        assert_eq!(
+            default_subject("say \"hi\".bin", 1, 1, None),
+            "\"say 'hi'.bin\" yEnc (1/1)"
+        );
+    }
+
+    #[test]
+    fn build_headers_neutralizes_crlf_in_subject() {
+        let article = Article {
+            message_id: "<id@pesto>".into(),
+            from: "p <p@x.com>".into(),
+            newsgroups: vec!["a.b.test".into()],
+            subject: "ok\r\nX-Injected: yes".into(),
+            date: None,
+            no_archive: false,
+        };
+        let headers = String::from_utf8(article.build_headers()).unwrap();
+        assert!(!headers.lines().any(|l| l.starts_with("X-Injected")));
+        assert!(headers.contains("Subject: ok  X-Injected: yes\r\n"));
     }
 
     #[test]

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use clap::Parser;
 use parmesan::SimdPath;
-use pesto::compress::{compress, random_password, ArchiveFormat};
+use pesto::compress::{compress, existing_archive, random_password, ArchiveFormat};
 use pesto::config::{
     self, parse_memory_limit_spec, parse_upload_rate, Config, FileConfig, ObfuscateMode, Overrides,
 };
@@ -1362,11 +1362,19 @@ async fn run_single_upload(
             .compress_temp_dir
             .clone()
             .unwrap_or_else(std::env::temp_dir);
-        let tmp_dir = tmp_base.join(format!(
-            "pesto_compress_{}_{}",
-            std::process::id(),
-            entry_label
-        ));
+        // A pid-keyed directory is gone on the next process, so `--resume`
+        // can never see the archive it recorded. When resuming, key the
+        // scratch dir by the (stable) archive stem so an interrupted run
+        // finds the same files and can skip recompression.
+        let tmp_dir = if config.resume {
+            tmp_base.join(format!("pesto_compress_{archive_stem}"))
+        } else {
+            tmp_base.join(format!(
+                "pesto_compress_{}_{}",
+                std::process::id(),
+                entry_label
+            ))
+        };
         compress_temp_dir = Some(tmp_dir.clone());
 
         let fs_paths: Vec<PathBuf> = collect_compress_roots(&inputs);
@@ -1400,18 +1408,36 @@ async fn run_single_upload(
         let compress_dest = tmp_dir.clone();
         let compress_pass = effective_password.clone();
         let compress_volume_size = config.compress_volume_size.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            compress(
-                &compress_inputs,
-                &compress_stem,
-                &compress_dest,
+        let result = if config.resume {
+            existing_archive(
+                &tmp_dir,
+                &archive_stem,
                 format,
-                compress_pass.as_deref(),
                 compress_volume_size.as_deref(),
             )
-        })
-        .await
-        .context("compressor task panicked")??;
+        } else {
+            None
+        };
+        let result = if let Some(reused) = result {
+            eprintln!(
+                "resume: reusing existing archive `{}`",
+                reused.path.display()
+            );
+            reused
+        } else {
+            tokio::task::spawn_blocking(move || {
+                compress(
+                    &compress_inputs,
+                    &compress_stem,
+                    &compress_dest,
+                    format,
+                    compress_pass.as_deref(),
+                    compress_volume_size.as_deref(),
+                )
+            })
+            .await
+            .context("compressor task panicked")??
+        };
 
         poll_handle.abort();
         let _ = progress_tx.send(pesto::progress::ProgressEvent::CompressDone);
@@ -3604,13 +3630,7 @@ fn reuse_or_generate_archive_stem(resume_path: Option<&Path>, config: &Config) -
     let Some(rp) = resume_path else {
         return pesto::article::obfuscated_name();
     };
-    let fingerprint = pesto::resume::RunFingerprint {
-        article_size: config.article_size as u64,
-        obfuscate: config.obfuscate,
-        compress_format: config.compress_format.clone(),
-        par2_percent: config.par2,
-        file_counter: config.file_counter,
-    };
+    let fingerprint = pesto::resume::RunFingerprint::from_config(config);
     let mut state = pesto::resume::ResumeState::load(rp).unwrap_or_default();
     // Normalizes the loaded state first: a fingerprint mismatch clears any
     // stale archive_stem (and segments/files) before we look at it, so an
@@ -3650,6 +3670,21 @@ fn resume_flags_string(config: &Config) -> String {
     }
     if config.file_counter {
         flags.push_str(" --file-counter");
+    }
+    if let Some(n) = config.par2_slice_size {
+        flags.push_str(&format!(" --par2-slice-size {n}"));
+    }
+    if let Some(n) = config.par2_slice_count {
+        flags.push_str(&format!(" --par2-slice-count {n}"));
+    }
+    if let Some(n) = config.par2_recovery_count {
+        flags.push_str(&format!(" --par2-recovery-count {n}"));
+    }
+    if let Some(v) = &config.compress_volume_size {
+        flags.push_str(&format!(" --compress-volume-size {v}"));
+    }
+    if config.line_length != pesto::yenc::DEFAULT_LINE_LENGTH {
+        flags.push_str(&format!(" --line-length {}", config.line_length));
     }
     flags
 }

--- a/crates/pesto/src/compress.rs
+++ b/crates/pesto/src/compress.rs
@@ -137,6 +137,39 @@ pub fn compress(
     }
 }
 
+/// If `dest_dir` already holds a complete archive for `archive_stem`,
+/// return it so a `--resume` run can skip recompression (and keep the
+/// recorded `{size, mtime}` fingerprints valid).
+pub fn existing_archive(
+    dest_dir: &Path,
+    archive_stem: &str,
+    format: ArchiveFormat,
+    volume_size: Option<&str>,
+) -> Option<CompressResult> {
+    if !dest_dir.is_dir() {
+        return None;
+    }
+    let archive_name = format!("{}.{}", archive_stem, format.extension());
+    let archive_path = dest_dir.join(&archive_name);
+    let mut paths = match (format, volume_size) {
+        (ArchiveFormat::Rar, Some(_)) => collect_rar_volumes(dest_dir, archive_stem).ok()?,
+        (ArchiveFormat::SevenZip | ArchiveFormat::Zip, Some(_)) => {
+            collect_7z_volumes(dest_dir, &archive_name).ok()?
+        }
+        (_, None) if archive_path.is_file() => vec![archive_path],
+        _ => return None,
+    };
+    if paths.is_empty() || !paths.iter().all(|p| p.is_file()) {
+        return None;
+    }
+    let path = paths.remove(0);
+    Some(CompressResult {
+        path,
+        extra_paths: paths,
+        format,
+    })
+}
+
 /// Validate a `-v<size>[u]` value shared by the `rar` and `7z` CLIs: digits
 /// followed by an optional single unit character from `bBkKmMgGtT`.
 fn validate_volume_size(size: &str) -> Result<()> {

--- a/crates/pesto/src/nntp/mod.rs
+++ b/crates/pesto/src/nntp/mod.rs
@@ -318,8 +318,14 @@ impl Connection {
         dot_stuff(headers, &mut stuffed_headers);
         self.write_all_timeout(&stuffed_headers).await?;
 
-        // Write body directly; the BufWriter coalesces this with the headers
-        // before the TLS flush.
+        // Body is *not* dot-stuffed. yEnc already escapes a '.' that would
+        // start a line (draft v1.3 §4 / `=ybegin` line wrap), so stuffing
+        // here would be a second pass over every article on the hot path.
+        debug_assert!(
+            !yenc_body_has_leading_dot(body),
+            "yEnc body must not contain a line starting with '.'; \
+             NNTP would treat it as end-of-article"
+        );
         self.write_all_timeout(body).await?;
         if !body.ends_with(b"\r\n") {
             self.write_all_timeout(b"\r\n").await?;
@@ -352,6 +358,11 @@ impl Connection {
         let mut stuffed_headers = Vec::with_capacity(headers.len() + 4);
         dot_stuff(headers, &mut stuffed_headers);
         self.write_all_timeout(&stuffed_headers).await?;
+        debug_assert!(
+            !yenc_body_has_leading_dot(body),
+            "yEnc body must not contain a line starting with '.'; \
+             NNTP would treat it as end-of-article"
+        );
         self.write_all_timeout(body).await?;
         if !body.ends_with(b"\r\n") {
             self.write_all_timeout(b"\r\n").await?;
@@ -732,6 +743,15 @@ fn is_dot_terminator(line: &[u8]) -> bool {
     trimmed == b"."
 }
 
+/// True when any line of a yEnc body starts with `.`.
+///
+/// The poster relies on the encoder never producing that (see
+/// [`post_parts_inner`] / [`NntpConnection::enqueue_post`]); this is the
+/// predicate those `debug_assert!`s use.
+pub(crate) fn yenc_body_has_leading_dot(body: &[u8]) -> bool {
+    body.starts_with(b".") || body.windows(3).any(|w| w == b"\r\n.")
+}
+
 /// Apply NNTP dot-stuffing: any line that begins with `.` gets an extra `.`
 /// prepended, so it cannot be mistaken for the end-of-data marker.
 fn dot_stuff(input: &[u8], out: &mut Vec<u8>) {
@@ -944,6 +964,29 @@ mod tests {
     }
 
     // ── dot_stuff ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn yenc_body_has_leading_dot_detects_first_and_later_lines() {
+        assert!(yenc_body_has_leading_dot(b".hidden\r\n"));
+        assert!(yenc_body_has_leading_dot(b"ok\r\n.bad\r\n"));
+        assert!(!yenc_body_has_leading_dot(b"ok\r\na.b\r\n"));
+        assert!(!yenc_body_has_leading_dot(b""));
+    }
+
+    #[test]
+    fn yenc_encoder_never_starts_a_body_line_with_dot() {
+        // Raw 0x04 + 42 == 0x2E ('.'). At line start the encoder must escape it.
+        let mut crafted = vec![0x04u8; 512];
+        crafted.extend((0u8..=255).cycle().take(1024));
+        for line_len in [1usize, 2, 4, 16, 128] {
+            let mut body = Vec::new();
+            crate::yenc::encode(&mut body, &crafted, line_len);
+            assert!(
+                !yenc_body_has_leading_dot(&body),
+                "encoder produced a leading-dot line at line_len={line_len}"
+            );
+        }
+    }
 
     #[test]
     fn dot_stuffs_lines_starting_with_dot() {

--- a/crates/pesto/src/nzb.rs
+++ b/crates/pesto/src/nzb.rs
@@ -573,6 +573,8 @@ fn escape(s: &str) -> String {
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
+            // XML 1.0 forbids C0 controls other than tab / LF / CR.
+            c if c.is_control() && !matches!(c, '\t' | '\n' | '\r') => {}
             _ => out.push(c),
         }
     }
@@ -855,6 +857,12 @@ mod tests {
             ObfuscateMode::None,
         );
         assert!(xml.contains("subject=\"&quot;file.bin&quot; yEnc (1/1)\""));
+    }
+
+    #[test]
+    fn escape_drops_xml_illegal_controls() {
+        assert_eq!(escape("ok\u{0001}name"), "okname");
+        assert_eq!(escape("keep\ttab"), "keep\ttab");
     }
 
     #[test]

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -3866,6 +3866,17 @@ async fn generate_season_par2(episode_paths: &[PathBuf], config: &Config) -> Res
         total_slices, recovery_count, "season PAR2 geometry"
     );
 
+    // Validate PAR2 spec limits — same check `producer()` does for the
+    // per-file path. Sharing `par2_geometry_from_sizes` between the two
+    // paths means an explicit `--par2-slice-count`/`--par2-recovery-count`
+    // can equally overflow the GF(2^16) exponent space here.
+    if total_slices > 32768 {
+        anyhow::bail!("too many input slices: {total_slices} (max 32768). Increase --slice-size or decrease --slice-count.");
+    }
+    if recovery_count > 65535 {
+        anyhow::bail!("too many recovery blocks: {recovery_count} (max 65535). Increase --slice-size or decrease --par2/--recovery-count.");
+    }
+
     if total_slices == 0 {
         return Ok(SeasonPar2Set::empty());
     }

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -121,26 +121,34 @@ fn optimal_par2_slice_size(
 /// progress total. Mirrors the geometry logic in `producer` exactly; keep
 /// the two in sync.
 fn par2_geometry(metas: &[Arc<FileMeta>], config: &Config) -> (usize, usize, usize) {
+    let sizes: Vec<u64> = metas.iter().map(|m| m.size).collect();
+    par2_geometry_from_sizes(&sizes, config)
+}
+
+/// Shared PAR2 geometry for the per-file path and the season path so
+/// `--par2-slice-size` / `--par2-slice-count` / `--par2-recovery-count`
+/// cannot drift between them.
+fn par2_geometry_from_sizes(sizes: &[u64], config: &Config) -> (usize, usize, usize) {
     let article_size = config.article_size;
-    let per_file_articles: Vec<usize> = metas
+    let per_file_articles: Vec<usize> = sizes
         .iter()
-        .map(|m| {
-            if m.size == 0 {
+        .map(|&size| {
+            if size == 0 {
                 0
             } else {
-                yenc::segments(m.size, article_size).len()
+                yenc::segments(size, article_size).len()
             }
         })
         .collect();
 
     let (par2_slice_size, total_slices) = if let Some(size) = config.par2_slice_size {
         let s = (size / 64 * 64).max(64);
-        let n: usize = metas.iter().map(|m| (m.size as usize).div_ceil(s)).sum();
+        let n: usize = sizes.iter().map(|sz| (*sz as usize).div_ceil(s)).sum();
         (s, n)
     } else if let Some(count) = config.par2_slice_count {
-        let total_bytes: u64 = metas.iter().map(|m| m.size).sum();
+        let total_bytes: u64 = sizes.iter().sum();
         let s = ((total_bytes as usize).div_ceil(count.max(1)) / 64 * 64).max(64);
-        let n: usize = metas.iter().map(|m| (m.size as usize).div_ceil(s)).sum();
+        let n: usize = sizes.iter().map(|sz| (*sz as usize).div_ceil(s)).sum();
         (s, n)
     } else {
         optimal_par2_slice_size(&per_file_articles, article_size, config.par2)
@@ -566,13 +574,7 @@ pub async fn post_files_with_progress_and_cancel(
     // recorded Message-ID could reference the wrong byte range, so the
     // *entire* state is discarded rather than trusted partially — see
     // `resume::RunFingerprint` and GitHub issue #18.
-    let run_fingerprint = crate::resume::RunFingerprint {
-        article_size: config.article_size as u64,
-        obfuscate: config.obfuscate,
-        compress_format: config.compress_format.clone(),
-        par2_percent: config.par2,
-        file_counter: config.file_counter,
-    };
+    let run_fingerprint = crate::resume::RunFingerprint::from_config(config);
     if let Some(resume) = &resume_arc {
         let mut state = resume.lock().unwrap();
         let had_segments = !state.is_empty();
@@ -1740,6 +1742,92 @@ fn address_space_budget(reserve: u64, slice_size: usize, recovery_count: usize) 
     Some((headroom / (PASS_WORKING_SET_FACTOR * (1.0 + CROSS_PASS_RETENTION))) as u64)
 }
 
+/// Shared PAR2 memory budget + pass list used by the per-file producer and
+/// the season path so `--memory-limit` cannot drift between them.
+fn par2_memory_plan(
+    config: &Config,
+    par2_slice_size: usize,
+    recovery_count: usize,
+    active_connections: usize,
+) -> Result<(usize, Vec<(u32, usize)>)> {
+    let reserve_threads = if config.threads > 0 {
+        config.threads
+    } else {
+        parmesan::performance_core_count()
+    };
+    let overhead_reserve = connection_overhead_reserve(active_connections, reserve_threads);
+    let as_budget = address_space_budget(overhead_reserve, par2_slice_size, recovery_count);
+    if as_budget == Some(0) && recovery_count > 0 {
+        anyhow::bail!(
+            "not enough address space to generate PAR2: this session's limit \
+             (RLIMIT_AS = {}) is already exceeded by the ~{} reserved for {} \
+             connections and {} PAR2 threads. Lower --connections/--threads, \
+             disable PAR2 with --par2 0, or raise `ulimit -v` for this session.",
+            crate::progress::format_size(address_space_limit().unwrap_or_default()),
+            crate::progress::format_size(overhead_reserve),
+            active_connections,
+            reserve_threads,
+        );
+    }
+    let ceiling = crate::memory::Ceiling::discover(config.memory_limit);
+    let non_as_par2_share = crate::memory::budget::share_of(
+        ceiling.effective_excluding_address_space(),
+        crate::memory::budget::Stage::Par2,
+    );
+    let binding_budget = as_budget.map_or(non_as_par2_share, |b| b.min(non_as_par2_share));
+
+    let memory_limit = match config.par2_memory_limit {
+        Some(limit) => {
+            if limit as u64 > binding_budget {
+                let bound_by_as = as_budget.is_some_and(|b| b <= non_as_par2_share);
+                anyhow::bail!(
+                    "--par2-memory-limit {} won't fit safely: {} leaves a safe budget of \
+                     only {} once ~{} is reserved for {} connections and {} PAR2 threads. \
+                     Lower --par2-memory-limit (or --memory-limit / --connections/--threads), \
+                     or {}.",
+                    crate::progress::format_size(limit as u64),
+                    if bound_by_as {
+                        format!(
+                            "this session's address-space limit (RLIMIT_AS = {})",
+                            crate::progress::format_size(address_space_limit().unwrap_or_default())
+                        )
+                    } else {
+                        format!(
+                            "the global --memory-limit budget (effective ceiling {})",
+                            crate::progress::format_size(ceiling.effective)
+                        )
+                    },
+                    crate::progress::format_size(binding_budget),
+                    crate::progress::format_size(overhead_reserve),
+                    active_connections,
+                    reserve_threads,
+                    if bound_by_as {
+                        "raise `ulimit -v` for this session"
+                    } else {
+                        "raise --memory-limit"
+                    },
+                );
+            }
+            limit
+        }
+        None => (binding_budget as usize).max(256 * 1024 * 1024),
+    };
+
+    let slices_per_pass = (memory_limit / par2_slice_size.max(1)).max(1);
+    let mut passes = Vec::new();
+    if recovery_count > 0 {
+        let mut start = 0;
+        while start < recovery_count {
+            let count = (recovery_count - start).min(slices_per_pass);
+            passes.push((start as u32, count));
+            start += count;
+        }
+    } else {
+        passes.push((0, 0));
+    }
+    Ok((memory_limit, passes))
+}
+
 async fn producer(
     metas: Vec<Arc<FileMeta>>,
     tx_opt: Option<tokio::sync::mpsc::Sender<PostTask>>,
@@ -1809,99 +1897,13 @@ async fn producer(
         parmesan::performance_core_count()
     };
     let overhead_reserve = connection_overhead_reserve(active_connections, reserve_threads);
-    // `par2_slice_size`/`recovery_count` come from `par2_geometry` above, so the
-    // budget can tell a single-pass run (no cross-pass retention to pay for)
-    // from a multi-pass one before the pass list is built below.
-    let as_budget = address_space_budget(overhead_reserve, par2_slice_size, recovery_count);
-    // A zero budget means the reserve alone already exceeds the safe share of
-    // the ceiling. Falling through would clamp to the 256 MiB floor below and
-    // silently produce hundreds of passes (each a full re-read of the input);
-    // failing here with the actual numbers is far more useful.
-    if as_budget == Some(0) && recovery_count > 0 {
-        anyhow::bail!(
-            "not enough address space to generate PAR2: this session's limit \
-             (RLIMIT_AS = {}) is already exceeded by the ~{} reserved for {} \
-             connections and {} PAR2 threads. Lower --connections/--threads, \
-             disable PAR2 with --par2 0, or raise `ulimit -v` for this session.",
-            crate::progress::format_size(address_space_limit().unwrap_or_default()),
-            crate::progress::format_size(overhead_reserve),
-            active_connections,
-            reserve_threads,
-        );
-    }
-    // The global `--memory-limit` ceiling (RLIMIT_AS/cgroup/host/explicit,
-    // each haircut for its own failure mode — see `crate::memory::Ceiling`),
-    // minus the RLIMIT_AS term: PAR2's pass sizing already has its own
-    // RLIMIT_AS-specific model just below (`as_budget`, validated against a
-    // live 83.4 GiB run — see `docs/memory-management.md` §9), tuned more
-    // precisely than `Ceiling`'s flat haircut. Taking PAR2's share of the
-    // *full* `Ceiling::effective` and combining it with `as_budget` via
-    // `min()` would haircut RLIMIT_AS twice — once inside `Ceiling`, again as
-    // the 60% share — silently starving PAR2 far below either model alone.
-    // `effective_excluding_address_space` is exactly the fix: it folds in
-    // cgroup/host/explicit as additional caps without re-litigating RLIMIT_AS.
     let ceiling = crate::memory::Ceiling::discover(shared.config.memory_limit);
-    let non_as_par2_share = crate::memory::budget::share_of(
-        ceiling.effective_excluding_address_space(),
-        crate::memory::budget::Stage::Par2,
-    );
-    // The binding constraint is whichever of the two independent models is
-    // tighter for this run.
-    let binding_budget = as_budget.map_or(non_as_par2_share, |b| b.min(non_as_par2_share));
-
-    let memory_limit = match shared.config.par2_memory_limit {
-        Some(limit) => {
-            if limit as u64 > binding_budget {
-                // Name whichever source actually bound the budget instead of
-                // always blaming RLIMIT_AS, now that there are two candidates.
-                let bound_by_as = as_budget.is_some_and(|b| b <= non_as_par2_share);
-                anyhow::bail!(
-                    "--par2-memory-limit {} won't fit safely: {} leaves a safe budget of \
-                     only {} once ~{} is reserved for {} connections and {} PAR2 threads. \
-                     Lower --par2-memory-limit (or --memory-limit / --connections/--threads), \
-                     or {}.",
-                    crate::progress::format_size(limit as u64),
-                    if bound_by_as {
-                        format!(
-                            "this session's address-space limit (RLIMIT_AS = {})",
-                            crate::progress::format_size(address_space_limit().unwrap_or_default())
-                        )
-                    } else {
-                        format!(
-                            "the global --memory-limit budget (effective ceiling {})",
-                            crate::progress::format_size(ceiling.effective)
-                        )
-                    },
-                    crate::progress::format_size(binding_budget),
-                    crate::progress::format_size(overhead_reserve),
-                    active_connections,
-                    reserve_threads,
-                    if bound_by_as {
-                        "raise `ulimit -v` for this session"
-                    } else {
-                        "raise --memory-limit"
-                    },
-                );
-            }
-            limit
-        }
-        // At least 256MB as a bare minimum fallback.
-        None => (binding_budget as usize).max(256 * 1024 * 1024),
-    };
-
-    let slices_per_pass = (memory_limit / par2_slice_size).max(1);
-
-    let mut passes = Vec::new();
-    if recovery_count > 0 {
-        let mut start = 0;
-        while start < recovery_count {
-            let count = (recovery_count - start).min(slices_per_pass);
-            passes.push((start as u32, count));
-            start += count;
-        }
-    } else {
-        passes.push((0, 0));
-    }
+    let (memory_limit, passes) = par2_memory_plan(
+        &shared.config,
+        par2_slice_size,
+        recovery_count,
+        active_connections,
+    )?;
 
     if recovery_count > 0 {
         // A single combined status line (not gated on -v): the numbers
@@ -3618,11 +3620,12 @@ impl SeasonPar2Set {
 /// Write season PAR2 recovery volumes to disk.
 ///
 /// Serializes `season` into PAR2 packet format and writes it to volume files
-/// (`.par2.vol0+1`, `.par2.vol1+2`, etc.) in the output directory. Every
-/// volume carries the full base packet set — Main (with every episode's real
-/// File ID), Creator, and one File Description + IFSC pair per episode — not
-/// just its own Recovery packets, so any single volume is self-describing.
-/// Returns (index_packet_bytes, volume_file_paths) for use in NZB generation.
+/// (`{name}.vol000+001.par2`, `{name}.vol001+002.par2`, …) in the output
+/// directory. Every volume carries the full base packet set — Main (with
+/// every episode's real File ID), Creator, and one File Description + IFSC
+/// pair per episode — not just its own Recovery packets, so any single
+/// volume is self-describing. Returns (index_packet_bytes, volume_file_paths)
+/// for use in NZB generation.
 async fn write_season_par2_volumes(
     season: &SeasonPar2Set,
     release_name: &str,
@@ -3677,43 +3680,116 @@ async fn write_season_par2_volumes(
     let volumes = layout::plan_volumes(season.recovery_slices.len() as u32);
     let mut volume_paths = Vec::new();
 
-    // Write each recovery slice to its volume file.
-    for slice in &season.recovery_slices {
-        let (_vol_idx, vol) = volumes
+    // `plan_volumes` keys "write the base packets now" off the first
+    // exponent of each volume. The worker normally emits slices in
+    // ascending exponent order; sort so a future change cannot produce a
+    // volume with no Main packet.
+    let mut slices: Vec<_> = season.recovery_slices.iter().collect();
+    slices.sort_by_key(|s| s.exponent);
+
+    let mut open: Option<(PathBuf, tokio::fs::File)> = None;
+
+    for slice in slices {
+        let vol = volumes
             .iter()
-            .enumerate()
-            .find(|(_, v)| slice.exponent >= v.first && slice.exponent < v.first + v.count)
+            .find(|v| slice.exponent >= v.first && slice.exponent < v.first + v.count)
             .ok_or_else(|| anyhow::anyhow!("recovery slice exponent out of range"))?;
 
         let vol_name = layout::volume_name(release_name, *vol);
         let vol_path = output_dir.join(&vol_name);
 
-        let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&vol_path)
-            .await?;
-
-        // Write base packets on first slice of volume.
-        if slice.exponent == vol.first {
+        let need_new = open.as_ref().is_none_or(|(p, _)| p != &vol_path);
+        if need_new {
+            let mut file = tokio::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&vol_path)
+                .await?;
             file.write_all(&base_packets).await?;
+            volume_paths.push(vol_path.clone());
+            open = Some((vol_path, file));
         }
 
-        // Serialize and write recovery packet.
         let pkt = packet::serialize_packet(
             &rsid,
             &packet::TYPE_RECOVERY,
             &packet::recovery_body(slice.exponent, &slice.data),
         );
-        file.write_all(&pkt).await?;
-
-        // Track volume path (add once).
-        if slice.exponent == vol.first {
-            volume_paths.push(vol_path);
-        }
+        open.as_mut()
+            .expect("volume file opened above")
+            .1
+            .write_all(&pkt)
+            .await?;
     }
 
     Ok((base_packets, volume_paths))
+}
+
+/// Read every episode into `worker` as PAR2 input slices. Empty files
+/// contribute no slices (the hasher never sees an `is_last_of_file` for
+/// them). Returns `(names, slices_per_episode, total_slices_added)`.
+async fn feed_season_episodes(
+    ordered: &[(PathBuf, String, u64)],
+    worker: &Par2Worker,
+    par2_slice_size: usize,
+) -> Result<(Vec<String>, Vec<usize>, usize)> {
+    let mut episode_names = Vec::with_capacity(ordered.len());
+    let mut slices_per_episode = Vec::with_capacity(ordered.len());
+    let mut total_slices_added = 0;
+
+    for (ep_idx, (episode_path, name, file_size)) in ordered.iter().enumerate() {
+        let file_size = *file_size;
+        episode_names.push(name.clone());
+
+        if file_size == 0 {
+            slices_per_episode.push(0);
+            continue;
+        }
+
+        let mut file = tokio::fs::File::open(episode_path)
+            .await
+            .with_context(|| format!("opening episode `{}`", episode_path.display()))?;
+
+        let mut accum = worker.take_buffer(par2_slice_size);
+        accum.clear();
+        let mut remaining = file_size as usize;
+        let mut slices_for_episode = 0usize;
+
+        while remaining > 0 {
+            let space = par2_slice_size - accum.len();
+            let to_read = space.min(remaining);
+            let base = accum.len();
+            accum.resize(base + to_read, 0);
+            file.read_exact(&mut accum[base..base + to_read])
+                .await
+                .with_context(|| format!("reading episode `{}`", episode_path.display()))?;
+            remaining -= to_read;
+
+            if accum.len() >= par2_slice_size {
+                let is_last = remaining == 0;
+                feed_par2_slice(&mut accum, par2_slice_size, worker, is_last)?;
+                slices_for_episode += 1;
+            }
+        }
+        if !accum.is_empty() {
+            feed_par2_slice(&mut accum, par2_slice_size, worker, true)?;
+            slices_for_episode += 1;
+        }
+
+        total_slices_added += slices_for_episode;
+        slices_per_episode.push(slices_for_episode);
+        debug!(
+            episode_idx = ep_idx + 1,
+            total_episodes = ordered.len(),
+            file_size,
+            slices_for_episode,
+            expected_slices = (file_size as usize).div_ceil(par2_slice_size),
+            "finished reading episode"
+        );
+    }
+
+    Ok((episode_names, slices_per_episode, total_slices_added))
 }
 
 /// Generate a global PAR2 recovery set that covers all episodes in a season.
@@ -3783,44 +3859,16 @@ async fn generate_season_par2(episode_paths: &[PathBuf], config: &Config) -> Res
             .collect();
     }
 
-    let article_size = config.article_size;
-    let per_file_articles: Vec<usize> = ordered
-        .iter()
-        .map(|(_, _, size)| {
-            if *size == 0 {
-                0
-            } else {
-                yenc::segments(*size, article_size).len()
-            }
-        })
-        .collect();
-
-    let (par2_slice_size, total_slices) = if let Some(size) = config.par2_slice_size {
-        let s = (size / 64 * 64).max(64);
-        let n: usize = ordered
-            .iter()
-            .map(|(_, _, size)| (*size as usize).div_ceil(s))
-            .sum();
-        debug!(
-            "season PAR2: using config slice_size={} (rounded from {}), total_slices={}",
-            s, size, n
-        );
-        (s, n)
-    } else {
-        let (s, n) = optimal_par2_slice_size(&per_file_articles, article_size, config.par2);
-        debug!(
-            "season PAR2: using optimal slice_size={}, total_slices={}",
-            s, n
-        );
-        (s, n)
-    };
+    let sizes: Vec<u64> = ordered.iter().map(|(_, _, size)| *size).collect();
+    let (par2_slice_size, total_slices, recovery_count) = par2_geometry_from_sizes(&sizes, config);
+    debug!(
+        par2_slice_size,
+        total_slices, recovery_count, "season PAR2 geometry"
+    );
 
     if total_slices == 0 {
         return Ok(SeasonPar2Set::empty());
     }
-
-    let recovery_pct = config.par2;
-    let recovery_count = (total_slices as u32 * recovery_pct as u32 / 100).min(65535) as usize;
 
     if recovery_count == 0 {
         return Ok(SeasonPar2Set::empty());
@@ -3831,81 +3879,57 @@ async fn generate_season_par2(episode_paths: &[PathBuf], config: &Config) -> Res
         par2_slice_size, total_slices, recovery_count, "season PAR2 configuration"
     );
 
-    let encoder = RecoveryEncoder::try_new_smart(par2_slice_size, total_slices, 0, recovery_count)
-        .context("allocating season PAR2 recovery buffers")?
-        .with_checksums() // required for IFSC — see SeasonFileEntry::slice_checksums
-        .with_simd_path(config.simd);
-    let worker = Par2Worker::spawn(encoder, true, parmesan::worker::DEFAULT_CHANNEL_DEPTH);
-
-    let mut episode_names: Vec<String> = Vec::with_capacity(ordered.len());
-    let mut slices_per_episode: Vec<usize> = Vec::with_capacity(ordered.len());
-    let mut total_slices_added = 0;
-
-    for (ep_idx, (episode_path, name, file_size)) in ordered.iter().enumerate() {
-        let file_size = *file_size;
-        episode_names.push(name.clone());
-
-        // Empty episodes contribute zero PAR2 input slices — the worker's
-        // hasher never sees an `is_last_of_file` boundary for them, so they
-        // get no entry in its returned `hashes`; a placeholder is inserted
-        // for them below once `worker.finish()` returns.
-        if file_size == 0 {
-            slices_per_episode.push(0);
-            continue;
-        }
-
-        let mut file = tokio::fs::File::open(episode_path)
-            .await
-            .with_context(|| format!("opening episode `{}`", episode_path.display()))?;
-
-        let mut accum = worker.take_buffer(par2_slice_size);
-        accum.clear();
-        let mut remaining = file_size as usize;
-        let mut slices_for_episode = 0usize;
-
-        while remaining > 0 {
-            let space = par2_slice_size - accum.len();
-            let to_read = space.min(remaining);
-            let base = accum.len();
-            accum.resize(base + to_read, 0);
-            file.read_exact(&mut accum[base..base + to_read])
-                .await
-                .with_context(|| format!("reading episode `{}`", episode_path.display()))?;
-            remaining -= to_read;
-
-            if accum.len() >= par2_slice_size {
-                let is_last = remaining == 0;
-                feed_par2_slice(&mut accum, par2_slice_size, &worker, is_last)?;
-                slices_for_episode += 1;
-            }
-        }
-        // Flush the final partial slice for this episode (zero-padded inside
-        // feed_par2_slice), when the file size wasn't an exact multiple of
-        // par2_slice_size.
-        if !accum.is_empty() {
-            feed_par2_slice(&mut accum, par2_slice_size, &worker, true)?;
-            slices_for_episode += 1;
-        }
-
-        total_slices_added += slices_for_episode;
-        slices_per_episode.push(slices_for_episode);
-        debug!(
-            episode_idx = ep_idx + 1,
-            total_episodes = ordered.len(),
-            file_size,
-            slices_for_episode,
-            expected_slices = (file_size as usize).div_ceil(par2_slice_size),
-            "finished reading episode"
-        );
-    }
-
-    debug!(
-        calculated_total_slices = total_slices,
-        actual_slices_added = total_slices_added,
-        "season PAR2 slice count mismatch"
+    // Same budget/pass split as the per-file producer. Connection reserve
+    // is 0: season generation runs before (or without) the NNTP pool, like
+    // `--par2-before-upload`.
+    let (memory_limit, passes) = par2_memory_plan(config, par2_slice_size, recovery_count, 0)?;
+    info!(
+        memory_limit,
+        passes = passes.len(),
+        "season PAR2 memory plan"
     );
 
-    let (recovery_slices, slice_checksums, hashes) = worker.finish();
+    let mut all_recovery_slices = Vec::new();
+    let mut episode_names = Vec::new();
+    let mut slices_per_episode = Vec::new();
+    let mut slice_checksums = Vec::new();
+    let mut hashes = Vec::new();
+
+    for (pass_idx, (exp_start, rec_count)) in passes.iter().copied().enumerate() {
+        if rec_count == 0 {
+            continue;
+        }
+        let mut enc =
+            RecoveryEncoder::try_new_smart(par2_slice_size, total_slices, exp_start, rec_count)
+                .context("allocating season PAR2 recovery buffers")?
+                .with_simd_path(config.simd);
+        if pass_idx == 0 {
+            enc = enc.with_checksums();
+        }
+        let queue_limit = (memory_limit / 4).clamp(256 * 1024 * 1024, 2 * 1024 * 1024 * 1024);
+        let enc = enc.with_flush_limit(queue_limit);
+        let worker = Par2Worker::spawn(enc, pass_idx == 0, parmesan::worker::DEFAULT_CHANNEL_DEPTH);
+
+        let (names, slices, added) =
+            feed_season_episodes(&ordered, &worker, par2_slice_size).await?;
+        debug!(
+            pass = pass_idx,
+            calculated_total_slices = total_slices,
+            actual_slices_added = added,
+            "season PAR2 pass fed"
+        );
+
+        let (recovery, checksums, pass_hashes) = worker.finish();
+        all_recovery_slices.extend(recovery);
+        if pass_idx == 0 {
+            episode_names = names;
+            slices_per_episode = slices;
+            slice_checksums = checksums;
+            hashes = pass_hashes;
+        }
+    }
+
+    let recovery_slices = all_recovery_slices;
     info!(
         recovery_slices = recovery_slices.len(),
         "season PAR2 generation complete"

--- a/crates/pesto/src/resume.rs
+++ b/crates/pesto/src/resume.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::config::ObfuscateMode;
+use crate::config::{Config, ObfuscateMode};
 
 /// Posting parameters that change how the *whole* input is chunked or named.
 /// Captured once per run and compared on `--resume`: any difference means
@@ -42,6 +42,47 @@ pub struct RunFingerprint {
     /// resumed run's reused Message-IDs would be recorded against a subject
     /// that no longer matches what the original run actually posted.
     pub file_counter: bool,
+    /// Geometry / compression options that change the posted bytes without
+    /// touching `article_size` or `par2_percent`. `#[serde(default)]` so a
+    /// state file written before these fields existed still loads.
+    #[serde(default)]
+    pub par2_slice_size: Option<usize>,
+    #[serde(default)]
+    pub par2_slice_count: Option<usize>,
+    #[serde(default)]
+    pub par2_recovery_count: Option<usize>,
+    #[serde(default)]
+    pub compress_volume_size: Option<String>,
+    /// SHA-256 hex of the compression password. The state file is plaintext;
+    /// never store the password itself.
+    #[serde(default)]
+    pub compress_password: Option<String>,
+    #[serde(default)]
+    pub line_length: usize,
+}
+
+impl RunFingerprint {
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            article_size: config.article_size as u64,
+            obfuscate: config.obfuscate,
+            compress_format: config.compress_format.clone(),
+            par2_percent: config.par2,
+            file_counter: config.file_counter,
+            par2_slice_size: config.par2_slice_size,
+            par2_slice_count: config.par2_slice_count,
+            par2_recovery_count: config.par2_recovery_count,
+            compress_volume_size: config.compress_volume_size.clone(),
+            compress_password: config.compress_password.as_deref().map(hash_secret),
+            line_length: config.line_length,
+        }
+    }
+}
+
+fn hash_secret(secret: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(secret.as_bytes());
+    digest.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// A single file's identity at the time its segments were recorded. Compared
@@ -101,22 +142,43 @@ impl ResumeState {
     }
 
     /// Load state from `path`. Returns an empty state when the file does not
-    /// exist (fresh run) or cannot be parsed (corrupt state file).
+    /// exist (fresh run) or cannot be parsed (corrupt state file). I/O
+    /// failures other than not-found remain hard errors.
     pub fn load(path: &Path) -> Result<Self> {
-        if !path.exists() {
-            return Ok(Self::default());
+        let text = match std::fs::read_to_string(path) {
+            Ok(t) => t,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::default());
+            }
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("reading resume state `{}`", path.display()));
+            }
+        };
+        match serde_json::from_str(&text) {
+            Ok(state) => Ok(state),
+            Err(_) => Ok(Self::default()),
         }
-        let text = std::fs::read_to_string(path)
-            .with_context(|| format!("reading resume state `{}`", path.display()))?;
-        serde_json::from_str(&text)
-            .with_context(|| format!("parsing resume state `{}`", path.display()))
     }
 
-    /// Write the current state to `path`, creating or truncating the file.
+    /// Write the current state to `path` via a sibling temp file + rename
+    /// so a crash mid-write cannot leave a truncated JSON document.
     pub fn save(&self, path: &Path) -> Result<()> {
         let text = serde_json::to_string(self).context("serialising resume state")?;
-        std::fs::write(path, text)
-            .with_context(|| format!("writing resume state `{}`", path.display()))
+        let tmp = {
+            let mut name = path.as_os_str().to_owned();
+            name.push(".tmp");
+            std::path::PathBuf::from(name)
+        };
+        std::fs::write(&tmp, &text)
+            .with_context(|| format!("writing resume state `{}`", tmp.display()))?;
+        std::fs::rename(&tmp, path).with_context(|| {
+            format!(
+                "replacing resume state `{}` from `{}`",
+                path.display(),
+                tmp.display()
+            )
+        })
     }
 
     /// Compare `current` against the fingerprint this state was last
@@ -251,6 +313,12 @@ mod tests {
             compress_format: None,
             par2_percent: 0,
             file_counter: false,
+            par2_slice_size: None,
+            par2_slice_count: None,
+            par2_recovery_count: None,
+            compress_volume_size: None,
+            compress_password: None,
+            line_length: 128,
         }
     }
 
@@ -441,5 +509,54 @@ mod tests {
                 mtime: Some(1)
             }
         ));
+    }
+
+    #[test]
+    fn corrupt_state_file_loads_as_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        std::fs::write(&path, "this is not json {").unwrap();
+        let loaded = ResumeState::load(&path).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn save_is_readable_after_replace() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut s = ResumeState::default();
+        s.record("a.bin", 1, "id1@x", 100);
+        s.save(&path).unwrap();
+        assert!(!path.with_file_name("state.json.tmp").exists());
+        let loaded = ResumeState::load(&path).unwrap();
+        assert_eq!(loaded.get("a.bin", 1).unwrap().message_id, "id1@x");
+    }
+
+    #[test]
+    fn each_new_fingerprint_field_changes_identity() {
+        let base = fp(768_000);
+        let mut slice = base.clone();
+        slice.par2_slice_size = Some(4096);
+        assert_ne!(base, slice);
+
+        let mut count = base.clone();
+        count.par2_slice_count = Some(100);
+        assert_ne!(base, count);
+
+        let mut rec = base.clone();
+        rec.par2_recovery_count = Some(20);
+        assert_ne!(base, rec);
+
+        let mut vol = base.clone();
+        vol.compress_volume_size = Some("500m".into());
+        assert_ne!(base, vol);
+
+        let mut pw = base.clone();
+        pw.compress_password = Some(hash_secret("secret"));
+        assert_ne!(base, pw);
+
+        let mut ll = base.clone();
+        ll.line_length = 256;
+        assert_ne!(base, ll);
     }
 }

--- a/crates/pesto/src/walk.rs
+++ b/crates/pesto/src/walk.rs
@@ -92,6 +92,10 @@ pub fn expand_inputs(paths: &[PathBuf]) -> Result<Vec<InputFile>> {
         bail!("no files to post: the given directories were empty or held only skipped entries");
     }
 
+    for file in &mut out {
+        file.name = sanitize_published_name(&file.name)?;
+    }
+
     out.sort_by(|a, b| natural_cmp(&a.name, &b.name));
     for pair in out.windows(2) {
         if pair[0].name == pair[1].name {
@@ -157,6 +161,20 @@ fn walk_dir(dir: &Path, prefix: &str, out: &mut Vec<InputFile>) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Replace CR, LF, NUL and other C0 controls in a published name so it can
+/// never become an NNTP header, a `=ybegin name=` line or raw NZB text.
+/// Rejects a name that would be empty after sanitization.
+pub fn sanitize_published_name(name: &str) -> Result<String> {
+    let out: String = name
+        .chars()
+        .map(|c| if c.is_control() { '_' } else { c })
+        .collect();
+    if out.is_empty() {
+        bail!("published file name is empty after sanitizing control characters");
+    }
+    Ok(out)
 }
 
 /// The final path component of `path` as a UTF-8 string.
@@ -300,6 +318,16 @@ mod tests {
         assert_eq!(out[0].name, "show/ep01.mkv");
 
         fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn published_names_replace_control_characters() {
+        assert_eq!(
+            sanitize_published_name("ok\r\nfile.bin").unwrap(),
+            "ok__file.bin"
+        );
+        assert_eq!(sanitize_published_name("a\0b").unwrap(), "a_b");
+        assert!(sanitize_published_name("").is_err());
     }
 
     #[test]

--- a/crates/pesto/src/yenc/aarch64.rs
+++ b/crates/pesto/src/yenc/aarch64.rs
@@ -10,10 +10,20 @@ pub fn encode(out: &mut Vec<u8>, data: &[u8], line_len: usize) {
     unsafe { encode_neon_impl(out, data, line_len) }
 }
 
-/// # Safety
-/// Caller must ensure `data` is a valid slice. This function uses NEON
-/// intrinsics which are always available on aarch64.
-pub unsafe fn encoded_size_neon(data: &[u8], line_len: usize) -> usize {
+/// Exact encoded length of `data` under NEON, including escapes and CRLFs.
+///
+/// Empty input is 0 (the same contract as [`super::encoded_size`]). This
+/// function uses NEON, which is always available on aarch64.
+pub fn encoded_size_neon(data: &[u8], line_len: usize) -> usize {
+    if data.is_empty() {
+        return 0;
+    }
+    // SAFETY: aarch64 always has NEON; `data` is a live slice and non-empty
+    // so `data.len() - 1` cannot underflow.
+    unsafe { encoded_size_neon_impl(data, line_len) }
+}
+
+unsafe fn encoded_size_neon_impl(data: &[u8], line_len: usize) -> usize {
     use std::arch::aarch64::*;
     let last = data.len() - 1;
     let mut escapes = 0usize;

--- a/crates/pesto/src/yenc/mod.rs
+++ b/crates/pesto/src/yenc/mod.rs
@@ -367,7 +367,7 @@ pub fn encoded_size(data: &[u8], line_len: usize) -> usize {
 
     #[cfg(target_arch = "aarch64")]
     {
-        unsafe { aarch64::encoded_size_neon(data, line_len) }
+        aarch64::encoded_size_neon(data, line_len)
     }
 
     #[cfg(not(target_arch = "aarch64"))]

--- a/crates/pesto/src/yenc/tests.rs
+++ b/crates/pesto/src/yenc/tests.rs
@@ -586,6 +586,165 @@ fn dispatcher_matches_scalar_large_payload() {
     assert_eq!(a, b);
 }
 
+// --- 26b/c (aarch64): NEON path produces identical output to scalar ---
+
+#[cfg(target_arch = "aarch64")]
+fn encode_neon_vec(data: &[u8], line_len: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    encode_neon(&mut out, data, line_len);
+    out
+}
+
+#[allow(unused_macros)]
+macro_rules! assert_neon_eq {
+    ($data:expr, $line_len:expr) => {{
+        #[cfg(target_arch = "aarch64")]
+        {
+            let scalar = encode_s($data, $line_len);
+            let simd = encode_neon_vec($data, $line_len);
+            assert_eq!(
+                simd, scalar,
+                "NEON diverges from scalar (line_len={})",
+                $line_len
+            );
+            assert_eq!(
+                crate::yenc::aarch64::encoded_size_neon($data, $line_len),
+                simd.len(),
+                "encoded_size_neon != encode_neon length (line_len={})",
+                $line_len
+            );
+        }
+    }};
+}
+
+#[test]
+fn neon_matches_scalar_all_256_byte_values() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let data: Vec<u8> = (0u8..=255).collect();
+        assert_neon_eq!(&data, 128);
+    }
+}
+
+#[test]
+fn neon_matches_scalar_all_critical_bytes() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let data: Vec<u8> = [NUL_IN, LF_IN, CR_IN, EQ_IN]
+            .iter()
+            .cycle()
+            .copied()
+            .take(512)
+            .collect();
+        assert_neon_eq!(&data, 128);
+    }
+}
+
+#[test]
+fn neon_matches_scalar_positional_bytes_at_boundaries() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let data: Vec<u8> = [DOT_IN, SP_IN, TAB_IN, 0x00]
+            .iter()
+            .cycle()
+            .copied()
+            .take(256)
+            .collect();
+        assert_neon_eq!(&data, 4);
+    }
+}
+
+#[test]
+fn neon_matches_scalar_large_random_like_payload() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let data: Vec<u8> = (0u8..=255)
+            .cycle()
+            .enumerate()
+            .map(|(i, b): (usize, u8)| b.wrapping_add((i.wrapping_mul(7).wrapping_add(13)) as u8))
+            .take(750 * 1024)
+            .collect();
+        assert_neon_eq!(&data, 128);
+    }
+}
+
+#[test]
+fn neon_matches_scalar_empty() {
+    #[cfg(target_arch = "aarch64")]
+    assert_neon_eq!(&[], 128);
+}
+
+#[test]
+fn neon_matches_scalar_single_byte() {
+    #[cfg(target_arch = "aarch64")]
+    for b in 0u8..=255 {
+        let data = [b];
+        assert_neon_eq!(&data, 128);
+    }
+}
+
+#[test]
+fn neon_matches_scalar_short_line_len() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let data: Vec<u8> = (0u8..=255).cycle().take(512).collect();
+        for ll in [1, 2, 3, 4, 7, 16, 17] {
+            assert_neon_eq!(&data, ll);
+        }
+    }
+}
+
+#[test]
+fn neon_round_trip() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let data: Vec<u8> = (0u8..=255).cycle().take(750 * 1024).collect();
+        let mut encoded = Vec::new();
+        encode_neon(&mut encoded, &data, 128);
+        assert_eq!(decode(&encoded), data);
+    }
+}
+
+/// Every compiled backend must match `encode_scalar` for arbitrary
+/// `(data, line_len)`. This is the architecture-independent property that
+/// replaces per-backend vector lists.
+#[test]
+fn available_backends_match_scalar_on_varied_inputs() {
+    let payloads: &[&[u8]] = &[
+        &[],
+        &[0x00],
+        &[0x04], // becomes '.'
+        &[0xD6], // becomes NUL
+        &(0u8..=255).collect::<Vec<_>>(),
+    ];
+    let extra: Vec<u8> = (0u8..=255)
+        .cycle()
+        .enumerate()
+        .map(|(i, b)| b.wrapping_add((i * 3) as u8))
+        .take(8192)
+        .collect();
+    for data in payloads
+        .iter()
+        .copied()
+        .chain(std::iter::once(extra.as_slice()))
+    {
+        for line_len in [1usize, 2, 3, 4, 7, 16, 17, 32, 128] {
+            let scalar = encode_s(data, line_len);
+            let mut dispatched = Vec::new();
+            super::encode(&mut dispatched, data, line_len);
+            assert_eq!(
+                dispatched, scalar,
+                "dispatcher vs scalar line_len={line_len}"
+            );
+            assert_eq!(encoded_size(data, line_len), scalar.len());
+            assert!(
+                !crate::nntp::yenc_body_has_leading_dot(&scalar),
+                "scalar produced a leading-dot line at line_len={line_len}"
+            );
+        }
+    }
+}
+
 // --- 26d: encoded_size matches actual output length ---
 
 fn check_encoded_size(data: &[u8], line_len: usize) {

--- a/crates/pesto/tests/integration.rs
+++ b/crates/pesto/tests/integration.rs
@@ -593,6 +593,12 @@ async fn resume_with_different_article_size_discards_stale_state_instead_of_corr
         compress_format: None,
         par2_percent: 0,
         file_counter: false,
+        par2_slice_size: None,
+        par2_slice_count: None,
+        par2_recovery_count: None,
+        compress_volume_size: None,
+        compress_password: None,
+        line_length: 128,
     });
     stale.record("resize.bin", 1, "stale-part1@x", 100);
     stale.record("resize.bin", 2, "stale-part2@x", 100);
@@ -677,6 +683,12 @@ async fn resume_reuses_the_full_shared_prefix_across_runs() {
         compress_format: None,
         par2_percent: 0,
         file_counter: false,
+        par2_slice_size: None,
+        par2_slice_count: None,
+        par2_recovery_count: None,
+        compress_volume_size: None,
+        compress_password: None,
+        line_length: config.line_length,
     });
     prior.record_file(
         "a.bin",

--- a/crates/pesto/tests/resume_par2_cross_invalidation.rs
+++ b/crates/pesto/tests/resume_par2_cross_invalidation.rs
@@ -179,13 +179,7 @@ async fn changed_file_with_par2_invalidates_previously_resumed_par2_volumes_too(
     // per-file fingerprint check that would otherwise catch this on their
     // own (see the module doc comment).
     let mut prior = ResumeState::default();
-    prior.validate_run(&RunFingerprint {
-        article_size: config.article_size as u64,
-        obfuscate: ObfuscateMode::None,
-        compress_format: None,
-        par2_percent: config.par2,
-        file_counter: config.file_counter,
-    });
+    prior.validate_run(&RunFingerprint::from_config(&config));
     prior.record_file(
         "movie.bin",
         FileFingerprint {

--- a/crates/pesto/tests/season_par2_file_desc.rs
+++ b/crates/pesto/tests/season_par2_file_desc.rs
@@ -209,3 +209,36 @@ async fn season_par2_verifies_and_repairs_under_the_real_episode_names() {
 
     std::fs::remove_dir_all(&root).ok();
 }
+
+/// Regression test: the season path shares `par2_geometry_from_sizes` with
+/// the per-file path (fixing the "ignores --par2-slice-count/
+/// --par2-recovery-count" bug), but that refactor dropped the season path's
+/// old silent `.min(65535)` clamp on `recovery_count` without replacing it
+/// with the same PAR2 spec-limit validation `producer()` performs for the
+/// per-file path. An explicit `--par2-recovery-count` above the GF(2^16)
+/// exponent space must fail loudly here too, not overflow into a malformed
+/// recovery set.
+#[tokio::test(flavor = "multi_thread")]
+async fn season_par2_rejects_recovery_count_past_the_spec_limit() {
+    let root = std::env::temp_dir().join(format!("pesto_season_par2_limit_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+
+    let episode_path = root.join("S01E01.mkv");
+    std::fs::write(&episode_path, content(0, 50_000)).unwrap();
+
+    let mut config = season_config(16_384);
+    config.par2_recovery_count = Some(70_000);
+    let par2_dir = root.join("par2out");
+    std::fs::create_dir_all(&par2_dir).unwrap();
+
+    let err = generate_and_write_season_par2(&[episode_path], "Season01", &par2_dir, &config)
+        .await
+        .expect_err("recovery_count above 65535 must be rejected, not overflow silently");
+    assert!(
+        err.to_string().contains("too many recovery blocks"),
+        "unexpected error: {err}"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -560,7 +560,11 @@ The budget model itself was re-derived ahead of this phase — see
 3. ✅ PAR2 sizing (`producer`, `poster/mod.rs`) now folds the global ceiling
    in as an *additional* cap on top of the existing RLIMIT_AS-specific
    `address_space_budget` model (§9) — not a replacement for it. That model
-   is validated against a live 83.4 GiB run and stayed untouched.
+   is validated against a live 83.4 GiB run and stayed untouched. The
+   season-mode global PAR2 path (`generate_season_par2`) uses the same
+   `par2_memory_plan` helper, with a connection reserve of 0 (no NNTP pool
+   is open during generation), so `--memory-limit` splits the season
+   encoder into the same multi-pass schedule as a per-file run.
 4. ⚠️ **The one correctness trap found while implementing this**:
    `Ceiling::effective` already haircuts RLIMIT_AS (`× 0.60`); naively taking
    `share_of(ceiling.effective, Par2)` and combining it with


### PR DESCRIPTION
## Summary

Closes the Phase 1 gate from `ROADMAP.new.md`: untrusted-input boundaries, cross-arch yEnc checks, PAR2 geometry/memory consistency, and resume robustness.

### 1a — Untrusted input
- **#109** — Sanitize PAR2 File Description names in `RecoverySet::load` (no `..`, absolute, or drive prefixes). `contained_path` is the join used by verify, repair, and penne deobfuscate.
- **#115** — C0 controls stripped at `walk::InputFile`; NNTP headers neutralize CR/LF; `nzb::escape` drops XML-illegal controls; quotes in `default_subject` are replaced.
- **#116** — Reject IFSC vs length mismatch at load; saturating `slice_write_len`; verify flags trailing junk; repair `set_len`s to the recorded length.

### 1b — Cross-arch / yEnc invariant
- **#111** — NEON encoder tests mirror the x86 differentials; empty-input underflow in `encoded_size_neon` is fixed. New `test-aarch64` CI job on `ubuntu-24.04-arm`.
- **#114** — `debug_assert!` in `post_parts_inner` / `enqueue_post`; test that a payload which encodes to `.` never starts a body line with `.`.

### 1c — PAR2 memory and geometry
- **#110** — Shared `par2_memory_plan` (Ceiling + `share_of` + `address_space_budget`). Season generation uses it with a connection reserve of 0 and splits into read passes.
- **#117** — Season geometry goes through `par2_geometry_from_sizes`; volumes truncate on first open and reuse the handle; slices sorted by exponent.
- **#118** — `load_metadata` indexes recovery blocks as `(path, offset, len)` without holding bodies. Repair loads only `total_bad_slices()` blocks. verify / health / deobfuscate stay metadata-only.

### 1d — Resume
- **#112** — `RunFingerprint::from_config` includes PAR2 geometry, compress volume/password (SHA-256), and `line_length`.
- **#113** — Corrupt state loads as empty; `save` is temp-file + rename.
- **#119** — `--resume --compress` uses a stem-keyed temp dir and reuses an existing archive when it is still on disk.

### 1e
- Recovery-set / repair module docs no longer describe the pre-Phase-48 ordering situation.
- `docs/memory-management.md` notes that `--memory-limit` now covers season PAR2.

## Test plan
- [x] `cargo clippy -p pesto-poster -p parmesan-par2 -p penne --all-targets -- -D warnings`
- [x] `cargo test -p parmesan-par2 --lib -- recovery_set:: verify:: repair::`
- [x] `cargo test -p pesto-poster --lib` (new yEnc / resume / header tests)
- [x] `cargo test -p pesto-poster --test season_par2_file_desc`
- [x] `cargo test -p pesto-poster --test resume_par2_cross_invalidation`
- [x] `cargo test -p penne --lib -- health deobfuscate`
- [ ] CI on x86-64 + new aarch64 job

Closes #109
Closes #110
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115
Closes #116
Closes #117
Closes #118
Closes #119