### PR TITLE
feat(upapasta): real pause + watch mode v1 in the TUI

### DIFF
--- a/ROADMAP.new.md
+++ b/ROADMAP.new.md
@@ -196,13 +196,28 @@ introduced.
 
 The remaining gap against the legacy Python version.
 
-- [ ] **Watch mode** with smart rules and move-to-done logic — the single largest
-      missing feature.
+- [x] **Watch mode v1.** Dedicated Watch screen (F7): one monitored directory,
+      optional extension filter, configurable poll interval, move-to-done on
+      success. Detected top-level entries are baselined on first scan (nothing
+      pre-existing is uploaded), then auto-upload once their size repeats
+      unchanged across two scans — the same settle check `pesto --watch` uses
+      — through the same single-item pipeline manual uploads use, so pause/
+      cancel/progress on the Dashboard work for free. Runs outside the manual
+      Queue tab entirely (its own `ready` queue) so it can never sweep up
+      items the user queued but hasn't confirmed; `upload_in_progress` is
+      shared so a manual and a watch upload never run concurrently. Settings
+      persist to `upapasta-watch.json`; `enabled` deliberately does not, so a
+      background upload can never start silently on launch. Multiple watch
+      directories with per-directory rules remain a v2 idea, not committed.
 - [ ] **Metadata enrichment**: TMDb lookup, improved NFO generation.
 - [ ] **First-run setup wizard.**
 - [ ] Directory-level queuing (Space on a directory marks its files recursively).
 - [ ] Auto-switch to Dashboard when an upload starts.
