### PR TITLE
feat(penne): download exit codes + --verbose/--quiet matching pesto

### DIFF
--- a/ROADMAP.new.md
+++ b/ROADMAP.new.md
@@ -236,8 +236,13 @@ The remaining gap against the legacy Python version.
 `penne` first — `sugo` builds on it.
 
 - [ ] Multi-`.nzb` batch input (a queue of queues).
-- [ ] Exit codes distinguishing "fully complete", "complete after repair" and
-      "incomplete"; `--verbose`/`--quiet` matching `pesto`'s conventions.
+- [x] **Exit codes distinguishing "fully complete", "complete after repair"
+      and "incomplete"; `--verbose`/`--quiet` matching `pesto`'s conventions.**
+      `penne download` now returns a real exit code (0/1/2/3) instead of a
+      binary `Result<()>` that exited 0 for an incomplete `--mode download`
+      run; `-v`/`--verbose`/`--log-file` (global) and `download --quiet` mirror
+      `pesto`'s flags exactly, reusing `pesto::logging::init` directly. See
+      `crates/penne/ROADMAP.md` Phase 5.
 - [ ] On-demand extra-volume fetching: today every `.par2` volume in the NZB is
       downloaded whether or not repair needs it.
 - [ ] Parallel `verify()` — currently single-threaded and sequential; pairs

--- a/crates/penne/CHANGELOG.md
+++ b/crates/penne/CHANGELOG.md
@@ -7,6 +7,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`penne download` exit codes distinguishing fully complete, complete
+  after repair, and incomplete.** Previously any `Result<()>` `Ok` exited 0
+  regardless of whether PAR2 had to repair something, or whether data was
+  still missing/damaged after a run under `--mode download` (which skips
+  repair) — the latter case exited 0 even though the release wasn't
+  actually usable. Now: `0` = every file complete, nothing needed fixing;
+  `1` = PAR2 repaired something but the end result is complete; `2` =
+  incomplete (PAR2 couldn't fix it, no recovery data was found, or repair
+  was skipped by `--mode`); `3` = a fatal error (config/network/I/O).
+- **`-v`/`--verbose` and `--log-file`**, global flags matching `pesto`'s own
+  convention exactly (`-v`/`-vv`/`-vvv` = INFO/DEBUG/TRACE, reusing
+  `pesto::logging::init` directly instead of the bare
+  `tracing_subscriber::fmt::init()` call, which had no verbosity control at
+  all).
+- **`penne download -q`/`--quiet`**, matching `pesto`'s `--quiet`: suppresses
+  the live progress panel, leaving only the status/result lines. `penne
+  check` already had its own `--quiet`; `download` didn't.
+
 ## [0.4.1] — 2026-08-12
 
 ### Fixed

--- a/crates/penne/ROADMAP.md
+++ b/crates/penne/ROADMAP.md
@@ -43,7 +43,7 @@ testable state.
 | 2 | NNTP article retrieval — `BODY` in `pesto::nntp`, `DownloadClient::body`, per-segment server failover, missing-segment tracking |
 | 3 | yEnc decoding — `pesto::yenc::decode_part`, wired into `download_queue` with per-segment corrupt-copy failover |
 | 4 | File assembly — `penne::assemble::assemble`/`assemble_all`, whole-file CRC-32, temp-file-then-rename; `penne download` CLI now performs a real end-to-end download |
-| 5 (partial) | Progress & CLI UX — `pesto`-style live panel in `penne download` (overall bar, speed, ETA, capped per-file bars), on stderr; plain fallback when redirected. Exit-code granularity and `--verbose`/`--quiet` still open. |
+| 5 | Progress & CLI UX — `pesto`-style live panel in `penne download` (overall bar, speed, ETA, capped per-file bars), on stderr; plain fallback when redirected; exit codes distinguishing complete/repaired/incomplete; `-v`/`--verbose`/`--log-file`/`--quiet` matching `pesto`'s conventions. |
 | 6 | PAR2 verify & repair — `penne::repair::verify_and_repair`, wired into `penne download`; recreates fully-missing files and patches damaged ones via `pesto::par2` |
 | 7 | Archive extraction — `penne::extract::extract_all` (`.rar`/`.7z`/`.zip`, multi-volume, password), wired into `penne download` after PAR2 |
 | 8 | Resilience — `penne::cache` (segment-level resume), configurable retry/backoff in `download_queue` |
