### PR TITLE
docs: record that parallelizing parmesan verify() showed no real gain

### DIFF
--- a/ROADMAP.new.md
+++ b/ROADMAP.new.md
@@ -251,8 +251,15 @@ The remaining gap against the legacy Python version.
       `crates/penne/ROADMAP.md` Phase 5.
 - [ ] On-demand extra-volume fetching: today every `.par2` volume in the NZB is
       downloaded whether or not repair needs it.
-- [ ] Parallel `verify()` — currently single-threaded and sequential; pairs
-      naturally with #118's streaming rework.
+- [x] **Investigated: parallel `verify()` — no measurable win, reverted.**
+      Implemented (`rayon`-parallel slice hashing in batches) and A/B
+      benchmarked before committing: 568.6 vs. 573.6 MiB/s on a 250 MiB
+      fixture in `--release` — within noise. At `--release` speed, MD5+CRC32
+      is already fast enough that sequential file reads dominate wall time,
+      not hashing — `rayon` parallelizes compute, not I/O. See
+      `crates/penne/ROADMAP.md` Phase 13 for the full writeup and what a
+      real follow-up would need to target instead (the read path, not the
+      hash step).
 - [ ] Double-buffered writer / buffer pool on the assembly path.
 - [ ] Incremental extraction (`DirectUnpack`-style).
 - [ ] Benchmark against a real indexer/provider pair.

--- a/crates/penne/ROADMAP.md
+++ b/crates/penne/ROADMAP.md
@@ -834,17 +834,32 @@ time before finally printing `PAR2: all files verified intact`.
          could dominate real-world throughput independent of anything in
          `penne`. Flagged to the reporter directly — freeing space on that
          volume is outside this codebase's scope to fix.
-- [ ] **Still open**: `verify()` remains single-threaded and sequential
-      across files even in `--release` — `parmesan` already depends on
-      `rayon` (used extensively by the encoder for Reed-Solomon), so
-      parallelizing slice verification is a contained, believable further
-      win if the ~12–16s `--release` figure for a single very large file
-      is ever still worth cutting down. A live progress readout for the
-      verify phase (mirroring `pesto`'s existing
-      `Par2EncodeStarted`/`Par2InputProgress` events on the posting side)
-      is a separate, larger piece of work spanning `parmesan`,
-      `penne::repair`, and `penne::ui` — deferred until the status-line
-      fix plus the assembly speedup above prove insufficient on their own.
+- [x] **Investigated: parallelizing `verify()`'s slice checksums — no
+      measurable win, reverted.** Implemented and benchmarked before
+      committing: `parmesan::verify::verify_with_progress` read slices in
+      batches (bounded to 16 MiB) and hashed each batch's slices across
+      every core via `rayon::par_chunks` instead of one at a time,
+      correctness-tested including a cross-batch-offset regression test and
+      the real `par2cmdline` compat suite (all green). A/B timing on a 250
+      MiB synthetic file in `--release`, same machine, same fixture:
+      **568.6 MiB/s sequential vs. 573.6 MiB/s parallel — within noise, no
+      real improvement.** Root cause: this phase's own earlier benchmark
+      (immediately above) measured `--release` at 567 MiB/s vs. an
+      unoptimized *debug* build at 49 MiB/s and concluded verify was
+      "CPU-bound" — true for the debug build, but at `--release` speed
+      MD5+CRC32 is already fast enough that sequential file reads (even
+      page-cache-warm) dominate wall time instead, so fanning the hash step
+      out across cores has nothing to hide behind. `rayon` parallelizes
+      compute, not I/O — this workload's `--release` bottleneck turned out
+      to be the latter. Reverted rather than shipping unproven complexity
+      (batch buffering, offset math, a test-only tuned constant). If this
+      is revisited, profile the read path itself (syscall count, buffer
+      sizing) rather than the hash step.
+- [ ] A live progress readout for the verify phase (mirroring `pesto`'s
+      existing `Par2EncodeStarted`/`Par2InputProgress` events on the posting
+      side) is a separate, larger piece of work spanning `parmesan`,
+      `penne::repair`, and `penne::ui` — deferred until the status-line fix
+      plus the assembly speedup above prove insufficient on their own.
 
 ---
 


### PR DESCRIPTION
## Summary
- Implemented and A/B benchmarked `rayon`-parallel slice hashing for `parmesan::verify::verify_with_progress` before deciding whether to keep it — correctness held (new cross-batch offset test, existing suite, real `par2cmdline` compat suite, all green), but a 250 MiB `--release` A/B timing showed no real improvement (568.6 vs 573.6 MiB/s, within noise).
- Root cause: at `--release` speed MD5+CRC32 is already fast enough that sequential file reads dominate wall time, not hashing — the item's originating benchmark had compared `--release` against a debug build, not against itself.
- Reverted the implementation; this PR only records the investigation and result in both roadmap files.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p parmesan-par2 verify` (confirms the crate is back to its original, unmodified state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR4BoNpwBRRvViEhypFjsE