### PR TITLE
feat(penne): multi-.nzb batch input for download

### DIFF
--- a/ROADMAP.new.md
+++ b/ROADMAP.new.md
@@ -235,7 +235,13 @@ The remaining gap against the legacy Python version.
 
 `penne` first — `sugo` builds on it.
 
-- [ ] Multi-`.nzb` batch input (a queue of queues).
+- [x] **Multi-`.nzb` batch input (a queue of queues).** `penne download`
+      takes one or more `.nzb` paths, looping the existing single-item
+      pipeline unchanged; each release beyond the first gets its own
+      subdirectory (named after its `.nzb`'s stem) to avoid collisions
+      between same-named files across releases, and the overall exit code
+      is the worst of any individual release's. See `crates/penne/ROADMAP.md`
+      Phase 1.
 - [x] **Exit codes distinguishing "fully complete", "complete after repair"
       and "incomplete"; `--verbose`/`--quiet` matching `pesto`'s conventions.**
       `penne download` now returns a real exit code (0/1/2/3) instead of a

--- a/crates/penne/CHANGELOG.md
+++ b/crates/penne/CHANGELOG.md
@@ -26,6 +26,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`penne download -q`/`--quiet`**, matching `pesto`'s `--quiet`: suppresses
   the live progress panel, leaving only the status/result lines. `penne
   check` already had its own `--quiet`; `download` didn't.
+- **`penne download` accepts multiple `.nzb` paths** (a queue of queues),
+  downloading each sequentially through the same single-item pipeline as
+  before. Every release beyond the first gets its own subdirectory (named
+  after its `.nzb`'s stem) under the shared destination, so same-named
+  files across releases (a `readme.txt`, a generically-named `.par2` set)
+  can't collide; a single `.nzb` keeps downloading straight into the
+  destination, unchanged from before this flag accepted more than one
+  path. The overall exit code is the worst of any individual release's own
+  code.
 
 ## [0.4.1] — 2026-08-12
 

--- a/crates/penne/ROADMAP.md
+++ b/crates/penne/ROADMAP.md
@@ -66,8 +66,24 @@ testable state.
 - [x] `penne::nzb::summarize` — file/segment/byte counts (`penne info`).
 - [x] `penne::queue::build` — group parsed segments into `QueuedFile`/`QueuedSegment`
       (pure data, no I/O; drives Phase 2 onward).
-- [ ] Handle multi-`.nzb` batch input (a queue of queues) once single-file
-      download works end-to-end.
+- [x] **Handle multi-`.nzb` batch input (a queue of queues).** `penne
+      download` takes `nzb: Vec<PathBuf>` (was a single `PathBuf`); each is
+      still routed through the exact same single-item pipeline (unchanged
+      behavior for one file), just called in a sequential loop from `main`.
+      Each release beyond the first downloads into its own subdirectory
+      (its `.nzb`'s file stem) under the shared destination, so two releases
+      shipping a same-named file — a routine reality (`readme.txt`,
+      generically-named `.par2` sets) — can't collide; a single `.nzb` keeps
+      the old flat destination, unchanged. The overall exit code is the
+      worst (highest, per Phase 5's 0/1/2/3 scale) of any individual
+      release's own code, so one incomplete release in a batch of ten still
+      fails the run. A per-item `Err` (bad NZB, network failure) is caught
+      and mapped to that item's own `EXIT_FATAL` rather than aborting the
+      rest of the batch — mirroring how `main` already handles the
+      single-item case, just per iteration instead of once. New end-to-end
+      test `download_processes_multiple_nzbs_each_into_its_own_subdirectory`
+      proves the collision case specifically (two releases, same inner file
+      name, same command).
 
 ## Phase 2 — NNTP article retrieval ✅
 

--- a/crates/penne/src/bin/penne.rs
+++ b/crates/penne/src/bin/penne.rs
@@ -72,17 +72,28 @@ enum Command {
         /// Path to the `.nzb` file.
         nzb: PathBuf,
     },
-    /// Download and assemble the contents of a `.nzb`. Exits 0 if every file
-    /// ended up complete with no repair needed, 1 if PAR2 repaired something
-    /// but the end result is complete, 2 if data is still missing or damaged
-    /// (PAR2 couldn't fix it, no recovery data was available, or repair was
-    /// skipped via `--mode download`), 3 on a fatal error (config, network,
-    /// I/O). `--stat`'s own pass/fail (see below) surfaces as a fatal error
-    /// too, since it never reaches the download/repair pipeline these codes
-    /// describe.
+    /// Download and assemble the contents of one or more `.nzb` files. Exits
+    /// 0 if every file ended up complete with no repair needed, 1 if PAR2
+    /// repaired something but the end result is complete, 2 if data is still
+    /// missing or damaged (PAR2 couldn't fix it, no recovery data was
+    /// available, or repair was skipped via `--mode download`), 3 on a fatal
+    /// error (config, network, I/O). `--stat`'s own pass/fail (see below)
+    /// surfaces as a fatal error too, since it never reaches the
+    /// download/repair pipeline these codes describe.
+    ///
+    /// Multiple `.nzb` files download sequentially, sharing one `--config`/
+    /// `--out-dir`/`--mode`/etc. for the whole batch; the overall exit code
+    /// is the worst (highest) of any individual file's own code — one
+    /// incomplete release in a batch of ten still needs to fail the run.
+    /// Each release beyond the first downloads into its own subdirectory
+    /// (named after its `.nzb` file's stem) under the shared destination, so
+    /// same-named files across releases can never collide; a single `.nzb`
+    /// keeps downloading straight into the destination, unchanged from
+    /// before this flag accepted more than one path.
     Download {
-        /// Path to the `.nzb` file.
-        nzb: PathBuf,
+        /// Path(s) to the `.nzb` file(s).
+        #[arg(required = true)]
+        nzb: Vec<PathBuf>,
         /// Destination directory for completed files. Defaults to the
         /// config file's `download_dir`, or the current directory.
         #[arg(long)]
@@ -207,23 +218,43 @@ async fn main() -> Result<()> {
             mode,
             quiet,
         }) => {
-            let exit_code = download(
-                &nzb,
-                out_dir,
-                cli.config.flatten(),
-                password,
-                stat.map(|inner| inner.unwrap_or_default()),
-                sample,
-                &server,
-                mode,
-                quiet,
-            )
-            .await
-            .unwrap_or_else(|e| {
-                eprintln!("error: {e:#}");
-                EXIT_FATAL
-            });
-            process::exit(exit_code);
+            let stat = stat.map(|inner| inner.unwrap_or_default());
+            let multi = nzb.len() > 1;
+            let mut worst_exit_code = EXIT_COMPLETE;
+            for (i, path) in nzb.iter().enumerate() {
+                if multi {
+                    println!("=== [{}/{}] {} ===", i + 1, nzb.len(), path.display());
+                }
+                // Beyond the first release, each gets its own subdirectory
+                // (named after its .nzb's stem) under the shared destination
+                // so same-named files across releases can never collide. A
+                // single .nzb keeps the old flat destination unchanged.
+                let subdir = multi.then(|| {
+                    path.file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("release")
+                        .to_string()
+                });
+                let exit_code = download(
+                    path,
+                    out_dir.clone(),
+                    cli.config.clone().flatten(),
+                    password.clone(),
+                    stat,
+                    sample,
+                    &server,
+                    mode,
+                    quiet,
+                    subdir.as_deref(),
+                )
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("error: {e:#}");
+                    EXIT_FATAL
+                });
+                worst_exit_code = worst_exit_code.max(exit_code);
+            }
+            process::exit(worst_exit_code);
         }
         Some(Command::Check {
             nzb,
@@ -286,6 +317,7 @@ async fn download(
     server_names: &[String],
     cli_mode: Option<ProcessingMode>,
     quiet: bool,
+    subdir: Option<&str>,
 ) -> Result<i32> {
     anyhow::ensure!(
         stat.is_some() || sample.is_none(),
@@ -344,6 +376,10 @@ async fn download(
     }
 
     let dest_dir = out_dir.unwrap_or(config.download_dir);
+    let dest_dir = match subdir {
+        Some(name) => dest_dir.join(name),
+        None => dest_dir,
+    };
 
     let required = penne::diskspace::required_bytes(&queue);
     let space = penne::diskspace::check(&dest_dir, required)?;

--- a/crates/penne/tests/cli_download_end_to_end.rs
+++ b/crates/penne/tests/cli_download_end_to_end.rs
@@ -123,6 +123,14 @@ fn segment(file_name: &str, part: u32, total: u32, message_id: &str, size: u64) 
 }
 
 fn write_nzb(dir: &Path, segments: Vec<PostedSegment>) -> std::path::PathBuf {
+    write_nzb_named(dir, "test.nzb", segments)
+}
+
+fn write_nzb_named(
+    dir: &Path,
+    file_name: &str,
+    segments: Vec<PostedSegment>,
+) -> std::path::PathBuf {
     let groups = vec!["alt.binaries.test".to_string()];
     let xml = pesto::nzb::generate(
         &groups,
@@ -130,7 +138,7 @@ fn write_nzb(dir: &Path, segments: Vec<PostedSegment>) -> std::path::PathBuf {
         &NzbMeta::default(),
         pesto::config::ObfuscateMode::None,
     );
-    let nzb_path = dir.join("test.nzb");
+    let nzb_path = dir.join(file_name);
     std::fs::write(&nzb_path, xml).unwrap();
     nzb_path
 }
@@ -184,6 +192,15 @@ fn run_penne_download_quiet(nzb_path: &Path, config_path: &Path) -> Output {
         .arg(nzb_path)
         .args(["--config", config_path.to_str().unwrap()])
         .arg("--quiet")
+        .output()
+        .unwrap()
+}
+
+fn run_penne_download_multi(nzb_paths: &[std::path::PathBuf], config_path: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_penne"))
+        .arg("download")
+        .args(nzb_paths)
+        .args(["--config", config_path.to_str().unwrap()])
         .output()
         .unwrap()
 }
@@ -495,6 +512,94 @@ fn quiet_suppresses_the_live_progress_panel() {
 
     let written = std::fs::read(download_dir.join("greeting.txt")).unwrap();
     assert_eq!(written, data);
+}
+
+#[test]
+fn download_processes_multiple_nzbs_each_into_its_own_subdirectory() {
+    // Both releases ship a same-named file. Passing both `.nzb`s to one
+    // `penne download` invocation must not let the second overwrite the
+    // first — each release beyond the first gets its own subdirectory named
+    // after its `.nzb` file's stem.
+    let data_a = b"release A's greeting".to_vec();
+    let data_b = b"release B's greeting".to_vec();
+    let encoded_a = encode_part(
+        "greeting.txt",
+        data_a.len() as u64,
+        PartSpec {
+            number: 1,
+            total: 1,
+            offset: 0,
+        },
+        &data_a,
+        128,
+        None,
+    );
+    let encoded_b = encode_part(
+        "greeting.txt",
+        data_b.len() as u64,
+        PartSpec {
+            number: 1,
+            total: 1,
+            offset: 0,
+        },
+        &data_b,
+        128,
+        None,
+    );
+
+    let mut known = HashMap::new();
+    known.insert("art-a@test", encoded_a.body);
+    known.insert("art-b@test", encoded_b.body);
+    let addr = spawn_fake_server(known);
+
+    let dir = tempfile::tempdir().unwrap();
+    let download_dir = dir.path().join("downloads");
+    let nzb_a = write_nzb_named(
+        dir.path(),
+        "release-a.nzb",
+        vec![segment(
+            "greeting.txt",
+            1,
+            1,
+            "art-a@test",
+            data_a.len() as u64,
+        )],
+    );
+    let nzb_b = write_nzb_named(
+        dir.path(),
+        "release-b.nzb",
+        vec![segment(
+            "greeting.txt",
+            1,
+            1,
+            "art-b@test",
+            data_b.len() as u64,
+        )],
+    );
+    let config_path = write_config(dir.path(), &download_dir, addr.port());
+
+    let output = run_penne_download_multi(&[nzb_a, nzb_b], &config_path);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== [1/2]") && stdout.contains("=== [2/2]"),
+        "expected a per-release banner for each item:\n{stdout}"
+    );
+
+    assert_eq!(
+        std::fs::read(download_dir.join("release-a").join("greeting.txt")).unwrap(),
+        data_a
+    );
+    assert_eq!(
+        std::fs::read(download_dir.join("release-b").join("greeting.txt")).unwrap(),
+        data_b
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `penne download`'s `nzb` argument is now `Vec<PathBuf>` (one or more), looped sequentially through the same unchanged single-item pipeline — the existing single-nzb test suite stays green as proof.
- Each release beyond the first downloads into its own subdirectory (named after its `.nzb`'s file stem) under the shared destination, so same-named files across releases can't collide with each other. A single `.nzb` keeps the old flat destination, unchanged.
- Overall exit code is the worst (highest, on the 0/1/2/3 scale from #123) of any individual release's own code; a per-item `Err` is caught and mapped to that item's `EXIT_FATAL` instead of aborting the rest of the batch.
- New test drives two releases that intentionally ship a same-named inner file, proving the collision case the subdirectory logic exists for.
- `ROADMAP.new.md`, `crates/penne/ROADMAP.md`, `crates/penne/CHANGELOG.md` updated.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR4BoNpwBRRvViEhypFjsE