-- [ ] Real pause (blocked on Phase 2's pesto API).
+- [x] **Real pause.** `upload::run_upload` now takes a `pause` flag threaded
+      through to `poster::post_files_inner`'s `external_pause`; the TUI's `p`
+      key on the Dashboard toggles it (`App::toggle_pause_upload`), with a
+      yellow "PAUSED" gauge state and updated status-bar hints. See
+      `crates/upapasta/ROADMAP.md` Phase 46.
 - [ ] Theme support (dark/light, user-configurable colors).
 - [ ] TUI performance tuning during long uploads.
 - [ ] Comprehensive error handling and user feedback.

--- a/ROADMAP.new.md
+++ b/ROADMAP.new.md
@@ -212,7 +212,13 @@ The remaining gap against the legacy Python version.
 - [ ] **Metadata enrichment**: TMDb lookup, improved NFO generation.
 - [ ] **First-run setup wizard.**
 - [ ] Directory-level queuing (Space on a directory marks its files recursively).
-- [ ] Auto-switch to Dashboard when an upload starts.
+- [x] **Auto-switch to Dashboard when an upload starts.** Manual uploads already
+      did this as part of the explicit `y`-to-confirm action; watch-triggered
+      uploads didn't, since they start on their own with no confirm step —
+      `App::begin_watch_upload` now jumps to the Dashboard too, unless the
+      user is mid-edit somewhere else (Config/Watch field editing, the
+      upload-confirm panel, or an active search), where yanking the screen
+      away would lose their typing.
 - [x] **Real pause.** `upload::run_upload` now takes a `pause` flag threaded
       through to `poster::post_files_inner`'s `external_pause`; the TUI's `p`
       key on the Dashboard toggles it (`App::toggle_pause_upload`), with a

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,14 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Added
+- **`upload::run_upload` takes a new `pause: Option<Arc<AtomicBool>>` parameter**,
+  threaded straight through to `poster::post_files_inner`'s `external_pause`
+  (added in `0.7.0`'s `post_pausable`). Existing callers pass `None` for the
+  same behavior as before; the CLI's own `season-par2` sub-upload does this,
+  since PAR2 volumes have no pause UI to drive it. This is the library-side
+  half of real pause/resume in `upapasta`'s TUI — see its `ROADMAP.md` Phase 46.
+
 ## [0.7.0] — 2026-08-11
 
 ### Added

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -2174,6 +2174,7 @@ async fn post_season_par2_volumes(
         Some(cancel.clone()),
         Some(par2_nzb_path), // write NZB to temp (discarded after)
         false,               // don't write history for PAR2 volumes
+        None,                // no pause support for PAR2 volume posting
     )
     .await?;
 

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -38,6 +38,11 @@ pub struct UploadOutcome {
 /// `entry_label` is the display name written to history and passed to hooks.
 /// `write_history` controls whether a record is appended to the shared
 /// pesto history file after a successful upload.
+/// `pause`, when given, suspends the posting phase at the next segment-batch
+/// boundary while `true` — see [`crate::poster::post_files_inner`]'s doc for
+/// the same scoping `cancel` already has (PAR2/compression/check still run
+/// to completion).
+#[allow(clippy::too_many_arguments)]
 pub async fn run_upload(
     config: &Config,
     entry_paths: &[PathBuf],
@@ -46,6 +51,7 @@ pub async fn run_upload(
     cancel: Option<Arc<AtomicBool>>,
     nzb_out_override: Option<PathBuf>,
     write_history: bool,
+    pause: Option<Arc<AtomicBool>>,
 ) -> anyhow::Result<UploadOutcome> {
     let upload_start = std::time::Instant::now();
     let mut inputs = crate::walk::expand_inputs(entry_paths)?;
@@ -218,26 +224,17 @@ pub async fn run_upload(
 
     // ── Post ─────────────────────────────────────────────────────────────────
     let post_tx = progress_tx.clone();
-    let outcome = if let Some(ref cancel_flag) = cancel {
-        crate::poster::post_files_with_progress_and_cancel(
-            config,
-            &inputs,
-            post_tx,
-            resume_path.as_deref(),
-            Some(cancel_flag.clone()),
-            Some(entry_label),
-        )
-        .await?
-    } else {
-        crate::poster::post_files_with_progress(
-            config,
-            &inputs,
-            post_tx,
-            resume_path.as_deref(),
-            Some(entry_label),
-        )
-        .await?
-    };
+    let outcome = crate::poster::post_files_inner(
+        config,
+        &inputs,
+        post_tx,
+        resume_path.as_deref(),
+        cancel.clone(),
+        Some(entry_label),
+        None,
+        pause,
+    )
+    .await?;
     // ─────────────────────────────────────────────────────────────────────────
 
     let has_post_failures = !outcome.failures.is_empty();

--- a/crates/upapasta/ROADMAP.md
+++ b/crates/upapasta/ROADMAP.md
@@ -400,9 +400,76 @@ This phase is lower priority. Do not block earlier phases on it.
 - Retry failed articles automatically with exponential backoff.
 - Per-server connection health indicators in the Config screen.
 - Alert when a server connection is degraded during upload.
-- **Real pause/resume:** requires a suspend mechanism in `pesto`'s poster
-  (hold the connection pool without tearing it down). Removed from the TUI in
-  40c-5 until the engine supports it — do not re-add a UI-only pause.
+- **Real pause/resume ✅ Done.** `pesto`'s `poster::post_files_inner` gained an
+  `external_pause` flag (Phase 2 of `ROADMAP.new.md`); `upload::run_upload`
+  now takes a matching `pause: Option<Arc<AtomicBool>>` and threads it
+  straight through instead of branching between the cancel-only and
+  cancel+pause poster entry points. The TUI re-adds the `p` key on the
+  Dashboard (`App::toggle_pause_upload`, `App::current_pause_flag`): it flips
+  the shared `AtomicBool`, the upload bar switches to a yellow "PAUSED" state
+  with `[p: resume]`, and the status-bar hint swaps between "p pause"/"p
+  resume". Unlike the dishonest pre-40c-5 pause, workers now genuinely stop
+  draining the segment queue at the next batch boundary and keep the
+  connection alive via the same `MODE READER` keepalive idle time already
+  uses, so resuming pays no reconnect. PAR2 generation, compression and the
+  check/repost passes are unaffected by pause, matching `cancel`'s scoping.
+
+---
+
+## Phase 47 — Watch Mode v1 ✅ Done
+
+The single largest feature gap against the legacy Python version, scoped down
+to one directory + one rule set for v1 (see `ROADMAP.new.md` Phase 3).
+
+- **New Watch screen (F7, `AppState::Watch`).** Editable fields — Directory,
+  Done directory, Extensions (comma-separated, empty = no filtering),
+  Interval — with the same select/Enter-to-edit UX as the Config screen.
+  `w` toggles watching on/off; a status panel shows the currently-uploading
+  item plus the stabilizing/queued lists. A yellow `WATCH` chip appears in
+  the top bar whenever it's running, from any tab.
+- **Detection.** A background `spawn_blocking` scan (`scan_watch_dir`) lists
+  the directory's top-level entries every `interval_secs`, skipping
+  dotfiles and `.nfo`/`.nzb` artifacts. The *first* scan of a directory only
+  baselines it (`WatchState::baseline_captured`) — nothing already present
+  gets uploaded, matching the legacy `watch.py` behavior. Later scans queue
+  an entry once its size repeats unchanged across two consecutive scans
+  (`App::apply_watch_scan` / the free `fold_watch_scan`, unit-tested in
+  `app.rs`'s `watch_scan` module without needing a full `App`).
+- **Auto-upload, not auto-queue.** A stabilized entry uploads immediately
+  through the *same* single-item pipeline manual uploads use
+  (`App::begin_watch_upload` + `run_real_upload`), so the Dashboard's
+  progress bars, `x` cancel and `p` pause all work on a watch-triggered
+  upload for free. It deliberately runs outside the manual Queue tab's
+  `upload_queue.items` — a separate `WatchState::ready` queue — so an
+  unrelated watch detection can never sweep up files the user queued via
+  Space but hasn't confirmed with `u`. Both paths share `upload_in_progress`
+  so a manual and a watch upload never run concurrently; whichever is
+  waiting resumes the instant the other's `UploadFinished`/`WatchUploadDone`
+  event lands.
+- **Move-to-done.** A successful watch upload is recorded in the catalog
+  exactly like a manual one, then `rename`d into `done_dir` if set (a
+  same-filesystem metadata op, safe to run inline on the event-loop thread;
+  a cross-device destination fails fast with a logged error instead of
+  silently copying gigabytes). A cancelled or failed watch item is never
+  retried — it stays in `WatchState::seen` permanently, mirroring the `x`
+  semantics used everywhere else in the app.
+- **Persistence.** Directory/done-dir/extensions/interval survive a restart
+  (`upapasta-watch.json`). `enabled` is deliberately excluded from that file
+  — watch mode never resumes silently on launch, so a background upload can
+  never start without the user seeing it happen first.
+- **Not in v1:** multiple watch directories with independent per-directory
+  rules (the roadmap's "smart rules" phrase) — deferred until real usage
+  shows it's needed; season/per-file folder-mode handling for watched
+  folders (a watched folder always uploads as a single release, matching
+  legacy `watch.py`).
+
+> **Caution for anyone testing this manually:** dropping a file into the
+> watched directory queues a **real** upload the moment it stabilizes,
+> including running the user's real post-upload hooks (indexer submission,
+> etc.) if a real `pesto` config is loaded — there is no confirmation step
+> by design. Point it at a config with no server configured, or be ready to
+> disable watch (`w`) within one poll interval, before testing with real
+> files present.
 
 ---
 
@@ -434,7 +501,7 @@ This phase is lower priority. Do not block earlier phases on it.
 
 | Key         | Context          | Action                              |
 |-------------|------------------|-------------------------------------|
-| F1–F6       | Global           | Jump to tab (Dash/Queue/Browser/Hist/Vault/Config) |
+| F1–F7       | Global           | Jump to tab (Dash/Queue/Browser/Hist/Vault/Config/Watch) |
 | Tab / S-Tab | Global           | Cycle tabs                          |
 | j / k       | Lists            | Move cursor                         |
 | Enter       | File tree        | Enter directory / open detail       |
@@ -446,7 +513,9 @@ This phase is lower priority. Do not block earlier phases on it.
 | d / Del     | Queue            | Remove item from queue              |
 | c           | Queue            | Clear queue                         |
 | Shift+J/K   | Queue            | Reorder items                       |
-| x           | Queue, Dashboard | Cancel running upload               |
+| x           | Dashboard        | Cancel running upload (manual or watch) |
+| p           | Dashboard        | Pause / resume running upload       |
+| w           | Watch            | Start / stop watching the configured directory |
 | /           | Log, History     | Start search                        |
 | Esc         | Any              | Close modal / cancel search         |
 | P           | Browser, Vault   | Search Prowlarr for selected file   |
@@ -478,4 +547,5 @@ This phase is lower priority. Do not block earlier phases on it.
 | 43d       | Automated Prowlarr backup workflow               | 🔲 Planned |
 | 44        | Catalog enhancements (tags, export, dedup)       | 🔲 Planned |
 | 45        | TMDb metadata enrichment                         | 🔲 Later   |
-| 46        | Multi-server posting + retry + real pause        | 🔲 Later   |
+| 46        | Multi-server posting + retry (real pause ✅ done) | 🔲 Later   |
+| 47        | Watch mode v1 (one directory, auto-upload, move-to-done) | ✅ Done |

--- a/crates/upapasta/src/app.rs
+++ b/crates/upapasta/src/app.rs
@@ -6,7 +6,9 @@ use crate::nzb_viewer::{NzbContents, NzbViewerState};
 use crate::prowlarr::{ConnectionStatus, ProwlarrConfig};
 use crate::ui::components::{FileTree, LogPanel, StatusBar, UploadQueue};
 use pesto::config::{self, Config as PestoConfig, FileConfig, ObfuscateMode};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 
@@ -21,6 +23,9 @@ pub enum AppState {
     History,
     NzbVault,
     Config,
+    /// Watch-mode setup and live status (monitored directory, stabilizing /
+    /// queued items, on/off toggle).
+    Watch,
 }
 
 #[derive(Debug, Default)]
@@ -34,6 +39,12 @@ pub struct UploadProgress {
     #[allow(dead_code)]
     pub active_connections: usize,
     pub is_cancelled: bool,
+    /// True while the user has paused the upload (`p` on the Dashboard).
+    /// Posting workers suspend at the next segment-batch boundary; PAR2,
+    /// compression and the check/repost passes are unaffected — see
+    /// `pesto::poster::post_files_inner`'s doc for the same scoping `cancel`
+    /// already has.
+    pub is_paused: bool,
 
     /// Ring buffer of recent speeds (MB/s) for sparkline
     pub speed_history: Vec<f64>,
@@ -429,6 +440,10 @@ pub struct App {
     pub upload_in_progress: bool,
     pub progress: UploadProgress,
     pub current_cancel_token: Option<CancellationToken>,
+    /// Shared with the in-flight upload task via `pesto::upload::run_upload`'s
+    /// `pause` parameter. Set to `true`/`false` by `toggle_pause_upload`;
+    /// dropped (set back to `None`) when the upload ends.
+    pub current_pause_flag: Option<Arc<AtomicBool>>,
 
     /// Loaded pesto config (if available)
     pub pesto_config: Option<PestoConfig>,
@@ -448,6 +463,9 @@ pub struct App {
 
     /// Config screen state + per-session overrides
     pub config_state: ConfigState,
+
+    /// Watch-mode state (monitored directory, stability tracking, toggle).
+    pub watch: WatchState,
 
     /// When true, draw the upload config panel (replaces NZB detail in browser)
     pub show_upload_confirm: bool,
@@ -834,6 +852,54 @@ pub struct ConfirmFieldView {
     pub hint: &'static str,
 }
 
+/// Persisted watch-mode settings (survives restarts); `enabled` is
+/// deliberately excluded — watch never resumes silently on launch, so a
+/// background upload can never start without the user seeing it happen.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+struct WatchSettings {
+    dir: Option<PathBuf>,
+    done_dir: Option<PathBuf>,
+    /// Comma-separated extensions (e.g. "mkv,mp4"); empty = no filtering.
+    ext_filter: String,
+    interval_secs: u64,
+}
+
+/// State for the Watch screen: monitors one directory, auto-uploading each
+/// top-level entry once its size is unchanged across two consecutive scans
+/// (the same settle check `pesto --watch` uses), then optionally moves the
+/// source into `done_dir`.
+#[derive(Debug, Default)]
+pub struct WatchState {
+    pub enabled: bool,
+    pub dir: Option<PathBuf>,
+    pub done_dir: Option<PathBuf>,
+    pub ext_filter: String,
+    pub interval_secs: u64,
+    pub last_scan: Option<Instant>,
+    /// Set while a background scan of `dir` is in flight, so the poll loop
+    /// never overlaps two scans of the same directory.
+    pub scanning: bool,
+    /// True once the first scan of the current `dir` has run: that scan's
+    /// entries are the pre-existing baseline (ignored, never uploaded) —
+    /// only entries that show up in later scans are new arrivals.
+    pub baseline_captured: bool,
+    /// path -> size observed on the previous scan, for the settle check.
+    pub pending: std::collections::HashMap<PathBuf, u64>,
+    /// Stable entries waiting for the poster to be free.
+    pub ready: std::collections::VecDeque<PathBuf>,
+    /// Permanently resolved paths (baselined, uploaded, failed, cancelled or
+    /// ignored as empty) that must never be re-detected.
+    pub seen: std::collections::HashSet<PathBuf>,
+    /// The entry currently uploading via watch, if any.
+    pub current: Option<PathBuf>,
+    /// Index of the selected field in the Watch screen's field list.
+    pub selected: usize,
+    pub editing: bool,
+    pub edit_buf: String,
+}
+
+pub const WATCH_FIELD_COUNT: usize = 4;
+
 /// State for the Config screen.
 #[derive(Debug, Default)]
 pub struct ConfigState {
@@ -892,6 +958,7 @@ impl App {
             upload_in_progress: false,
             progress: UploadProgress::default(),
             current_cancel_token: None,
+            current_pause_flag: None,
             pesto_config,
             config_path,
             config_error,
@@ -899,6 +966,7 @@ impl App {
             history: HistoryState::default(),
             upload_started_at: None,
             config_state: ConfigState::default(),
+            watch: WatchState::default(),
             show_upload_confirm: false,
             confirm_field: 0,
             confirm_editing: false,
@@ -908,6 +976,7 @@ impl App {
             prowlarr: ProwlarrState::default(),
             hook_picker: None,
         };
+        app.load_watch_settings();
         // Import legacy JSONL once if catalog is empty
         if let Some(ref cat) = app.catalog {
             if !cat.is_populated() {
@@ -1053,7 +1122,8 @@ impl App {
             AppState::Browser => AppState::History,
             AppState::History => AppState::NzbVault,
             AppState::NzbVault => AppState::Config,
-            AppState::Config => AppState::Dashboard,
+            AppState::Config => AppState::Watch,
+            AppState::Watch => AppState::Dashboard,
         };
         if self.state == AppState::NzbVault {
             self.load_vault();
@@ -1063,12 +1133,13 @@ impl App {
 
     pub fn prev_tab(&mut self) {
         self.state = match self.state {
-            AppState::Dashboard => AppState::Config,
+            AppState::Dashboard => AppState::Watch,
             AppState::Queue => AppState::Dashboard,
             AppState::Browser => AppState::Queue,
             AppState::History => AppState::Browser,
             AppState::NzbVault => AppState::History,
             AppState::Config => AppState::NzbVault,
+            AppState::Watch => AppState::Config,
         };
         if self.state == AppState::NzbVault {
             self.load_vault();
@@ -1188,6 +1259,7 @@ impl App {
 
         let token = CancellationToken::new();
         self.current_cancel_token = Some(token.clone());
+        self.current_pause_flag = Some(Arc::new(AtomicBool::new(false)));
 
         // Initialize per-file tracking
         let file_progress: Vec<FileProgress> = self
@@ -1441,6 +1513,8 @@ impl App {
         self.upload_in_progress = false;
         self.upload_queue.active = 0;
         self.progress.is_cancelled = cancelled;
+        self.progress.is_paused = false;
+        self.current_pause_flag = None;
 
         // On a non-cancelled batch, successfully uploaded items leave the queue
         // (they now live in History with a ✓ badge); failed items stay queued
@@ -1496,6 +1570,281 @@ impl App {
 
         // Refresh the history list if it's currently visible
         self.refresh_history();
+    }
+
+    // ── Watch mode ──────────────────────────────────────────────────────────
+
+    pub fn watch_select_next(&mut self) {
+        self.watch.selected = (self.watch.selected + 1).min(WATCH_FIELD_COUNT - 1);
+    }
+
+    pub fn watch_select_prev(&mut self) {
+        self.watch.selected = self.watch.selected.saturating_sub(1);
+    }
+
+    pub fn watch_start_edit(&mut self) {
+        self.watch.edit_buf = match self.watch.selected {
+            0 => self
+                .watch
+                .dir
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+            1 => self
+                .watch
+                .done_dir
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+            2 => self.watch.ext_filter.clone(),
+            3 => self.watch.interval_secs.to_string(),
+            _ => String::new(),
+        };
+        self.watch.editing = true;
+    }
+
+    pub fn watch_cancel_edit(&mut self) {
+        self.watch.editing = false;
+        self.watch.edit_buf.clear();
+    }
+
+    /// Commit the edit buffer for the selected field. Changing the watched
+    /// directory resets all stability/dedup state: paths tracked against the
+    /// old directory have no bearing on the new one.
+    pub fn watch_confirm_edit(&mut self) {
+        let buf = self.watch.edit_buf.trim().to_string();
+        match self.watch.selected {
+            0 => {
+                let new_dir = if buf.is_empty() {
+                    None
+                } else {
+                    Some(expand_tilde(&buf))
+                };
+                if new_dir != self.watch.dir {
+                    self.watch.dir = new_dir;
+                    self.watch.pending.clear();
+                    self.watch.ready.clear();
+                    self.watch.seen.clear();
+                    self.watch.baseline_captured = false;
+                    self.watch.last_scan = None;
+                }
+            }
+            1 => {
+                self.watch.done_dir = if buf.is_empty() {
+                    None
+                } else {
+                    Some(expand_tilde(&buf))
+                };
+            }
+            2 => {
+                self.watch.ext_filter = buf.trim_start_matches('.').replace(' ', "");
+            }
+            3 => {
+                if let Ok(secs) = buf.parse::<u64>() {
+                    self.watch.interval_secs = secs.max(5);
+                }
+            }
+            _ => {}
+        }
+        self.watch.editing = false;
+        self.watch.edit_buf.clear();
+        self.save_watch_settings();
+    }
+
+    /// Start or stop watching. Refuses to start without a valid directory;
+    /// stopping never touches items already queued or mid-upload — it only
+    /// stops future scans/dispatches.
+    pub fn toggle_watch_enabled(&mut self) {
+        if self.watch.enabled {
+            self.watch.enabled = false;
+            self.status_bar.set("Watch stopped");
+            self.log_panel.push("=== Watch stopped ===".to_string());
+            return;
+        }
+        let Some(dir) = self.watch.dir.clone() else {
+            self.status_bar.set("Set a directory first (Enter to edit)");
+            return;
+        };
+        if !dir.is_dir() {
+            self.status_bar
+                .set(format!("Not a directory: {}", dir.display()));
+            return;
+        }
+        self.watch.enabled = true;
+        self.watch.last_scan = None; // scan on the next loop iteration
+        self.status_bar.set(format!("Watching {}", dir.display()));
+        self.log_panel
+            .push(format!("=== Watch started: {} ===", dir.display()));
+    }
+
+    /// Fold a background scan's (path, size) snapshot into the stability
+    /// tracker and log the result. The actual bookkeeping lives in the
+    /// free function [`fold_watch_scan`] so it is testable without a full
+    /// `App`.
+    pub fn apply_watch_scan(&mut self, entries: Vec<(PathBuf, u64)>) {
+        self.watch.scanning = false;
+        self.watch.last_scan = Some(Instant::now());
+        for (line, is_warn) in fold_watch_scan(&mut self.watch, &entries) {
+            if is_warn {
+                self.log_panel.push_warn(line);
+            } else {
+                self.log_panel.push(line);
+            }
+        }
+    }
+
+    /// Prepare app state for a single watch-triggered upload and return the
+    /// pieces the caller needs to spawn the pipeline. Mirrors `trigger_upload`
+    /// but for exactly one item, outside the manual queue.
+    pub fn begin_watch_upload(
+        &mut self,
+        path: &Path,
+    ) -> (String, CancellationToken, Arc<AtomicBool>) {
+        let label = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "watch-item".to_string());
+
+        self.watch.current = Some(path.to_path_buf());
+        self.upload_in_progress = true;
+        self.upload_started_at = Some(Instant::now());
+
+        let token = CancellationToken::new();
+        self.current_cancel_token = Some(token.clone());
+        let pause_flag = Arc::new(AtomicBool::new(false));
+        self.current_pause_flag = Some(pause_flag.clone());
+
+        self.progress = UploadProgress {
+            start_time: Some(Instant::now()),
+            speed_history: vec![0.0; 5],
+            files: vec![FileProgress {
+                name: label.clone(),
+                total_segments: 0,
+                done_segments: 0,
+                total_bytes: 0,
+                done_bytes: 0,
+                status: FileStatus::Pending,
+            }],
+            ..Default::default()
+        };
+
+        self.status_bar
+            .set(format!("[watch] uploading {label} (x to cancel)"));
+        self.log_panel
+            .push(format!("=== [watch] Starting upload: {label} ==="));
+
+        (label, token, pause_flag)
+    }
+
+    /// A watch-triggered upload finished. Unlike the manual queue's
+    /// `upload_finished`, a failed or cancelled item is never retried here —
+    /// it stays in `watch.seen` permanently, matching the manual `x`-to-cancel
+    /// semantics used everywhere else in the app.
+    pub fn watch_upload_done(
+        &mut self,
+        path: PathBuf,
+        success: bool,
+        cancelled: bool,
+        size_bytes: u64,
+        nzb_path: Option<PathBuf>,
+        duration_s: f64,
+    ) {
+        self.upload_in_progress = false;
+        self.watch.current = None;
+        self.current_cancel_token = None;
+        self.current_pause_flag = None;
+        self.progress.is_paused = false;
+
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+
+        if cancelled {
+            self.progress.is_cancelled = true;
+            self.status_bar.set(format!("[watch] cancelled: {name}"));
+            self.log_panel
+                .push(format!("=== [watch] Cancelled: {name} ==="));
+            return;
+        }
+        self.progress.is_cancelled = false;
+
+        self.record_catalog_entry(name.clone(), size_bytes, nzb_path, duration_s, !success);
+
+        if success {
+            self.status_bar.set(format!("[watch] done: {name}"));
+            self.log_panel
+                .push(format!("=== [watch] Completed: {name} ==="));
+            self.move_watch_item_to_done(&path, &name);
+        } else {
+            self.status_bar
+                .set(format!("[watch] failed: {name} (see log)"));
+            self.log_panel
+                .push_error(format!("[watch] upload failed: {name}"));
+        }
+    }
+
+    /// Move a successfully uploaded watch item into `watch.done_dir`, if set.
+    /// `rename` is a same-filesystem metadata op (no data copy), so this is
+    /// safe to call inline from the event loop; a cross-device destination
+    /// fails fast rather than silently copying gigabytes on the render thread.
+    fn move_watch_item_to_done(&mut self, path: &Path, name: &str) {
+        let Some(done_dir) = self.watch.done_dir.clone() else {
+            return;
+        };
+        if let Err(e) = std::fs::create_dir_all(&done_dir) {
+            self.log_panel
+                .push_error(format!("[watch] could not create done dir: {e}"));
+            return;
+        }
+        let Some(file_name) = path.file_name() else {
+            return;
+        };
+        let dest = done_dir.join(file_name);
+        match std::fs::rename(path, &dest) {
+            Ok(()) => {
+                self.log_panel
+                    .push(format!("[watch] moved {name} -> {}", dest.display()));
+            }
+            Err(e) => {
+                self.log_panel
+                    .push_error(format!("[watch] move failed for {name}: {e}"));
+            }
+        }
+    }
+
+    /// Persist watch settings (directory, done dir, extension filter,
+    /// interval) so they survive a restart. `enabled` is deliberately not
+    /// persisted — see `WatchSettings`'s doc comment.
+    pub fn save_watch_settings(&self) {
+        if let Some(path) = watch_settings_path() {
+            let settings = WatchSettings {
+                dir: self.watch.dir.clone(),
+                done_dir: self.watch.done_dir.clone(),
+                ext_filter: self.watch.ext_filter.clone(),
+                interval_secs: self.watch.interval_secs,
+            };
+            if let Ok(json) = serde_json::to_string_pretty(&settings) {
+                let _ = std::fs::write(path, json);
+            }
+        }
+    }
+
+    /// Load previously saved watch settings. Falls back to a 30s interval
+    /// when nothing was ever saved (or the saved value is unusable).
+    pub fn load_watch_settings(&mut self) {
+        let loaded = watch_settings_path()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|data| serde_json::from_str::<WatchSettings>(&data).ok());
+        let settings = loaded.unwrap_or_default();
+        self.watch.dir = settings.dir;
+        self.watch.done_dir = settings.done_dir;
+        self.watch.ext_filter = settings.ext_filter;
+        self.watch.interval_secs = if settings.interval_secs == 0 {
+            30
+        } else {
+            settings.interval_secs
+        };
     }
 
     /// Called from the event loop when we receive a human log line
@@ -1567,6 +1916,28 @@ impl App {
         self.status_bar.set("Cancelling upload...");
         self.log_panel
             .push("=== Upload cancellation requested ===".to_string());
+    }
+
+    /// Flip the shared pause flag for the in-flight upload. Connections stay
+    /// open and kept alive while paused (see `post_files_inner`), so toggling
+    /// back resumes immediately without a reconnect.
+    pub fn toggle_pause_upload(&mut self) {
+        if !self.upload_in_progress || self.progress.is_cancelled {
+            return;
+        }
+        let Some(flag) = self.current_pause_flag.as_ref() else {
+            return;
+        };
+        let now_paused = !self.progress.is_paused;
+        flag.store(now_paused, std::sync::atomic::Ordering::Relaxed);
+        self.progress.is_paused = now_paused;
+        if now_paused {
+            self.status_bar.set("Pausing... (p to resume)");
+            self.log_panel.push("=== Pause requested ===".to_string());
+        } else {
+            self.status_bar.set("Resuming...");
+            self.log_panel.push("=== Resume requested ===".to_string());
+        }
     }
 
     /// Returns a user-friendly summary of the settings that will be used
@@ -2753,6 +3124,84 @@ fn queue_path() -> Option<PathBuf> {
     pesto::config::config_dir().map(|d| d.join("upapasta-queue.json"))
 }
 
+/// Path to the persisted watch-mode settings.
+fn watch_settings_path() -> Option<PathBuf> {
+    pesto::config::config_dir().map(|d| d.join("upapasta-watch.json"))
+}
+
+/// Fold a background scan's (path, size) snapshot into `watch`'s stability
+/// tracker, returning the log lines the caller should display as `(message,
+/// is_warn)`. The first scan of a directory only baselines it (marks every
+/// current entry as already-seen, without queuing anything) — see
+/// `WatchState::baseline_captured`. Later scans queue an entry once its size
+/// stops changing across two consecutive scans, mirroring the settle check
+/// `pesto --watch` uses.
+fn fold_watch_scan(watch: &mut WatchState, entries: &[(PathBuf, u64)]) -> Vec<(String, bool)> {
+    let mut lines = Vec::new();
+
+    if !watch.baseline_captured {
+        watch.baseline_captured = true;
+        for (path, _) in entries {
+            watch.seen.insert(path.clone());
+        }
+        if !entries.is_empty() {
+            lines.push((
+                format!(
+                    "[watch] baseline captured — {} existing item(s) ignored",
+                    entries.len()
+                ),
+                false,
+            ));
+        }
+        return lines;
+    }
+
+    let done_dir = watch.done_dir.clone();
+    for (path, size) in entries {
+        if watch.seen.contains(path) {
+            continue;
+        }
+        if done_dir.as_ref().is_some_and(|done| path.starts_with(done)) {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+        match watch.pending.get(path).copied() {
+            None => {
+                watch.pending.insert(path.clone(), *size);
+                lines.push((
+                    format!("[watch] detected {name} — waiting to stabilize"),
+                    false,
+                ));
+            }
+            Some(prev) if prev != *size => {
+                watch.pending.insert(path.clone(), *size);
+            }
+            Some(prev) => {
+                watch.pending.remove(path);
+                watch.seen.insert(path.clone());
+                if prev == 0 {
+                    lines.push((format!("[watch] {name}: empty, ignoring"), true));
+                } else {
+                    watch.ready.push_back(path.clone());
+                    lines.push((
+                        format!("[watch] {name} is stable — queued for upload"),
+                        false,
+                    ));
+                }
+            }
+        }
+    }
+
+    // Drop stability tracking for anything that vanished before settling.
+    let present: std::collections::HashSet<&PathBuf> = entries.iter().map(|(p, _)| p).collect();
+    watch.pending.retain(|p, _| present.contains(p));
+
+    lines
+}
+
 /// Insert, update, or remove `[output.indexer].<field>` in a config.toml
 /// document, preserving everything else (comments, ordering, formatting).
 ///
@@ -2856,6 +3305,111 @@ fn load_pesto_config() -> (Option<PestoConfig>, Option<PathBuf>, Option<String>)
 mod tests {
     use super::{apply_indexer_field, queue_entry_info, queue_entry_info_quick};
     use std::fs;
+
+    mod watch_scan {
+        use super::super::{fold_watch_scan, WatchState};
+        use std::path::PathBuf;
+
+        fn p(name: &str) -> PathBuf {
+            PathBuf::from(format!("/watch/{name}"))
+        }
+
+        /// The first scan of a directory only baselines it: every entry
+        /// already present is marked seen but nothing is queued, matching
+        /// the "ignore what already exists" behavior watch mode promises.
+        #[test]
+        fn first_scan_baselines_without_queuing() {
+            let mut w = WatchState::default();
+            let lines = fold_watch_scan(&mut w, &[(p("a.mkv"), 100), (p("b.mkv"), 200)]);
+
+            assert!(w.baseline_captured);
+            assert!(w.ready.is_empty());
+            assert!(w.pending.is_empty());
+            assert!(w.seen.contains(&p("a.mkv")));
+            assert!(w.seen.contains(&p("b.mkv")));
+            assert_eq!(lines.len(), 1);
+            assert!(lines[0].0.contains("baseline captured"));
+        }
+
+        /// A brand-new entry (after baselining) is tracked as pending on its
+        /// first sighting, then queued only once its size repeats unchanged.
+        #[test]
+        fn new_entry_queues_once_size_is_stable_across_two_scans() {
+            let mut w = WatchState::default();
+            fold_watch_scan(&mut w, &[]); // baseline: nothing pre-existing
+
+            fold_watch_scan(&mut w, &[(p("new.mkv"), 100)]);
+            assert!(w.ready.is_empty(), "queued before stabilizing");
+            assert_eq!(w.pending.get(&p("new.mkv")), Some(&100));
+
+            fold_watch_scan(&mut w, &[(p("new.mkv"), 100)]);
+            assert_eq!(w.ready.into_iter().collect::<Vec<_>>(), vec![p("new.mkv")]);
+            assert!(w.pending.is_empty());
+            assert!(w.seen.contains(&p("new.mkv")));
+        }
+
+        /// A still-growing file must never be queued: each differing size
+        /// just re-arms the settle check instead.
+        #[test]
+        fn still_changing_size_is_never_queued() {
+            let mut w = WatchState::default();
+            fold_watch_scan(&mut w, &[]);
+
+            fold_watch_scan(&mut w, &[(p("f.mkv"), 100)]);
+            fold_watch_scan(&mut w, &[(p("f.mkv"), 150)]);
+            fold_watch_scan(&mut w, &[(p("f.mkv"), 200)]);
+
+            assert!(w.ready.is_empty());
+            assert_eq!(w.pending.get(&p("f.mkv")), Some(&200));
+        }
+
+        /// A stable empty file/dir is ignored (marked seen) rather than
+        /// queued for a pointless upload.
+        #[test]
+        fn stable_empty_entry_is_ignored_not_queued() {
+            let mut w = WatchState::default();
+            fold_watch_scan(&mut w, &[]);
+
+            fold_watch_scan(&mut w, &[(p("empty.txt"), 0)]);
+            let lines = fold_watch_scan(&mut w, &[(p("empty.txt"), 0)]);
+
+            assert!(w.ready.is_empty());
+            assert!(w.seen.contains(&p("empty.txt")));
+            assert!(lines.iter().any(|(_, is_warn)| *is_warn));
+        }
+
+        /// An entry inside `done_dir` (watch mode's own output) must never
+        /// be picked up, even once stable — otherwise a move-to-done would
+        /// feed straight back into the watch loop.
+        #[test]
+        fn entries_inside_done_dir_are_never_queued() {
+            let mut w = WatchState {
+                done_dir: Some(PathBuf::from("/watch/done")),
+                ..Default::default()
+            };
+            fold_watch_scan(&mut w, &[]);
+
+            fold_watch_scan(&mut w, &[(PathBuf::from("/watch/done/old.mkv"), 100)]);
+            fold_watch_scan(&mut w, &[(PathBuf::from("/watch/done/old.mkv"), 100)]);
+
+            assert!(w.ready.is_empty());
+            assert!(w.pending.is_empty());
+        }
+
+        /// An entry that disappears before settling (e.g. renamed or
+        /// deleted) drops out of `pending` instead of lingering forever.
+        #[test]
+        fn vanished_entry_is_dropped_from_pending() {
+            let mut w = WatchState::default();
+            fold_watch_scan(&mut w, &[]);
+
+            fold_watch_scan(&mut w, &[(p("gone.mkv"), 100)]);
+            assert!(w.pending.contains_key(&p("gone.mkv")));
+
+            fold_watch_scan(&mut w, &[]);
+            assert!(w.pending.is_empty());
+        }
+    }
 
     fn indexer_str(doc_text: &str, field: &str) -> Option<String> {
         let doc = doc_text

--- a/crates/upapasta/src/app.rs
+++ b/crates/upapasta/src/app.rs
@@ -1709,6 +1709,19 @@ impl App {
         self.upload_in_progress = true;
         self.upload_started_at = Some(Instant::now());
 
+        // Unlike the manual queue's `y`-to-confirm flow (which already jumps
+        // to the Dashboard as part of that explicit action), a watch upload
+        // starts on its own — surface it unless the user is mid-edit
+        // somewhere else, where yanking the screen away would lose context.
+        if !self.watch.editing
+            && !self.config_state.editing
+            && !self.confirm_editing
+            && !self.log_panel.searching
+            && !self.history.searching
+        {
+            self.state = AppState::Dashboard;
+        }
+
         let token = CancellationToken::new();
         self.current_cancel_token = Some(token.clone());
         let pause_flag = Arc::new(AtomicBool::new(false));

--- a/crates/upapasta/src/events.rs
+++ b/crates/upapasta/src/events.rs
@@ -183,6 +183,23 @@ pub enum AppEvent {
         hook_name: String,
         log: Vec<String>,
     },
+    // A background rescan of the watch directory finished: top-level entries
+    // as (path, size) snapshots for stability tracking.
+    WatchScanReady {
+        entries: Vec<(std::path::PathBuf, u64)>,
+    },
+    // A watch-triggered upload finished (success, failure, or cancellation).
+    // Separate from `UploadFinished`/`ItemUploadDone`, which are the manual
+    // queue's batch-completion events — watch mode drives its own single-item
+    // pipeline outside the manual queue so the two never interfere.
+    WatchUploadDone {
+        path: std::path::PathBuf,
+        success: bool,
+        cancelled: bool,
+        size_bytes: u64,
+        nzb_path: Option<std::path::PathBuf>,
+        duration_s: f64,
+    },
 }
 
 pub struct EventHandler {

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -136,6 +136,7 @@ async fn run_app<B: ratatui::backend::Backend>(
                             && !app.history.searching
                             && app.history.nzb_viewer.is_none()
                             && !app.config_state.editing
+                            && !app.watch.editing
                             && !app.show_upload_confirm
                             && app.prowlarr.search.is_none()
                             && app.prowlarr.batch.is_none() =>
@@ -147,6 +148,7 @@ async fn run_app<B: ratatui::backend::Backend>(
                             && !app.history.searching
                             && app.history.nzb_viewer.is_none()
                             && !app.config_state.editing
+                            && !app.watch.editing
                             && !app.show_upload_confirm
                             && app.prowlarr.search.is_none()
                             && app.prowlarr.batch.is_none() =>
@@ -165,7 +167,7 @@ async fn run_app<B: ratatui::backend::Backend>(
                             app.refresh_history();
                         }
                     }
-                    // F1–F6: direct tab jump
+                    // F1–F7: direct tab jump
                     KeyCode::F(1) => {
                         app.state = app::AppState::Dashboard;
                     }
@@ -185,6 +187,9 @@ async fn run_app<B: ratatui::backend::Backend>(
                     }
                     KeyCode::F(6) => {
                         app.state = app::AppState::Config;
+                    }
+                    KeyCode::F(7) => {
+                        app.state = app::AppState::Watch;
                     }
                     // ── Upload config panel (text-edit mode takes priority) ──
                     _ if app.show_upload_confirm && app.confirm_editing => match key.code {
@@ -450,6 +455,12 @@ async fn run_app<B: ratatui::backend::Backend>(
                     {
                         app.cancel_upload();
                     }
+                    // Pause/resume current upload
+                    KeyCode::Char('p')
+                        if app.state == app::AppState::Dashboard && app.upload_in_progress =>
+                    {
+                        app.toggle_pause_upload();
+                    }
                     // ── History screen keys ────────────────────────────────
                     // NZB viewer overlay takes priority when open
                     _ if app.state == app::AppState::History
@@ -584,6 +595,26 @@ async fn run_app<B: ratatui::backend::Backend>(
                         }
                         _ => {}
                     },
+                    // ── Watch screen (text-edit mode) ──────────────────────
+                    _ if app.state == app::AppState::Watch && app.watch.editing => match key.code {
+                        KeyCode::Esc => app.watch_cancel_edit(),
+                        KeyCode::Enter => app.watch_confirm_edit(),
+                        KeyCode::Backspace => {
+                            app.watch.edit_buf.pop();
+                        }
+                        KeyCode::Char(c) => {
+                            app.watch.edit_buf.push(c);
+                        }
+                        _ => {}
+                    },
+                    // ── Watch screen (navigation) ──────────────────────────
+                    _ if app.state == app::AppState::Watch => match key.code {
+                        KeyCode::Char('j') | KeyCode::Down => app.watch_select_next(),
+                        KeyCode::Char('k') | KeyCode::Up => app.watch_select_prev(),
+                        KeyCode::Enter | KeyCode::Char('e') => app.watch_start_edit(),
+                        KeyCode::Char('w') => app.toggle_watch_enabled(),
+                        _ => {}
+                    },
                     _ => {}
                 },
                 AppEvent::Progress(msg) => {
@@ -679,6 +710,26 @@ async fn run_app<B: ratatui::backend::Backend>(
                 }
                 AppEvent::UploadFinished { success, cancelled } => {
                     app.upload_finished(success, cancelled);
+                    // A manual batch just freed the poster — let a waiting
+                    // watch item start right away instead of idling until
+                    // the next poll interval.
+                    start_watch_upload(app, tx.clone());
+                }
+                AppEvent::WatchScanReady { entries } => {
+                    app.apply_watch_scan(entries);
+                }
+                AppEvent::WatchUploadDone {
+                    path,
+                    success,
+                    cancelled,
+                    size_bytes,
+                    nzb_path,
+                    duration_s,
+                } => {
+                    app.watch_upload_done(
+                        path, success, cancelled, size_bytes, nzb_path, duration_s,
+                    );
+                    start_watch_upload(app, tx.clone());
                 }
                 AppEvent::ProwlarrStatus(status) => {
                     match &status {
@@ -832,6 +883,36 @@ async fn run_app<B: ratatui::backend::Backend>(
                     results,
                 });
             });
+        }
+
+        // Watch mode: periodically rescan the configured directory off-thread.
+        // `scanning` guards against a scan overlapping the next poll tick if
+        // a directory listing is unusually slow.
+        if app.watch.enabled && !app.watch.scanning {
+            let due = app
+                .watch
+                .last_scan
+                .map(|t| t.elapsed() >= Duration::from_secs(app.watch.interval_secs))
+                .unwrap_or(true);
+            if due {
+                if let Some(dir) = app.watch.dir.clone() {
+                    app.watch.scanning = true;
+                    let ext_filter = app.watch.ext_filter.clone();
+                    let tx_watch = tx.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let entries = scan_watch_dir(&dir, &ext_filter);
+                        let _ = tx_watch.send(AppEvent::WatchScanReady { entries });
+                    });
+                }
+            }
+        }
+
+        // Watch mode: start the next stabilized item once the poster is free.
+        // (Also triggered right after a manual/watch upload finishes, above —
+        // this covers the case where items became ready while nothing was
+        // running at all.)
+        if app.watch.enabled && !app.upload_in_progress {
+            start_watch_upload(app, tx.clone());
         }
 
         // Small sleep to avoid busy-looping the draw thread
@@ -1381,6 +1462,10 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
     let folder_mode = app.effective_folder_mode();
 
     let cancel_token = app.current_cancel_token.clone().unwrap_or_default();
+    let pause_flag = app
+        .current_pause_flag
+        .clone()
+        .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
 
     // Direct uploads into nzb_dir/uploaded/ so the vault can distinguish them
     // from downloaded and manually-placed NZBs.
@@ -1428,6 +1513,7 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
                     nzb_out_dir.clone(),
                     tx.clone(),
                     cancel_token.clone(),
+                    pause_flag.clone(),
                 )
                 .await;
                 let duration_s = item_start.elapsed().as_secs_f64();
@@ -1514,6 +1600,7 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
                     nzb_out_dir.clone(),
                     tx.clone(),
                     cancel_token.clone(),
+                    pause_flag.clone(),
                 )
                 .await;
                 let ep_dur = ep_start.elapsed().as_secs_f64();
@@ -1579,6 +1666,7 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
                         nzb_out_dir.clone(),
                         tx.clone(),
                         cancel_token.clone(),
+                        pause_flag.clone(),
                     )
                     .await;
                     let ep_dur = ep_start.elapsed().as_secs_f64();
@@ -1881,6 +1969,7 @@ async fn run_real_upload(
     nzb_out_dir: Option<PathBuf>,
     tx: mpsc::UnboundedSender<AppEvent>,
     cancel_token: CancellationToken,
+    pause_flag: Arc<AtomicBool>,
 ) -> anyhow::Result<pesto::upload::UploadOutcome> {
     // Route pesto's internal DEBUG traces to a per-upload session log file.
     // This mirrors what the pesto CLI does via --session-log.
@@ -1929,6 +2018,7 @@ async fn run_real_upload(
             Some(cancel_flag),
             nzb_override,
             true,
+            Some(pause_flag),
         )
         .await
     });
@@ -2055,6 +2145,144 @@ async fn run_real_upload(
     Ok(outcome)
 }
 
+/// Dispatch the next watch-mode item, if any, through the same upload
+/// pipeline manual uploads use. No-op when the ready queue is empty or an
+/// upload (manual or watch) is already running — the caller is expected to
+/// have checked `!app.upload_in_progress` already, but a stale/vanished path
+/// at the front of the queue is skipped in a loop rather than stalling watch
+/// mode until the next poll interval notices it too.
+fn start_watch_upload(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
+    if app.upload_in_progress {
+        return;
+    }
+    while let Some(path) = app.watch.ready.pop_front() {
+        if !path.exists() {
+            app.log_panel.push(format!(
+                "[watch] {} vanished before upload, skipping",
+                path.display()
+            ));
+            continue;
+        }
+
+        let (label, token, pause_flag) = app.begin_watch_upload(&path);
+
+        let config = if let Some(mut real_cfg) = app.effective_config_with_overrides() {
+            real_cfg.dry_run = false;
+            real_cfg
+        } else {
+            build_dry_run_config()
+        };
+        // Same "uploaded/" destination manual uploads use, so watch-sourced
+        // NZBs land in the same place and the Vault/History treat them alike.
+        let nzb_out_dir: Option<PathBuf> = app
+            .pesto_config
+            .as_ref()
+            .and_then(|c| c.nzb_dir.as_deref())
+            .map(|d| app::expand_tilde(d).join("uploaded"));
+        if let Some(ref d) = nzb_out_dir {
+            let _ = std::fs::create_dir_all(d);
+        }
+
+        let tx2 = tx.clone();
+        tokio::spawn(async move {
+            let start = Instant::now();
+            let result = run_real_upload(
+                config,
+                vec![path.clone()],
+                label,
+                nzb_out_dir,
+                tx2.clone(),
+                token,
+                pause_flag,
+            )
+            .await;
+            let duration_s = start.elapsed().as_secs_f64();
+            match result {
+                Ok(outcome) => {
+                    let _ = tx2.send(AppEvent::WatchUploadDone {
+                        path,
+                        success: !outcome.had_failures,
+                        cancelled: outcome.cancelled,
+                        size_bytes: outcome.total_bytes,
+                        nzb_path: outcome.nzb_path,
+                        duration_s,
+                    });
+                }
+                Err(e) => {
+                    let _ = tx2.send(AppEvent::UploadError(format!(
+                        "[watch] {}: {e}",
+                        path.display()
+                    )));
+                    let _ = tx2.send(AppEvent::WatchUploadDone {
+                        path,
+                        success: false,
+                        cancelled: false,
+                        size_bytes: 0,
+                        nzb_path: None,
+                        duration_s,
+                    });
+                }
+            }
+        });
+        return;
+    }
+}
+
+/// Snapshot of `dir`'s top-level entries as (path, size) pairs, for watch
+/// mode's stability tracking. `.nfo`/`.nzb` artifacts and dotfiles are
+/// skipped; `ext_filter` (comma-separated, case-insensitive, empty = no
+/// filtering) narrows which *files* count — subdirectories are always kept
+/// since matching files may live inside them.
+fn scan_watch_dir(dir: &Path, ext_filter: &str) -> Vec<(PathBuf, u64)> {
+    let filters: Vec<&str> = ext_filter
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    read_dir
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            let hidden = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.'));
+            if hidden {
+                return false;
+            }
+            let ext = p.extension().and_then(|e| e.to_str());
+            let is_artifact =
+                ext.is_some_and(|e| e.eq_ignore_ascii_case("nfo") || e.eq_ignore_ascii_case("nzb"));
+            if is_artifact {
+                return false;
+            }
+            p.is_dir()
+                || filters.is_empty()
+                || ext.is_some_and(|e| filters.iter().any(|f| f.eq_ignore_ascii_case(e)))
+        })
+        .map(|p| {
+            let size = watch_entry_size(&p);
+            (p, size)
+        })
+        .collect()
+}
+
+/// Total size of a watch-mode candidate: direct metadata for a file, a
+/// recursive walk for a directory (same helper the queue uses for folder
+/// sizing).
+fn watch_entry_size(path: &Path) -> u64 {
+    if path.is_file() {
+        std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+    } else {
+        app::dir_stats(path).1
+    }
+}
+
 /// Append a one-line structured summary to the session log file.
 ///
 /// Written after all tracing events so it is always the last line, making
@@ -2139,6 +2367,8 @@ fn format_progress_event(ev: &pesto::progress::ProgressEvent) -> String {
         E::Finished => "=== Pesto run finished ===".into(),
         E::Failed { description } => format!("FAILED: {}", description),
         E::Interrupted => "Interrupted by user".into(),
+        E::Paused => "=== Upload paused ===".into(),
+        E::Resumed => "=== Upload resumed ===".into(),
         E::CheckDone { failed } if *failed == 0 => "✓ Check: all articles verified".into(),
         E::CheckDone { failed } => {
             format!("✗ Check: {failed} article(s) still missing after every repost attempt")
@@ -2414,5 +2644,54 @@ fn extract_progress_update(
             par2_complete: false,
         }),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod watch_scan_dir_tests {
+    use super::scan_watch_dir;
+
+    /// `.nfo`/`.nzb` artifacts and dotfiles never show up as candidates,
+    /// extension filtering only narrows *files* (subdirectories always pass
+    /// through since a matching file may live inside), and sizes are real.
+    #[test]
+    fn skips_artifacts_and_hidden_entries_applies_ext_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("movie.mkv"), b"hello").unwrap();
+        std::fs::write(dir.path().join("subs.srt"), b"x").unwrap();
+        std::fs::write(dir.path().join("Show.nfo"), b"x").unwrap();
+        std::fs::write(dir.path().join("Show.nzb"), b"x").unwrap();
+        std::fs::write(dir.path().join(".hidden"), b"x").unwrap();
+        std::fs::create_dir(dir.path().join("Season 01")).unwrap();
+
+        let entries = scan_watch_dir(dir.path(), "mkv");
+        let names: Vec<String> = entries
+            .iter()
+            .map(|(p, _)| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+
+        assert!(names.contains(&"movie.mkv".to_string()));
+        assert!(names.contains(&"Season 01".to_string()));
+        assert!(!names.contains(&"subs.srt".to_string()));
+        assert!(!names.contains(&"Show.nfo".to_string()));
+        assert!(!names.contains(&"Show.nzb".to_string()));
+        assert!(!names.contains(&".hidden".to_string()));
+
+        let movie = entries
+            .iter()
+            .find(|(p, _)| p.file_name().unwrap() == "movie.mkv")
+            .unwrap();
+        assert_eq!(movie.1, 5);
+    }
+
+    /// An empty `ext_filter` matches every non-artifact, non-hidden file.
+    #[test]
+    fn empty_ext_filter_matches_everything() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.mkv"), b"x").unwrap();
+        std::fs::write(dir.path().join("b.srt"), b"x").unwrap();
+
+        let entries = scan_watch_dir(dir.path(), "");
+        assert_eq!(entries.len(), 2);
     }
 }

--- a/crates/upapasta/src/ui/mod.rs
+++ b/crates/upapasta/src/ui/mod.rs
@@ -137,13 +137,14 @@ fn draw_hook_picker_overlay(f: &mut Frame, app: &App, area: Rect) {
 /// the right. When `rule` is true a thin separator is drawn on the row below,
 /// giving structure without stacking bordered boxes.
 fn draw_top_bar(f: &mut Frame, app: &App, area: Rect, rule: bool) {
-    const TABS: [(&str, AppState); 6] = [
+    const TABS: [(&str, AppState); 7] = [
         ("Dashboard", AppState::Dashboard),
         ("Queue", AppState::Queue),
         ("Browser", AppState::Browser),
         ("History", AppState::History),
         ("Vault", AppState::NzbVault),
         ("Config", AppState::Config),
+        ("Watch", AppState::Watch),
     ];
 
     let mut spans: Vec<Span> = vec![
@@ -184,9 +185,20 @@ fn draw_top_bar(f: &mut Frame, app: &App, area: Rect, rule: bool) {
         area
     };
 
-    // Right-aligned version tag, drawn first so the tab strip can overlay the left.
+    // Right-aligned version tag (with a WATCH chip when watch mode is on),
+    // drawn first so the tab strip can overlay the left.
+    let mut right = Vec::new();
+    if app.watch.enabled {
+        right.push(Span::styled(
+            "WATCH ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    right.push(Span::styled("v2 ", theme::label()));
     f.render_widget(
-        Paragraph::new(Line::from(Span::styled("v2 ", theme::label()))).alignment(Alignment::Right),
+        Paragraph::new(Line::from(right)).alignment(Alignment::Right),
         strip_area,
     );
     f.render_widget(Paragraph::new(Line::from(spans)), strip_area);
@@ -217,6 +229,9 @@ fn draw_main(f: &mut Frame, app: &mut App, area: Rect) {
         }
         AppState::Config => {
             draw_config(f, app, area);
+        }
+        AppState::Watch => {
+            draw_watch(f, app, area);
         }
     }
 }
@@ -1093,21 +1108,40 @@ fn draw_upload_bar(f: &mut Frame, app: &App, area: Rect) {
         "ETA --:--".to_string()
     };
 
-    let label = format!(
-        "{}%  {} / {}  {}  {}",
-        upload_pct,
-        pesto::progress::format_size(p.done_bytes),
-        pesto::progress::format_size(p.total_bytes),
-        speed_str,
-        eta_str,
-    );
+    let label = if p.is_paused {
+        format!(
+            "PAUSED  {}%  {} / {}",
+            upload_pct,
+            pesto::progress::format_size(p.done_bytes),
+            pesto::progress::format_size(p.total_bytes),
+        )
+    } else {
+        format!(
+            "{}%  {} / {}  {}  {}",
+            upload_pct,
+            pesto::progress::format_size(p.done_bytes),
+            pesto::progress::format_size(p.total_bytes),
+            speed_str,
+            eta_str,
+        )
+    };
+
+    let accent = if p.is_paused {
+        Color::Yellow
+    } else {
+        Color::Green
+    };
 
     let gauge_style = Style::default()
-        .fg(Color::Green)
+        .fg(accent)
         .bg(Color::DarkGray)
         .add_modifier(Modifier::BOLD);
 
-    let title = " UPLOAD  [x: cancel] ";
+    let title = if p.is_paused {
+        " UPLOAD  [p: resume] [x: cancel] "
+    } else {
+        " UPLOAD  [p: pause] [x: cancel] "
+    };
 
     let gauge = Gauge::default()
         .block(
@@ -1115,11 +1149,9 @@ fn draw_upload_bar(f: &mut Frame, app: &App, area: Rect) {
                 .borders(Borders::ALL)
                 .title(Span::styled(
                     title,
-                    Style::default()
-                        .fg(Color::Green)
-                        .add_modifier(Modifier::BOLD),
+                    Style::default().fg(accent).add_modifier(Modifier::BOLD),
                 ))
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(Style::default().fg(accent)),
         )
         .gauge_style(gauge_style)
         .percent(upload_pct)
@@ -1348,7 +1380,11 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
             "j/k move · Enter/←→ edit · y start · Esc cancel".into()
         }
     } else if app.upload_in_progress {
-        "x cancel · Tab switch · q quit".into()
+        if app.progress.is_paused {
+            "p resume · x cancel · Tab switch · q quit".into()
+        } else {
+            "p pause · x cancel · Tab switch · q quit".into()
+        }
     } else if app.state == AppState::Queue && !app.upload_queue.items.is_empty() {
         "u upload · d remove · c clear · J/K reorder · p fetch NZBs · Tab switch".into()
     } else if app.state == AppState::Browser {
@@ -1365,6 +1401,15 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
         }
     } else if app.state == AppState::Config {
         "j/k move · Enter/e edit · r reset · R reset all · C check Prowlarr · Tab switch".into()
+    } else if app.state == AppState::Watch && app.watch.editing {
+        "Enter confirm · Esc cancel edit".into()
+    } else if app.state == AppState::Watch {
+        let toggle = if app.watch.enabled {
+            "w stop"
+        } else {
+            "w start"
+        };
+        format!("j/k move · Enter/e edit · {toggle} · Tab switch")
     } else {
         "Tab switch · q quit".into()
     };
@@ -1968,6 +2013,191 @@ fn draw_config(f: &mut Frame, app: &App, area: Rect) {
     let mut list_state = ListState::default();
     list_state.select(Some(selected));
     f.render_stateful_widget(list, chunks[1], &mut list_state);
+}
+
+struct WatchField {
+    label: &'static str,
+    value: String,
+    hint: &'static str,
+}
+
+fn build_watch_fields(app: &App) -> Vec<WatchField> {
+    use crate::app::UNSET;
+    vec![
+        WatchField {
+            label: "Directory",
+            value: app
+                .watch
+                .dir
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| UNSET.into()),
+            hint: "Folder to monitor for new files/folders",
+        },
+        WatchField {
+            label: "Done directory",
+            value: app
+                .watch
+                .done_dir
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| format!("{UNSET}  (source left in place after upload)")),
+            hint: "Move source here after a successful upload",
+        },
+        WatchField {
+            label: "Extensions",
+            value: if app.watch.ext_filter.is_empty() {
+                format!("{UNSET}  (no filtering)")
+            } else {
+                app.watch.ext_filter.clone()
+            },
+            hint: "Comma-separated, e.g. mkv,mp4 — folders always match",
+        },
+        WatchField {
+            label: "Interval",
+            value: format!("{}s", app.watch.interval_secs),
+            hint: "Seconds between directory scans",
+        },
+    ]
+}
+
+/// Watch-mode screen (F7): configure the monitored directory and see its
+/// live status (baselining, stabilizing, queued, uploading).
+fn draw_watch(f: &mut Frame, app: &App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(8), Constraint::Min(6)])
+        .split(area);
+
+    // ── Editable fields ──────────────────────────────────────────────────
+    let fields = build_watch_fields(app);
+    let selected = app.watch.selected;
+    let editing = app.watch.editing;
+
+    let items: Vec<ListItem> = fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let is_sel = i == selected;
+            let label_style = if is_sel {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            let value_display = if is_sel && editing {
+                format!("{}_", app.watch.edit_buf)
+            } else {
+                field.value.clone()
+            };
+            let value_style = if is_sel && editing {
+                Style::default().fg(Color::Green)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let line = Line::from(vec![
+                Span::styled(format!("{:<16}", field.label), label_style),
+                Span::styled(value_display, value_style),
+                if is_sel {
+                    Span::styled(
+                        format!("   ← {}", field.hint),
+                        Style::default().fg(Color::DarkGray),
+                    )
+                } else {
+                    Span::raw("")
+                },
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let title = if app.watch.enabled {
+        " Watch settings — RUNNING (w to stop) "
+    } else {
+        " Watch settings — stopped (w to start) "
+    };
+    let accent = if app.watch.enabled {
+        Color::Yellow
+    } else {
+        Color::Blue
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(Style::default().fg(accent)),
+        )
+        .highlight_style(Style::default().bg(Color::DarkGray));
+    let mut list_state = ListState::default();
+    list_state.select(Some(selected));
+    f.render_stateful_widget(list, chunks[0], &mut list_state);
+
+    // ── Live status ──────────────────────────────────────────────────────
+    let mut lines: Vec<Line> = Vec::new();
+
+    if let Some(current) = &app.watch.current {
+        let name = current
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| current.display().to_string());
+        lines.push(Line::styled(
+            format!(" ▶ uploading: {name}"),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    if !app.watch.pending.is_empty() {
+        lines.push(Line::styled(
+            format!(" ⏳ stabilizing ({}):", app.watch.pending.len()),
+            Style::default().fg(Color::DarkGray),
+        ));
+        for path in app.watch.pending.keys().take(5) {
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string());
+            lines.push(Line::raw(format!("    {name}")));
+        }
+    }
+
+    if !app.watch.ready.is_empty() {
+        lines.push(Line::styled(
+            format!(" ◷ queued ({}):", app.watch.ready.len()),
+            Style::default().fg(Color::Cyan),
+        ));
+        for path in app.watch.ready.iter().take(5) {
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string());
+            lines.push(Line::raw(format!("    {name}")));
+        }
+    }
+
+    if lines.is_empty() {
+        let msg = if !app.watch.enabled {
+            "Set a directory above, then press w to start watching."
+        } else {
+            "Idle — watching for new files or folders."
+        };
+        lines.push(Line::styled(
+            format!(" {msg}"),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+
+    let status = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Status ")
+            .border_style(Style::default().fg(Color::DarkGray)),
+    );
+    f.render_widget(status, chunks[1]);
 }
 
 fn draw_nzb_viewer_overlay(f: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary
- Wires `pesto`'s `post_pausable`/`external_pause` mechanism (already in `main`) into the `upapasta` TUI: `upload::run_upload` takes a new `pause` parameter, the Dashboard's `p` key toggles it, and the upload bar shows a yellow PAUSED state.
- Adds watch mode v1: a new Watch screen (F7) monitors one directory, auto-uploads each top-level entry once its size settles across two scans (baselining whatever already exists so nothing pre-existing gets swept up), and can move successful sources into a "done" directory. Runs through the same single-item pipeline manual uploads use but outside the manual Queue tab, so it can never sweep up items queued but not yet confirmed. Settings persist across restarts; `enabled` deliberately does not.
- Auto-switches to the Dashboard when a watch-triggered upload starts (manual uploads already did this via the confirm panel).
- CHANGELOG entry for `pesto`'s new `run_upload` parameter.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Manual TUI smoke test (tmux): app boots, Watch tab renders, field editing works, directory scan detects a new file and logs "waiting to stabilize"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR4BoNpwBRRvViEhypFjsE