@@ -185,7 +185,7 @@ back.
       `std::process::Command` inside an async `tokio` test would otherwise
       risk starving the mock server's own task).
 
-## Phase 5 — Progress & CLI UX (partial: live progress done; exit-code granularity and `--verbose`/`--quiet` still open)
+## Phase 5 — Progress & CLI UX ✅
 
 - [x] Wire `penne::progress::ProgressEvent` into `penne download`: found
       missing while dogfooding a release build — `download_queue` ran with
@@ -232,9 +232,34 @@ back.
       list), the updated `tests/cli_download_end_to_end.rs` (now asserting
       on `stderr`), and manually under a real pty via `script` against a
       12-file/48-segment synthetic release.
-- [ ] Exit codes distinguishing "fully complete", "complete after repair",
-      and "incomplete/missing data" — a downloader's most important signal.
-- [ ] `--verbose`/`--quiet`, matching `pesto`'s conventions.
+- [x] **Exit codes distinguishing "fully complete", "complete after
+      repair", and "incomplete/missing data".** `download()` now returns
+      `Result<i32>` instead of `Result<()>`: `0` = every file complete, `1` =
+      PAR2 repaired something but the end result is complete, `2` = data is
+      still missing/damaged (PAR2 couldn't fix it, no recovery data was
+      found, or repair was skipped via `--mode download`), `3` = a fatal
+      error. `main`'s `Download` arm now calls `process::exit`, mirroring
+      the pattern `Check` already established. `NotRepairable` and
+      `NoRecoveryData`-with-damage no longer `anyhow::bail!`/`ensure!` (which
+      collapsed them into the same generic-error exit as a config or network
+      failure) — they `eprintln!` the same message and `return Ok(2)`,
+      preserving the "stop before extraction/cleanup/cache-clear" behavior
+      the bail used to give for free. Closes the real gap this was tracking:
+      `--mode download` with missing/damaged data used to exit `0`.
+      Two existing end-to-end tests asserted `status.success()` for exactly
+      these two outcomes (a PAR2 repair, and a `--mode download` incomplete
+      file) and had to be updated to assert the specific new code instead —
+      confirmation the old exit-0-for-everything behavior was real, not
+      hypothetical. A new `quiet_suppresses_the_live_progress_panel` test
+      covers the flag below.
+- [x] **`-v`/`--verbose` and `--log-file`** (global flags) plus `download
+      -q`/`--quiet`, matching `pesto`'s conventions exactly — `main` now
+      calls `pesto::logging::init(cli.verbose, cli.log_file.as_deref(),
+      None)` instead of the bare `tracing_subscriber::fmt::init()`, which had
+      no verbosity control at all. `--quiet` suppresses `download`'s live
+      progress panel (channel receiver dropped, sender becomes a no-op),
+      mirroring `check`'s existing `--quiet` handling; `check` already had
+      its own local `--quiet`, `download` didn't.
 
 ## Phase 6 — PAR2 verify & repair ✅ (core done; on-demand extra-volume fetch still open)
 

--- a/crates/penne/src/bin/penne.rs
+++ b/crates/penne/src/bin/penne.rs
@@ -20,6 +20,13 @@ use clap::{Parser, Subcommand};
 use penne::check::CheckMethod;
 use penne::config::ProcessingMode;
 
+/// `penne download`'s exit codes — see [`Command::Download`]'s doc comment
+/// for the user-facing description.
+const EXIT_COMPLETE: i32 = 0;
+const EXIT_REPAIRED: i32 = 1;
+const EXIT_INCOMPLETE: i32 = 2;
+const EXIT_FATAL: i32 = 3;
+
 #[derive(Parser)]
 #[command(
     name = "penne",
@@ -42,6 +49,20 @@ struct Cli {
     /// config path is used.
     #[arg(long, global = true)]
     config: Option<Option<PathBuf>>,
+
+    /// Increase log verbosity. Repeat for more detail:
+    ///   `-v` = INFO (server selection, mode, PAR2/extract decisions),
+    ///   `-vv` = DEBUG (NNTP commands and responses — credentials masked),
+    ///   `-vvv` = TRACE (fine-grained timing and buffer events).
+    /// Logs are written to stderr (or --log-file). `RUST_LOG` overrides the
+    /// level when set. Matches `pesto`'s `-v`/`--verbose` convention.
+    #[arg(short, long, action = clap::ArgAction::Count, global = true, value_name = "LEVEL")]
+    verbose: u8,
+
+    /// Redirect verbose log output to FILE instead of stderr. Has no effect
+    /// without -v.
+    #[arg(long, global = true, value_name = "FILE")]
+    log_file: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -51,7 +72,14 @@ enum Command {
         /// Path to the `.nzb` file.
         nzb: PathBuf,
     },
-    /// Download and assemble the contents of a `.nzb`.
+    /// Download and assemble the contents of a `.nzb`. Exits 0 if every file
+    /// ended up complete with no repair needed, 1 if PAR2 repaired something
+    /// but the end result is complete, 2 if data is still missing or damaged
+    /// (PAR2 couldn't fix it, no recovery data was available, or repair was
+    /// skipped via `--mode download`), 3 on a fatal error (config, network,
+    /// I/O). `--stat`'s own pass/fail (see below) surfaces as a fatal error
+    /// too, since it never reaches the download/repair pipeline these codes
+    /// describe.
     Download {
         /// Path to the `.nzb` file.
         nzb: PathBuf,
@@ -112,6 +140,11 @@ enum Command {
         /// unset too.
         #[arg(long, value_enum)]
         mode: Option<ProcessingMode>,
+        /// Suppress the live progress panel; only status/result lines print.
+        /// Matches `pesto`'s `-q`/`--quiet` convention — handy for tmux/screen
+        /// sessions or when output is redirected to a log file.
+        #[arg(long, short)]
+        quiet: bool,
     },
     /// Check article availability across one or more `.nzb` files without
     /// downloading. Exits 0 if all articles are present, 1 if any are
@@ -153,8 +186,8 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
     let cli = Cli::parse();
+    pesto::logging::init(cli.verbose, cli.log_file.as_deref(), None)?;
 
     // `penne --config` with no value: launch the interactive setup wizard,
     // regardless of whether a subcommand was also given.
@@ -172,8 +205,9 @@ async fn main() -> Result<()> {
             sample,
             server,
             mode,
+            quiet,
         }) => {
-            download(
+            let exit_code = download(
                 &nzb,
                 out_dir,
                 cli.config.flatten(),
@@ -182,8 +216,14 @@ async fn main() -> Result<()> {
                 sample,
                 &server,
                 mode,
+                quiet,
             )
             .await
+            .unwrap_or_else(|e| {
+                eprintln!("error: {e:#}");
+                EXIT_FATAL
+            });
+            process::exit(exit_code);
         }
         Some(Command::Check {
             nzb,
@@ -245,7 +285,8 @@ async fn download(
     sample: Option<usize>,
     server_names: &[String],
     cli_mode: Option<ProcessingMode>,
-) -> Result<()> {
+    quiet: bool,
+) -> Result<i32> {
     anyhow::ensure!(
         stat.is_some() || sample.is_none(),
         "--sample only makes sense with --stat; a real download always fetches every segment"
@@ -280,8 +321,14 @@ async fn download(
     let mode = cli_mode.unwrap_or(config.mode);
 
     if let Some(method) = stat {
+        // `--stat` never reaches the download/repair pipeline, so it doesn't
+        // participate in the complete/repaired/incomplete distinction below —
+        // it either confirms availability (0) or fails outright (surfaced as
+        // an `Err`, exit EXIT_FATAL), per its own doc comment.
         let Some(per_file) = sample else {
-            return check_availability(&queue, &config.server_tiers, method, config.retries).await;
+            return check_availability(&queue, &config.server_tiers, method, config.retries)
+                .await
+                .map(|()| EXIT_COMPLETE);
         };
         let sampled = penne::queue::sample(&queue, per_file);
         let full_total: usize = queue.files.iter().map(|f| f.segments.len()).sum();
@@ -291,7 +338,9 @@ async fn download(
             per_file.max(1),
             sampled.files.len()
         );
-        return check_availability(&sampled, &config.server_tiers, method, config.retries).await;
+        return check_availability(&sampled, &config.server_tiers, method, config.retries)
+            .await
+            .map(|()| EXIT_COMPLETE);
     }
 
     let dest_dir = out_dir.unwrap_or(config.download_dir);
@@ -307,7 +356,12 @@ async fn download(
     );
 
     let (tx, rx) = penne::progress::channel();
-    let progress_task = penne::ui::terminal::spawn_renderer(rx);
+    let progress_task = if !quiet {
+        Some(penne::ui::terminal::spawn_renderer(rx))
+    } else {
+        drop(rx);
+        None
+    };
 
     let outcome = penne::download::download_queue(
         &queue,
@@ -323,7 +377,9 @@ async fn download(
     // here just waits for its last redraw to flush before the summary below
     // prints (avoiding any interleaving with the unbounded channel's
     // draining).
-    progress_task.await.ok();
+    if let Some(task) = progress_task {
+        task.await.ok();
+    }
 
     println!(
         "fetched {} segment(s); {} missing; {} corrupt",
@@ -363,6 +419,16 @@ async fn download(
             }
         }
     }
+    // Provisional: raised to EXIT_REPAIRED below if PAR2 fixes something, or
+    // returned early as EXIT_INCOMPLETE if it can't. Stays EXIT_INCOMPLETE
+    // as-is when repair is skipped entirely (`--mode download` with
+    // `needs_repair > 0`) — the data really is incomplete on disk even
+    // though the user chose not to attempt a fix this run.
+    let mut exit_code = if needs_repair == 0 {
+        EXIT_COMPLETE
+    } else {
+        EXIT_INCOMPLETE
+    };
 
     let synthetic_base = nzb
         .file_stem()
@@ -432,9 +498,13 @@ async fn download(
         let ran_full_verify = verify_progress_task.await.unwrap_or(false);
         match repair_outcome {
             penne::repair::RepairOutcome::Ok if !ran_full_verify => {
-                println!("  quick-check passed from already-known checksums; full re-hash skipped")
+                println!("  quick-check passed from already-known checksums; full re-hash skipped");
+                exit_code = EXIT_COMPLETE;
             }
-            penne::repair::RepairOutcome::Ok => println!("  PAR2: all files verified intact"),
+            penne::repair::RepairOutcome::Ok => {
+                println!("  PAR2: all files verified intact");
+                exit_code = EXIT_COMPLETE;
+            }
             penne::repair::RepairOutcome::Repaired(plan) => {
                 for f in &plan.repaired_files {
                     println!(
@@ -442,20 +512,29 @@ async fn download(
                         f.name, f.slices_repaired
                     );
                 }
+                exit_code = EXIT_REPAIRED;
             }
             penne::repair::RepairOutcome::NotRepairable(report) => {
-                anyhow::bail!(
-                    "{} damaged slice(s) exceed available PAR2 recovery data ({} block(s)); download is incomplete",
+                eprintln!(
+                    "error: {} damaged slice(s) exceed available PAR2 recovery data ({} block(s)); download is incomplete",
                     report.total_bad_slices(),
                     report.available_recovery_blocks
                 );
+                // Bails out here (skipping extraction/cleanup/cache-clear
+                // below) exactly like the old `anyhow::bail!` did — the
+                // difference is this is a known, reported outcome (exit
+                // EXIT_INCOMPLETE), not a generic fatal `Err`.
+                return Ok(EXIT_INCOMPLETE);
             }
             penne::repair::RepairOutcome::NoRecoveryData => {
                 println!("  no PAR2 recovery data found; skipping verification");
-                anyhow::ensure!(
-                    needs_repair == 0,
-                    "{needs_repair} file(s) incomplete or damaged, and no PAR2 recovery data was found to repair them"
-                );
+                if needs_repair > 0 {
+                    eprintln!(
+                        "error: {needs_repair} file(s) incomplete or damaged, and no PAR2 recovery data was found to repair them"
+                    );
+                    return Ok(EXIT_INCOMPLETE);
+                }
+                exit_code = EXIT_COMPLETE;
             }
         }
     } else if needs_repair > 0 {
@@ -507,7 +586,7 @@ async fn download(
         penne::cache::clear(&dest_dir)?;
     }
 
-    Ok(())
+    Ok(exit_code)
 }
 
 /// `penne download --stat`: verify every segment is still present on the

--- a/crates/penne/tests/cli_download_end_to_end.rs
+++ b/crates/penne/tests/cli_download_end_to_end.rs
@@ -178,6 +178,16 @@ fn run_penne_download_with_mode(nzb_path: &Path, config_path: &Path, mode: &str)
         .unwrap()
 }
 
+fn run_penne_download_quiet(nzb_path: &Path, config_path: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_penne"))
+        .arg("download")
+        .arg(nzb_path)
+        .args(["--config", config_path.to_str().unwrap()])
+        .arg("--quiet")
+        .output()
+        .unwrap()
+}
+
 #[test]
 fn download_fetches_decodes_and_writes_the_file() {
     let data = b"hello from penne end-to-end test".to_vec();
@@ -342,8 +352,11 @@ fn download_recovers_a_fully_missing_segment_via_par2() {
     let config_path = write_config(dir.path(), &download_dir, addr.port());
 
     let output = run_penne_download(&nzb_path, &config_path);
-    assert!(
-        output.status.success(),
+    // Exit 1 = "complete after repair": PAR2 fixed a fully-missing segment,
+    // which is exactly what this test exercises.
+    assert_eq!(
+        output.status.code(),
+        Some(1),
         "stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
@@ -430,6 +443,58 @@ fn download_prints_live_progress_instead_of_staying_silent_until_done() {
         stderr.contains("assembled: movie.bin"),
         "stderr did not report the file being assembled:\n{stderr}"
     );
+}
+
+#[test]
+fn quiet_suppresses_the_live_progress_panel() {
+    let data = b"hello from a quiet penne run".to_vec();
+    let encoded = encode_part(
+        "greeting.txt",
+        data.len() as u64,
+        PartSpec {
+            number: 1,
+            total: 1,
+            offset: 0,
+        },
+        &data,
+        128,
+        None,
+    );
+
+    let mut known = HashMap::new();
+    known.insert("art1@test", encoded.body);
+    let addr = spawn_fake_server(known);
+
+    let dir = tempfile::tempdir().unwrap();
+    let download_dir = dir.path().join("downloads");
+    let nzb_path = write_nzb(
+        dir.path(),
+        vec![segment(
+            "greeting.txt",
+            1,
+            1,
+            "art1@test",
+            data.len() as u64,
+        )],
+    );
+    let config_path = write_config(dir.path(), &download_dir, addr.port());
+
+    let output = run_penne_download_quiet(&nzb_path, &config_path);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("fetching:"),
+        "--quiet should suppress the progress panel entirely:\n{stderr}"
+    );
+
+    let written = std::fs::read(download_dir.join("greeting.txt")).unwrap();
+    assert_eq!(written, data);
 }
 
 #[test]
@@ -566,8 +631,11 @@ fn mode_download_skips_par2_repair_and_leaves_an_incomplete_file_unwritten() {
 
     let output = run_penne_download_with_mode(&nzb_path, &config_path, "download");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        output.status.success(),
+    // Exit 2 = "incomplete": the file is genuinely missing data on disk,
+    // even though `--mode download` means no repair was even attempted.
+    assert_eq!(
+        output.status.code(),
+        Some(2),
         "stdout: {stdout}\nstderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );


### PR DESCRIPTION
## Summary
- `penne download` now returns a real exit code instead of a plain success/failure `Result<()>`: `0` fully complete, `1` complete after PAR2 repair, `2` still incomplete/missing data, `3` fatal error. Closes the roadmap gap where `--mode download` with missing/damaged files exited `0`.
- `NotRepairable`/`NoRecoveryData`-with-damage no longer `bail!`/`ensure!` into a generic error exit — they report and return exit `2`, keeping the existing "skip extraction/cleanup/cache-clear" behavior.
- Adds global `-v`/`--verbose`/`--log-file` (reusing `pesto::logging::init` directly) and `download -q`/`--quiet`, matching `pesto`'s own CLI conventions.
- Updates two existing end-to-end tests whose `status.success()` assertions no longer hold now that those exact scenarios (PAR2 repair, `--mode download` incomplete) get their own specific codes, and adds a new quiet-mode test.
- `ROADMAP.new.md`, `crates/penne/ROADMAP.md` and `crates/penne/CHANGELOG.md` updated.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Manual `penne download --help` sanity check of the new flags' doc text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR4BoNpwBRRvViEhypFjsE