### PR TITLE
fix(pesto): clear feedback for the check/recovery panel, no more silent stalls

### DIFF
--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -26,6 +26,42 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
   same behavior as before; the CLI's own `season-par2` sub-upload does this,
   since PAR2 volumes have no pause UI to drive it. This is the library-side
   half of real pause/resume in `upapasta`'s TUI — see its `ROADMAP.md` Phase 46.
+- **The final automatic recovery pass (`check::recover_missing`) gets its own "recover" box and phase label in
+  the terminal panel**, instead of leaving it to look frozen. Before this, once the streaming check queue
+  drained, `CheckDone` already turned `check_active` off — so the panel had nothing to show but a static 100%
+  upload bar, an idle connection grid, and a header that fell through to a mislabeled "writing PAR2" (nothing
+  distinguished the recovery phase from that fallback branch). New `ProgressEvent::CheckRecoverStarted`/
+  `CheckRecoverProgress` events carry a real done/total count and per-article outcome for this pass, including
+  on failure — a repost or final-STAT failure inside the pass used to be completely silent (a `tracing::warn!`
+  only, invisible without `-v`).
+- **The `conns` line shows real check-pool activity, not just its configured size.** New
+  `ProgressEvent::CheckConnectionBusy`/`CheckConnectionIdle` events (only fired while a check-pool connection is
+  actually doing a STAT or repost) drive a per-connection dot row and an `X/N check` count, the same treatment
+  the upload pool's own connections already got. `CheckPoolScaledUp` also keeps that count accurate once the
+  upload's connections join in to help drain a backlog (`CheckCoordinatorHandle::scale_up`) — previously the
+  panel kept showing the smaller pool size announced at `Started` even after it grew.
+- **`ui::render::wrap()`**: word-wraps long panel status/failure text across a few lines (capped at 4, so a
+  status with no natural size limit — arbitrary hook output, a long list of empty-file names — still can't grow
+  the panel unbounded) instead of silently cutting it with `truncate()`'s single `…`. Dense one-line status
+  messages, like the PAR2 memory-budget banner (`memory: address-space limit … | reserved for overhead … |
+  PAR2 budget …/pass`), lost their back half on a normal-width terminal with no way to read the rest.
+
+### Changed
+- **The final automatic recovery pass (`check::recover_missing`) now runs concurrently**, bounded by
+  `Config::effective_check_connections()` — the same connection budget the streaming check itself uses — instead
+  of reposting-and-verifying one stubborn article at a time. A batch near `check_recover_max`'s default of 50
+  could previously take minutes strictly serially (repost + `check_delay_secs` + STAT, one article after
+  another) with the upload already sitting at 100% and every connection idle.
+
+### Fixed
+- **The panel header no longer claims "writing PAR2" during the final recovery pass.** The fallback branch that
+  shows once the upload and streaming check are both done (`!self.files.is_empty() && !self.finished`) used to
+  be the only thing left once `check_active` turned off, regardless of whether PAR2 writing was actually
+  running.
+- **A confirmed recovery now corrects the final summary's "missing"/"reposted" tallies.** `CheckDone` snapshots
+  the missing count before the recovery pass gets a chance to fix anything; a successful recovery used to leave
+  that snapshot stale, so the run summary could go on reporting an article as missing after it had actually been
+  confirmed present.
 
 ## [0.7.0] — 2026-08-11
 

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -235,6 +235,15 @@ impl CheckCoordinatorHandle {
                 check_worker(inner, base_idx + i).await;
             }));
         }
+        if additional > 0 {
+            // The panel's `conns` line otherwise keeps showing the pool
+            // size announced at `Started`, even once it's grown — right
+            // when the upload's connections join in, the moment the check
+            // pool is doing its most visible catch-up work.
+            self.inner.emit(ProgressEvent::CheckPoolScaledUp {
+                check_connections: self.workers.len(),
+            });
+        }
     }
 
     /// Close the input (no more segments will be queued) and wait for every
@@ -373,7 +382,15 @@ async fn check_worker(inner: Arc<Inner>, worker_idx: usize) {
             continue;
         };
 
+        // Busy for the duration of `process_item`'s actual network activity
+        // (STAT, and any repost it triggers) — everywhere else in this loop
+        // (draining a cancelled queue, or the 250ms poll above while every
+        // item is still inside its retry/repost delay) this connection is
+        // genuinely idle, which the old panel had no way to distinguish
+        // from "working through a backlog".
+        inner.emit(ProgressEvent::CheckConnectionBusy { conn: worker_idx });
         process_item(&inner, &mut slot, worker_idx, item).await;
+        inner.emit(ProgressEvent::CheckConnectionIdle { conn: worker_idx });
     }
 
     slot.quit().await;
@@ -673,6 +690,15 @@ async fn repost_one(
 /// after `check_delay_secs` — one round trip per article, not the full
 /// `check_retries`-attempt cycle.
 ///
+/// Runs the batch across up to `config.effective_check_connections()` worker
+/// tasks pulling from a shared queue — the same connection budget the
+/// streaming check itself uses, never more than there is work to do. This
+/// used to be a strict one-article-at-a-time loop: with `check_recover_max`
+/// defaulting to 50 and each article costing a repost round trip plus
+/// `check_delay_secs`, a stubborn batch could take minutes with the upload
+/// already at 100% and every upload connection sitting idle — the exact
+/// "why is this frozen" case the recovery pass exists to resolve *quickly*.
+///
 /// Returns the subset of `segments` that got reposted *and* confirmed
 /// present; anything not in the returned list is still genuinely missing.
 pub(crate) async fn recover_missing(
@@ -685,49 +711,100 @@ pub(crate) async fn recover_missing(
         return Vec::new();
     }
 
-    let servers: Arc<Vec<_>> = Arc::new(config.all_servers().collect());
-    // One connection per distinct server actually referenced, reused across
-    // the whole batch instead of reconnecting per article.
-    let mut slots: HashMap<usize, ConnectionSlot> = HashMap::new();
-    let mut recovered = Vec::with_capacity(segments.len());
-
-    for seg in segments {
-        let idx = seg.server_idx.min(servers.len().saturating_sub(1));
-        let slot = slots
-            .entry(idx)
-            .or_insert_with(|| ConnectionSlot::new(Arc::clone(&servers), idx));
-
-        let new_seg = match repost_one(config, slot, &seg, groups).await {
-            Ok(new_seg) => new_seg,
-            Err(e) => {
-                warn!(id = %seg.message_id, error = %e, "check: final recovery repost failed");
-                continue;
-            }
-        };
-
-        tokio::time::sleep(Duration::from_secs(config.check_delay_secs)).await;
-
-        let confirmed = match slot.ensure_connected().await {
-            Ok(conn) => conn.stat(&new_seg.message_id).await.unwrap_or(false),
-            Err(_) => false,
-        };
-
-        if confirmed {
-            if let Some(tx) = events {
-                let _ = tx.send(ProgressEvent::Status {
-                    text: format!(
-                        "check: recovered {} on final pass ({}/{})",
-                        new_seg.message_id, new_seg.part, new_seg.total
-                    ),
-                });
-            }
-            recovered.push(new_seg);
-        } else {
-            warn!(id = %new_seg.message_id, "check: recovery repost accepted but not confirmed on final STAT");
-        }
+    let total = segments.len() as u64;
+    if let Some(tx) = events {
+        let _ = tx.send(ProgressEvent::CheckRecoverStarted { total });
     }
 
-    recovered
+    let servers: Arc<Vec<_>> = Arc::new(config.all_servers().collect());
+    let n_workers = config
+        .effective_check_connections()
+        .max(1)
+        .min(segments.len());
+
+    let queue = Arc::new(Mutex::new(segments));
+    let done = Arc::new(AtomicUsize::new(0));
+    let recovered = Arc::new(Mutex::new(Vec::with_capacity(total as usize)));
+
+    let mut workers = Vec::with_capacity(n_workers);
+    for _ in 0..n_workers {
+        let config = config.clone();
+        let groups = groups.to_vec();
+        let servers = Arc::clone(&servers);
+        let queue = Arc::clone(&queue);
+        let done = Arc::clone(&done);
+        let recovered = Arc::clone(&recovered);
+        let events = events.cloned();
+
+        workers.push(tokio::spawn(async move {
+            // One connection per distinct server this worker happens to
+            // draw a segment for, reused across whatever it pulls from the
+            // shared queue instead of reconnecting per article.
+            let mut slots: HashMap<usize, ConnectionSlot> = HashMap::new();
+
+            loop {
+                let seg = queue.lock().unwrap().pop();
+                let Some(seg) = seg else { break };
+
+                let idx = seg.server_idx.min(servers.len().saturating_sub(1));
+                let slot = slots
+                    .entry(idx)
+                    .or_insert_with(|| ConnectionSlot::new(Arc::clone(&servers), idx));
+
+                let ok = match repost_one(&config, slot, &seg, &groups).await {
+                    Ok(new_seg) => {
+                        tokio::time::sleep(Duration::from_secs(config.check_delay_secs)).await;
+                        let confirmed = match slot.ensure_connected().await {
+                            Ok(conn) => conn.stat(&new_seg.message_id).await.unwrap_or(false),
+                            Err(_) => false,
+                        };
+                        if confirmed {
+                            recovered.lock().unwrap().push(new_seg);
+                            true
+                        } else {
+                            warn!(
+                                id = %new_seg.message_id,
+                                "check: recovery repost accepted but not confirmed on final STAT"
+                            );
+                            false
+                        }
+                    }
+                    Err(e) => {
+                        warn!(id = %seg.message_id, error = %e, "check: final recovery repost failed");
+                        false
+                    }
+                };
+
+                // Emits `CheckRecoverProgress` for *every* resolution,
+                // success or failure — unlike the old plain `Status` text,
+                // which only fired on success. A batch with real,
+                // unrecoverable misses used to go completely silent
+                // (nothing but a `tracing::warn!`, invisible without `-v`)
+                // for however long those repost/STAT round trips took.
+                let n = done.fetch_add(1, Ordering::Relaxed) + 1;
+                if let Some(tx) = &events {
+                    let _ = tx.send(ProgressEvent::CheckRecoverProgress {
+                        done: n as u64,
+                        total,
+                        ok,
+                    });
+                }
+            }
+
+            for (_, mut slot) in slots {
+                slot.quit().await;
+            }
+        }));
+    }
+
+    for w in workers {
+        let _ = w.await;
+    }
+
+    Arc::try_unwrap(recovered)
+        .expect("every worker task has finished by now")
+        .into_inner()
+        .unwrap()
 }
 
 #[cfg(test)]

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -1265,13 +1265,11 @@ pub async fn post_files_inner(
                     .cloned()
                     .collect()
             };
-            shared.emit(ProgressEvent::Status {
-                text: format!(
-                    "check: {} article(s) still missing after every round; \
-                     attempting one more automatic recovery pass",
-                    candidates.len()
-                ),
-            });
+            // `recover_missing` itself emits `CheckRecoverStarted`/
+            // `CheckRecoverProgress` (structured, so the renderer can show a
+            // real progress box instead of a one-shot status line — see
+            // `ui::terminal`'s "recover" box).
+            //
             // `recover_missing` returns *fresh* Message-IDs (every repost
             // gets a new one — see `repost_one`), so its output can never be
             // matched directly against `still_missing`'s old ids. Snapshot

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -160,6 +160,43 @@ pub enum ProgressEvent {
     /// its original copy exhausted its STAT attempts. `reposted` is a
     /// running count of reposts so far this run.
     CheckReposted { reposted: u64 },
+    /// The one-time final recovery pass (see `poster::check::recover_missing`)
+    /// has started, for a small stubborn tail of articles the streaming
+    /// check queue couldn't confirm after every `check_post_retries` round.
+    /// `total` is how many articles are in this batch. Unlike the streaming
+    /// check, this pass is sequential (one article at a time — repost, wait
+    /// `check_delay_secs`, STAT), so it can take a while with no other
+    /// visible activity; the renderer gives it its own phase and progress
+    /// box instead of leaving the user looking at an idle connection grid.
+    CheckRecoverStarted { total: u64 },
+    /// One article in the final recovery pass was resolved. `done` is a
+    /// running count within this batch (out of `total` from
+    /// `CheckRecoverStarted`); `ok` is true when the repost was confirmed
+    /// present, false when either the repost itself failed or the final
+    /// STAT still couldn't confirm it — both cases used to be completely
+    /// silent (a `tracing::warn!` only), fired for every resolution
+    /// (success or failure) so the run never goes quiet for the whole
+    /// batch.
+    CheckRecoverProgress { done: u64, total: u64, ok: bool },
+    /// Streaming-check worker connection `conn` (indexed within the check
+    /// pool, separate from the upload pool's own `conn` numbering) started
+    /// network activity — a STAT, or a repost after a confirmed miss.
+    /// Before this, the panel's `conns` line only ever showed the check
+    /// pool's *configured* size ("4 check"), never how many of those
+    /// connections were actually doing anything at a given moment — a
+    /// pool that looked identical whether it was working through a
+    /// backlog or sitting on 20-second STAT-retry backoffs.
+    CheckConnectionBusy { conn: usize },
+    /// The check worker named by [`CheckConnectionBusy`] went back to
+    /// waiting for its next ready item (queue empty, or every ready item
+    /// still inside its retry/repost delay).
+    CheckConnectionIdle { conn: usize },
+    /// The check pool grew past the size announced in [`Started`]'s
+    /// `check_connections` — see `CheckCoordinatorHandle::scale_up`: once
+    /// the upload's own connections go idle, they get reused to help drain
+    /// any remaining check backlog instead of sitting unused. `check_connections`
+    /// is the pool's new total size, not a delta.
+    CheckPoolScaledUp { check_connections: usize },
     /// Worker connection `conn` is authenticating with the server.
     ConnectionAuth { conn: usize },
     /// Worker connection `conn` failed an attempt and is retrying.
@@ -380,11 +417,30 @@ async fn json_emit_loop(mut rx: ProgressReceiver) {
                         let _ =
                             writeln!(out, r#"{{"type":"check_reposted","reposted":{reposted}}}"#);
                     }
+                    ProgressEvent::CheckRecoverStarted { total } => {
+                        let _ =
+                            writeln!(out, r#"{{"type":"check_recover_started","total":{total}}}"#);
+                    }
+                    ProgressEvent::CheckRecoverProgress { done, total, ok } => {
+                        let ok_str = if ok { "true" } else { "false" };
+                        let _ = writeln!(
+                            out,
+                            r#"{{"type":"check_recover_progress","done":{done},"total":{total},"ok":{ok_str}}}"#
+                        );
+                    }
+                    ProgressEvent::CheckPoolScaledUp { check_connections } => {
+                        let _ = writeln!(
+                            out,
+                            r#"{{"type":"check_pool_scaled_up","check_connections":{check_connections}}}"#
+                        );
+                    }
                     // Connection and pool events are noisy and not useful to consumers.
                     ProgressEvent::ConnectionBusy { .. }
                     | ProgressEvent::ConnectionIdle { .. }
                     | ProgressEvent::ConnectionAuth { .. }
                     | ProgressEvent::ConnectionRetrying { .. }
+                    | ProgressEvent::CheckConnectionBusy { .. }
+                    | ProgressEvent::CheckConnectionIdle { .. }
                     | ProgressEvent::BufferPoolStats { .. }
                     | ProgressEvent::Finished => {}
                 }

--- a/crates/pesto/src/ui/render.rs
+++ b/crates/pesto/src/ui/render.rs
@@ -167,6 +167,66 @@ pub fn pad(s: &str, width: usize) -> String {
     out
 }
 
+/// Word-wrap `s` into lines of at most `width` *visible* columns each,
+/// breaking on whitespace where possible. A single word wider than `width`
+/// on its own (a long path, hostname, or hex message-ID with no spaces) is
+/// hard-broken at the width boundary instead of overflowing.
+///
+/// Every returned line is guaranteed `visible_len(line) <= width`, which is
+/// what lets a caller push each one as an ordinary panel line: `ui::terminal`
+/// depends on every emitted line fitting one physical terminal row (its
+/// cursor-movement redraw counts *logical* lines), so a long, information-
+/// dense status message needs to become several such lines instead of one
+/// line silently cut short by [`truncate`].
+pub fn wrap(s: &str, width: usize) -> Vec<String> {
+    use unicode_width::UnicodeWidthChar;
+    if width == 0 {
+        return vec![String::new()];
+    }
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0usize;
+
+    for word in s.split_whitespace() {
+        let word_width = visible_len(word);
+        if word_width > width {
+            // The word alone doesn't fit even on an empty line — hard-break
+            // it across as many `width`-wide chunks as needed rather than
+            // let it overflow the row.
+            if !current.is_empty() {
+                lines.push(std::mem::take(&mut current));
+            }
+            let mut chunk_width = 0usize;
+            for c in word.chars() {
+                let w = c.width().unwrap_or(0);
+                if chunk_width + w > width && !current.is_empty() {
+                    lines.push(std::mem::take(&mut current));
+                    chunk_width = 0;
+                }
+                current.push(c);
+                chunk_width += w;
+            }
+            current_width = chunk_width;
+            continue;
+        }
+        let sep_width = if current.is_empty() { 0 } else { 1 };
+        if current_width + sep_width + word_width > width {
+            lines.push(std::mem::take(&mut current));
+            current_width = 0;
+        }
+        if !current.is_empty() {
+            current.push(' ');
+            current_width += 1;
+        }
+        current.push_str(word);
+        current_width += word_width;
+    }
+    if !current.is_empty() || lines.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
 /// Truncate `s` to at most `width` *visible* characters, marking a cut with
 /// `…`. ANSI escape sequences are preserved rather than being sliced
 /// through; if truncation cuts off before a colour's closing `\x1b[0m`, a
@@ -320,6 +380,70 @@ mod tests {
     #[test]
     fn truncate_leaves_short_lines_untouched() {
         assert_eq!(truncate("short", 80), "short");
+    }
+
+    #[test]
+    fn wrap_never_loses_content_unlike_truncate() {
+        // The actual PAR2 memory-budget status line (see `poster::mod`),
+        // which used to get cut short with `truncate` at normal terminal
+        // widths — the reader never saw anything past the "…".
+        let long = "memory: address-space limit none detected | reserved for overhead \
+                     (connections+threads+runtime) 512.0 MiB | PAR2 budget 8.0 GiB/pass \
+                     | split into 2 passes | global --memory-limit ceiling 16.0 GiB";
+        for width in [40, 60, 80, 120] {
+            let lines = wrap(long, width);
+            assert!(
+                lines.len() > 1,
+                "width={width}: a message this long should wrap onto more than one line"
+            );
+            let rejoined = lines.join(" ");
+            for word in long.split_whitespace() {
+                assert!(
+                    rejoined.contains(word),
+                    "width={width}: {word:?} lost during wrap — rejoined: {rejoined:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wrap_every_line_fits_the_requested_width() {
+        let long = "memory: address-space limit none detected | reserved for overhead \
+                     (connections+threads+runtime) 512.0 MiB | PAR2 budget 8.0 GiB/pass";
+        for width in [1, 5, 10, 20, 40, 80] {
+            for line in wrap(long, width) {
+                assert!(
+                    visible_len(&line) <= width,
+                    "width={width} produced a {}-wide line: {line:?}",
+                    visible_len(&line)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wrap_hard_breaks_a_single_word_wider_than_the_line() {
+        // A long Message-ID or path with no spaces must not overflow the
+        // row just because it has nowhere to break on whitespace.
+        let id = "18cc9fb3cbdc0862.10f2.2995b4f9c5230ed3@pesto.example.invalid";
+        for line in wrap(id, 10) {
+            assert!(visible_len(&line) <= 10, "line too wide: {line:?}");
+        }
+        assert_eq!(
+            wrap(id, 10).concat(),
+            id,
+            "hard-breaking must not drop characters"
+        );
+    }
+
+    #[test]
+    fn wrap_short_text_is_a_single_line() {
+        assert_eq!(wrap("short status", 80), vec!["short status".to_string()]);
+    }
+
+    #[test]
+    fn wrap_empty_input_is_one_empty_line() {
+        assert_eq!(wrap("", 80), vec![String::new()]);
     }
 
     #[test]

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -1,7 +1,7 @@
 use crate::progress::{ProgressEvent, ProgressReceiver, ProgressSender, RendererOptions, RunMode};
 use crate::ui::render::{
     ansi, box_bottom, box_line, box_top, format_duration, render_bar, render_sparkline,
-    terminal_width, truncate, SUBCHAR,
+    terminal_width, truncate, visible_len, wrap, SUBCHAR,
 };
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
@@ -188,8 +188,18 @@ struct RenderState {
     plain_connections_printed: bool,
     /// Number of NNTP connections dedicated to the streaming STAT check,
     /// separate from `conn_files`/`conn_state` (upload connections only).
-    /// 0 when checking is disabled.
+    /// 0 when checking is disabled. Grows past the `Started`-announced
+    /// value on `CheckPoolScaledUp` (see `check::CheckCoordinatorHandle::
+    /// scale_up`), so this is always the pool's *current* size.
     check_connections: usize,
+    /// Busy/idle state of each check-pool connection, indexed the same way
+    /// as `conn_state` but in the check pool's own numbering — a connection
+    /// is `Busy` only while actually doing a STAT or repost, `Idle`
+    /// otherwise (polling an empty queue, or every ready item still inside
+    /// its retry/repost delay). Without this the `conns` line only ever
+    /// showed the check pool's *configured* size, with no way to tell a
+    /// pool working through a backlog from one sitting on backoffs.
+    check_conn_state: Vec<ConnState>,
     /// File currently posted by each worker connection (`None` = idle).
     conn_files: Vec<Option<String>>,
     /// Per-file `(done, total)` segment counts, for the file tally.
@@ -278,6 +288,21 @@ struct RenderState {
     /// resolved article, so a fast-moving pool of concurrent check workers
     /// doesn't wipe it before the user can read it.
     check_retry: Option<(String, Instant)>,
+    // Final automatic recovery pass (`poster::check::recover_missing`) — runs
+    // strictly *after* the streaming check queue has fully drained
+    // (`check_active` is already false by the time this starts), for a
+    // small, bounded tail of articles that never got confirmed. It has its
+    // own phase/box rather than reusing the check box: it is sequential
+    // (one article at a time), so without a dedicated indicator the panel
+    // showed a 100% upload bar, an idle connection grid, and nothing else
+    // moving for however long the batch took.
+    recover_active: bool,
+    recover_done: u64,
+    recover_total: u64,
+    /// Resolutions in this batch that came back `ok: false` (repost failed,
+    /// or the final STAT still couldn't confirm it).
+    recover_failed: u64,
+    recover_start: Instant,
     // PAR2 input slice encode progress
     par2_encode_done: usize,
     par2_encode_total: usize,
@@ -309,6 +334,7 @@ impl RenderState {
             plain_failed_printed: false,
             plain_connections_printed: false,
             check_connections: 0,
+            check_conn_state: Vec::new(),
             conn_files: Vec::new(),
             files: HashMap::new(),
             lines_drawn: 0,
@@ -332,6 +358,11 @@ impl RenderState {
             check_reposted: 0,
             check_start: Instant::now(),
             check_retry: None,
+            recover_active: false,
+            recover_done: 0,
+            recover_total: 0,
+            recover_failed: 0,
+            recover_start: Instant::now(),
             par2_encode_done: 0,
             par2_encode_total: 0,
             par2_encode_start: Instant::now(),
@@ -374,6 +405,7 @@ impl RenderState {
                 self.check_connections = check_connections;
                 self.conn_files = vec![None; connections];
                 self.conn_state = vec![ConnState::Idle; connections];
+                self.check_conn_state = vec![ConnState::Idle; check_connections];
                 for f in files {
                     self.total_segments += f.segments;
                     self.total_bytes += f.bytes;
@@ -571,6 +603,50 @@ impl RenderState {
                 self.check_active = false;
                 self.check_failed = failed;
                 self.check_retry = None;
+            }
+            ProgressEvent::CheckRecoverStarted { total } => {
+                self.recover_active = true;
+                self.recover_done = 0;
+                self.recover_total = total;
+                self.recover_failed = 0;
+                self.recover_start = Instant::now();
+            }
+            ProgressEvent::CheckRecoverProgress { done, total, ok } => {
+                self.recover_done = done;
+                self.recover_total = total;
+                if ok {
+                    // This article was part of `check_failed`'s count from
+                    // `CheckDone` (that's how it ended up in this batch);
+                    // now that it's confirmed, the "missing" tally and the
+                    // final summary line must reflect that instead of
+                    // freezing on the pre-recovery number. Also counts
+                    // toward `check_reposted` — the streaming coordinator's
+                    // own counter never sees recovery-pass reposts, since
+                    // `recover_missing` runs standalone, after that
+                    // coordinator has already shut down.
+                    self.check_failed = self.check_failed.saturating_sub(1);
+                    self.check_reposted += 1;
+                } else {
+                    self.recover_failed += 1;
+                }
+                if done >= total {
+                    self.recover_active = false;
+                }
+            }
+            ProgressEvent::CheckConnectionBusy { conn } => {
+                if let Some(s) = self.check_conn_state.get_mut(conn) {
+                    *s = ConnState::Busy;
+                }
+            }
+            ProgressEvent::CheckConnectionIdle { conn } => {
+                if let Some(s) = self.check_conn_state.get_mut(conn) {
+                    *s = ConnState::Idle;
+                }
+            }
+            ProgressEvent::CheckPoolScaledUp { check_connections } => {
+                self.check_connections = check_connections;
+                self.check_conn_state
+                    .resize(check_connections, ConnState::Idle);
             }
         }
     }
@@ -819,6 +895,13 @@ impl RenderState {
 
         let eta_str = if final_draw {
             format!("done {}", format_duration(self.elapsed_secs()))
+        } else if self.recover_active {
+            // `pct` is already 100% here (it tracks upload segments, and the
+            // recovery pass only starts once every one of those is done),
+            // so without this the quiet line reads "100% · ETA —" for
+            // however long the sequential recovery batch takes — visually
+            // indistinguishable from a hang.
+            format!("recovering {}/{}", self.recover_done, self.recover_total)
         } else if let Some((secs, unstable)) = self.overall_eta_secs() {
             let mark = if unstable { "~" } else { "" };
             format!("ETA {mark}{}", format_duration(secs))
@@ -1085,6 +1168,15 @@ impl RenderState {
             ansi("posting data", "32") // green
         } else if self.check_active {
             ansi("verifying", "34") // blue — matches the check bar's band
+        } else if self.recover_active {
+            // Must come before the "writing PAR2" fallback below: once the
+            // upload and streaming check are both done, that fallback's
+            // `!self.files.is_empty() && !self.finished` condition is true
+            // for the *entire* recovery pass too (nothing else distinguishes
+            // them), so without this branch the header lied about "writing
+            // PAR2" while pesto was actually reposting stubborn misses one
+            // at a time.
+            ansi("recovering", "31") // red — a handful of articles needed reposting
         } else if self.par2_write_active || (!self.files.is_empty() && !self.finished) {
             ansi("writing PAR2", "36") // cyan
         } else if self.finished {
@@ -1263,6 +1355,43 @@ impl RenderState {
                 lines.push(box_bottom(body_w));
             }
 
+            // --- final recovery pass box ------------------------------------
+            // Only ever active once `check_active` above has already gone
+            // false (see `poster::post_files_inner`: the streaming check
+            // queue fully drains, *then* this bounded pass runs on whatever
+            // small tail is left) — the two boxes never show at the same
+            // time. Has its own bar (unlike the check box) because, unlike
+            // the streaming check, this pass has a known, fixed total up
+            // front (`CheckRecoverStarted`), so a real percentage is
+            // meaningful here.
+            if self.recover_active || (final_draw && self.recover_total > 0) {
+                let frac = if self.recover_total > 0 {
+                    (self.recover_done as f64 / self.recover_total as f64).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
+                let pct = (frac * 100.0).round() as u64;
+                let bar = render_bar(frac, bar_w);
+                let line1 = format!(
+                    "[{bar}] {pct:>3}%  {}/{} article(s)",
+                    self.recover_done, self.recover_total
+                );
+                let ok_count = self.recover_done.saturating_sub(self.recover_failed);
+                let mut line2 = ansi(&format!("{ok_count} recovered"), CHECK_BAND_COLOR);
+                if self.recover_failed > 0 {
+                    line2.push_str(&format!(
+                        " · {}",
+                        ansi(&format!("{} still missing", self.recover_failed), "31")
+                    ));
+                }
+                let elapsed = self.recover_start.elapsed().as_secs_f64().max(0.001);
+                line2.push_str(&format!(" · elapsed {}", format_duration(elapsed)));
+                lines.push(box_top("recover", body_w));
+                lines.push(box_line(&line1, body_w));
+                lines.push(box_line(&line2, body_w));
+                lines.push(box_bottom(body_w));
+            }
+
             // --- per-connection activity as a single dot row --------------
             // Was a two-per-line grid of `conn N ▸ file` cells: up to six rows
             // that, since every worker posts the *same* file, repeated one
@@ -1291,8 +1420,29 @@ impl RenderState {
                 } else {
                     String::new()
                 };
+                // Real activity, not just the configured pool size: a check
+                // pool sitting entirely on 20-second STAT-retry backoffs
+                // used to look identical to one actively working through a
+                // backlog — both just said "N check".
                 let check_str = if self.check_connections > 0 {
-                    format!(" · {} check", self.check_connections)
+                    let check_active = self
+                        .check_conn_state
+                        .iter()
+                        .filter(|&&s| s == ConnState::Busy)
+                        .count();
+                    let check_dots = if self.check_connections <= GRID_LIMIT {
+                        let mut s = String::from(" ");
+                        for st in &self.check_conn_state {
+                            s.push_str(&conn_dot(*st));
+                        }
+                        s
+                    } else {
+                        String::new()
+                    };
+                    format!(
+                        " ·{check_dots} {check_active}/{} check",
+                        self.check_connections
+                    )
                 } else {
                     String::new()
                 };
@@ -1397,8 +1547,16 @@ impl RenderState {
         }
 
         // --- optional status / interrupt / failure note -------------------
+        // Both branches below can carry information-dense free text (a
+        // long filename plus a network error message; a multi-clause status
+        // like the PAR2 memory-budget banner) that easily exceeds one
+        // terminal row. `truncate`-ing it to fit used to just cut the back
+        // half off with a bare "…" and no way to read the rest. Word-wrap
+        // it across a few lines instead — bounded by `STATUS_MAX_LINES` so
+        // a genuinely unbounded value (arbitrary hook output, a long list
+        // of file names) still can't make the panel grow without limit.
         if let Some(desc) = &self.failed_description {
-            lines.push(format!("⚠ {desc}"));
+            lines.extend(wrapped_note("⚠ ", desc, width));
         } else if self.interrupted {
             lines.push("⚠ interrupt received — finishing in-flight segments".to_string());
         } else if !self.status.is_empty() {
@@ -1407,7 +1565,8 @@ impl RenderState {
             } else {
                 String::new()
             };
-            lines.push(format!("▸ {}{}", self.status, elapsed_str));
+            let full = format!("{}{}", self.status, elapsed_str);
+            lines.extend(wrapped_note("▸ ", &full, width));
         }
 
         lines
@@ -1491,6 +1650,28 @@ impl RenderState {
             return;
         }
 
+        // Final recovery pass — see the TTY panel's "recover" box. Its own
+        // early-return branch for the same reason as `compress_active`/
+        // `par2_write_active` above: without one, this sequential,
+        // potentially multi-minute pass produced no plain-mode output at all
+        // once the streaming check's `check_active` suffix below stopped
+        // applying (`CheckDone` already fired by the time this starts).
+        if self.recover_active {
+            let ok_count = self.recover_done.saturating_sub(self.recover_failed);
+            let missing_str = if self.recover_failed > 0 {
+                format!(" · {} still missing", self.recover_failed)
+            } else {
+                String::new()
+            };
+            let _ = writeln!(
+                err,
+                "recovering: {}/{} article(s) · {ok_count} recovered{missing_str}",
+                self.recover_done, self.recover_total,
+            );
+            let _ = err.flush();
+            return;
+        }
+
         // Streaming check runs concurrently with the upload, so it's an
         // extra suffix on the normal progress line rather than a phase that
         // suppresses it.
@@ -1547,6 +1728,37 @@ impl RenderState {
         }
         let _ = err.flush();
     }
+}
+
+/// Maximum physical lines a wrapped status/failure note may occupy. Bounds
+/// the panel's height against a status text with no natural upper size (raw
+/// hook output, a long list of file names) — past this many lines the
+/// remainder is dropped with a trailing `…` on the last line rather than
+/// letting one bad status push the rest of the panel off screen.
+const STATUS_MAX_LINES: usize = 4;
+
+/// Word-wrap `text` (via [`wrap`]) into panel lines prefixed with `marker` on
+/// the first line and matching indentation on the rest, capped at
+/// [`STATUS_MAX_LINES`]. See the call site in `panel_lines` for why this
+/// exists: a `truncate`-to-one-line status used to silently cut long,
+/// information-dense messages in half with no way to read the rest.
+fn wrapped_note(marker: &str, text: &str, width: usize) -> Vec<String> {
+    let marker_w = visible_len(marker);
+    let wrap_width = width.saturating_sub(marker_w).max(1);
+    let mut lines = wrap(text, wrap_width);
+    let overflowed = lines.len() > STATUS_MAX_LINES;
+    lines.truncate(STATUS_MAX_LINES);
+    if overflowed {
+        if let Some(last) = lines.last_mut() {
+            *last = truncate(&format!("{last}…"), wrap_width);
+        }
+    }
+    let indent = " ".repeat(marker_w);
+    lines
+        .into_iter()
+        .enumerate()
+        .map(|(i, line)| format!("{}{line}", if i == 0 { marker } else { &indent }))
+        .collect()
 }
 
 /// One cell of the connection grid with colour-coded state (phase 21b).
@@ -2046,6 +2258,123 @@ mod tests {
         assert!(
             state.overall_eta_secs().is_none(),
             "a lone draining check must not synthesise an ETA"
+        );
+    }
+
+    /// Upload finished, streaming check drained with a couple of stubborn
+    /// misses, and the final recovery pass just started on that small tail —
+    /// mirrors what `poster::post_files_inner` actually does: `CheckDone`
+    /// fires (turning `check_active` off) strictly before
+    /// `check::recover_missing` (and its `CheckRecoverStarted`) ever runs.
+    fn recovery_pass_running() -> RenderState {
+        let mut state = upload_done_check_running();
+        state.apply(ProgressEvent::CheckDone { failed: 2 });
+        state.apply(ProgressEvent::CheckRecoverStarted { total: 2 });
+        state
+    }
+
+    #[test]
+    fn header_says_recovering_during_the_final_recovery_pass() {
+        let state = recovery_pass_running();
+        let header = &state.panel_lines(false, 100)[0];
+        assert!(
+            header.contains("recovering"),
+            "header should name the recovery pass: {header:?}"
+        );
+        assert!(
+            !header.contains("writing PAR2"),
+            "header must not fall through to the PAR2-write label during recovery: {header:?}"
+        );
+        assert!(
+            !header.contains("verifying"),
+            "the streaming check already finished by the time recovery starts: {header:?}"
+        );
+    }
+
+    #[test]
+    fn recover_box_replaces_the_check_box_and_tracks_progress() {
+        let mut state = recovery_pass_running();
+        let panel = state.panel_lines(false, 100);
+        assert!(
+            panel.iter().any(|l| l.contains("recover")),
+            "a recover box should be drawn while the pass is active:\n{}",
+            panel.join("\n")
+        );
+        assert!(
+            !panel.iter().any(|l| l.contains("verified")),
+            "the check box's tally line must not still be showing:\n{}",
+            panel.join("\n")
+        );
+
+        state.apply(ProgressEvent::CheckRecoverProgress {
+            done: 1,
+            total: 2,
+            ok: true,
+        });
+        let panel = state.panel_lines(false, 100);
+        let bar_line = panel
+            .iter()
+            .find(|l| l.contains("article(s)"))
+            .expect("recover progress line drawn");
+        assert!(
+            bar_line.contains("1/2 article(s)"),
+            "recover box should track done/total: {bar_line:?}"
+        );
+        let tally_line = panel
+            .iter()
+            .find(|l| l.contains("recovered"))
+            .expect("recover tally line drawn");
+        assert!(
+            tally_line.contains("1 recovered"),
+            "recover box should count confirmed reposts: {tally_line:?}"
+        );
+    }
+
+    #[test]
+    fn a_confirmed_recovery_repairs_the_missing_and_reposted_tallies() {
+        // `CheckDone` snapshots `check_failed` *before* the recovery pass
+        // gets a chance to fix anything; a successful recovery must correct
+        // that snapshot (and credit the repost), or the final summary would
+        // go on reporting an article as missing after it was actually
+        // confirmed present.
+        let mut state = recovery_pass_running();
+        assert_eq!(state.check_failed, 2);
+        assert_eq!(state.check_reposted, 0);
+
+        state.apply(ProgressEvent::CheckRecoverProgress {
+            done: 1,
+            total: 2,
+            ok: true,
+        });
+        assert_eq!(state.check_failed, 1);
+        assert_eq!(state.check_reposted, 1);
+    }
+
+    #[test]
+    fn a_failed_recovery_still_reports_progress_instead_of_going_silent() {
+        // Before this fix, a repost or final-STAT failure inside the
+        // recovery pass emitted nothing but a `tracing::warn!` (invisible
+        // without `-v`) — the batch could go silent for however long the
+        // remaining round trips took. Every resolution, success or failure,
+        // must now move `recover_done` and show up in the panel.
+        let mut state = recovery_pass_running();
+        state.apply(ProgressEvent::CheckRecoverProgress {
+            done: 1,
+            total: 2,
+            ok: false,
+        });
+        assert_eq!(state.recover_done, 1);
+        assert_eq!(state.recover_failed, 1);
+        // A failed resolution must not be mistaken for a fixed article.
+        assert_eq!(state.check_failed, 2);
+        let panel = state.panel_lines(false, 100);
+        let tally_line = panel
+            .iter()
+            .find(|l| l.contains("recovered"))
+            .expect("recover tally line drawn");
+        assert!(
+            tally_line.contains("still missing"),
+            "a failed resolution should surface in the panel, not go silent: {tally_line:?}"
         );
     }
 

--- a/crates/pesto/tests/check_recover_pass.rs
+++ b/crates/pesto/tests/check_recover_pass.rs
@@ -14,10 +14,11 @@
 //! (disabling the pass) to avoid an unrelated side effect — meaning this
 //! file is the only place the feature actually runs end to end.
 
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pesto::config::{Config, ObfuscateMode};
 use pesto::poster::post_files_with_progress;
@@ -249,4 +250,185 @@ async fn recovery_pass_disabled_leaves_the_segment_missing() {
     // Only the normal cycle ran: 1 original POST + 1 check_post_retries repost.
     assert_eq!(post_count.load(Ordering::SeqCst), 2);
     assert_eq!(stat_count.load(Ordering::SeqCst), 2);
+}
+
+/// A mock NNTP server for the multi-article recovery test below: every
+/// `POST` succeeds, and each *part's* first two `STAT` checks (across its
+/// original copy and its one `check_post_retries` repost) report the
+/// article missing — every later `STAT` for that same part succeeds,
+/// modelling the automatic recovery pass's own repost finally landing.
+///
+/// Unlike [`spawn_mock_server`]'s single global `stat_count`, failures here
+/// are tracked *per part* (keyed off the POSTed article's `Subject` header,
+/// which `poster::check::repost_one` always reconstructs identically across
+/// every repost of the same segment — see its `default_subject` call).
+/// A global counter can't express "this part's first two STATs fail" once
+/// several parts' repost-and-verify cycles are running concurrently on
+/// separate connections (the whole point of parallelising
+/// `recover_missing`): STATs for different parts would interleave and blow
+/// through a shared counter in the wrong order.
+fn spawn_mock_server_multi_article() -> (SocketAddr, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let post_count = Arc::new(AtomicUsize::new(0));
+    let stat_count = Arc::new(AtomicUsize::new(0));
+    let subject_by_id: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+    let stat_attempts_by_subject: Arc<Mutex<HashMap<String, u32>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+
+    let post_count_clone = Arc::clone(&post_count);
+    let stat_count_clone = Arc::clone(&stat_count);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            let post_count = Arc::clone(&post_count_clone);
+            let stat_count = Arc::clone(&stat_count_clone);
+            let subject_by_id = Arc::clone(&subject_by_id);
+            let stat_attempts_by_subject = Arc::clone(&stat_attempts_by_subject);
+            std::thread::spawn(move || {
+                handle_connection_multi(
+                    stream,
+                    post_count,
+                    stat_count,
+                    subject_by_id,
+                    stat_attempts_by_subject,
+                )
+            });
+        }
+    });
+
+    (addr, post_count, stat_count)
+}
+
+fn handle_connection_multi(
+    stream: TcpStream,
+    post_count: Arc<AtomicUsize>,
+    stat_count: Arc<AtomicUsize>,
+    subject_by_id: Arc<Mutex<HashMap<String, String>>>,
+    stat_attempts_by_subject: Arc<Mutex<HashMap<String, u32>>>,
+) {
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+    let mut reader = BufReader::new(stream);
+    if writer.write_all(b"200 pesto mock ready\r\n").is_err() {
+        return;
+    }
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+        let command = line.trim_end().to_string();
+
+        if command == "POST" {
+            if writer.write_all(b"340 send article\r\n").is_err() {
+                return;
+            }
+            let mut message_id = String::new();
+            let mut subject = String::new();
+            let mut raw = Vec::new();
+            loop {
+                raw.clear();
+                match reader.read_until(b'\n', &mut raw) {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+                if raw == b".\r\n" {
+                    break;
+                }
+                if let Ok(text) = std::str::from_utf8(&raw) {
+                    if let Some(v) = text.strip_prefix("Message-ID: ") {
+                        message_id = v.trim_end().to_string();
+                    } else if let Some(v) = text.strip_prefix("Subject: ") {
+                        subject = v.trim_end().to_string();
+                    }
+                }
+            }
+            if !message_id.is_empty() && !subject.is_empty() {
+                subject_by_id.lock().unwrap().insert(message_id, subject);
+            }
+            post_count.fetch_add(1, Ordering::SeqCst);
+            if writer.write_all(b"240 article received\r\n").is_err() {
+                return;
+            }
+        } else if let Some(id) = command.strip_prefix("STAT ") {
+            stat_count.fetch_add(1, Ordering::SeqCst);
+            let subject = subject_by_id.lock().unwrap().get(id).cloned();
+            let attempt = subject.map(|s| {
+                let mut attempts = stat_attempts_by_subject.lock().unwrap();
+                let n = attempts.entry(s).or_insert(0);
+                *n += 1;
+                *n
+            });
+            // First two STAT attempts for a given part (original + one
+            // check_post_retries repost) report missing; the third (the
+            // recovery pass's own repost) is confirmed present.
+            let resp: &[u8] = if attempt.is_none_or(|n| n <= 2) {
+                b"430 no such article found\r\n"
+            } else {
+                b"223 0 <id> article exists\r\n"
+            };
+            if writer.write_all(resp).is_err() {
+                return;
+            }
+        } else if command.starts_with("MODE READER") {
+            if writer.write_all(b"200 reader mode\r\n").is_err() {
+                return;
+            }
+        } else if command == "QUIT" {
+            let _ = writer.write_all(b"205 bye\r\n");
+            return;
+        } else if writer.write_all(b"500 unknown command\r\n").is_err() {
+            return;
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_recovery_pass_resolves_several_concurrent_stubborn_misses() {
+    // Regression guard for parallelising `recover_missing`: before it, a
+    // batch this size was reposted-and-verified strictly one article at a
+    // time (repost + `check_delay_secs` + STAT, serially), so a handful of
+    // stubborn misses could take minutes with the upload already sitting at
+    // 100%. `check_connections: 3` gives the recovery pass room to actually
+    // run several of these concurrently instead of only ever exercising the
+    // single-worker path the smaller test above already covers.
+    let (addr, post_count, stat_count) = spawn_mock_server_multi_article();
+
+    let dir = tempfile::tempdir().unwrap();
+    const N: usize = 6;
+    let inputs: Vec<_> = (0..N)
+        .map(|i| {
+            let path = dir.path().join(format!("movie{i}.bin"));
+            std::fs::write(&path, vec![(i + 1) as u8; 5_000]).unwrap();
+            path
+        })
+        .collect();
+
+    let mut config = test_config(addr);
+    config.check_connections = 3;
+    config.check_recover_percent = 100;
+    config.check_recover_max = N;
+
+    let expanded = expand_inputs(&inputs).unwrap();
+    let outcome = post_files_with_progress(&config, &expanded, None, None, None)
+        .await
+        .unwrap();
+
+    assert!(
+        outcome.still_missing.is_empty(),
+        "the automatic recovery pass should have resolved every stubborn miss: {:?}",
+        outcome.still_missing
+    );
+    assert!(outcome.failures.is_empty());
+    assert_eq!(outcome.segments.len(), N);
+    // Per part: 1 original POST + 1 check_post_retries repost + 1 recovery-pass repost.
+    assert_eq!(post_count.load(Ordering::SeqCst), N * 3);
+    // Per part: 2 failing STATs (original + first repost) + 1 succeeding STAT.
+    assert_eq!(stat_count.load(Ordering::SeqCst), N * 3);
 }


### PR DESCRIPTION
## Summary
The terminal panel could look frozen for minutes with no explanation whenever a handful of articles needed the automatic final recovery pass — reported from a real screenshot where the panel sat on `check: recovered <id> on final pass (62/3904) · 0:02` for a long stretch (that `(62/3904)` is the segment's position in the file, not batch progress — easy to misread as a stuck counter).

- **`recover_missing` now runs concurrently**, bounded by `effective_check_connections()` (the same budget the streaming check itself uses), instead of reposting-and-verifying one stubborn article at a time. A batch near `check_recover_max`'s default of 50 could previously take minutes strictly serially with the upload already at 100% and every connection idle.
- **New `CheckRecoverStarted`/`CheckRecoverProgress` events** drive a dedicated "recover" box with a real done/total count and per-article outcome — including failures, which used to be completely silent (only a `tracing::warn!`, invisible without `-v`).
- **New `CheckConnectionBusy`/`CheckConnectionIdle`/`CheckPoolScaledUp` events** make the `conns` line show real check-pool activity (`X/N check`, plus dots) instead of just the configured pool size, and keep that count accurate once the upload's connections join in to help drain a backlog.
- **New `ui::render::wrap()`** word-wraps long status/failure text across a few lines (capped, so nothing can grow the panel unbounded) instead of `truncate()` silently cutting it mid-sentence — the PAR2 memory-budget banner was the clearest example of a message losing its back half.
- **Fixed:** the panel header no longer claims "writing PAR2" during the recovery pass (nothing distinguished that phase from the fallback branch before); a confirmed recovery now corrects the final summary's missing/reposted tallies instead of leaving `CheckDone`'s pre-recovery snapshot stale.

`crates/pesto/CHANGELOG.md`'s `[Unreleased]` section is updated accordingly.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (whole workspace)
- [x] `cargo test --all` (whole workspace, 0 failures)
- [x] New unit tests: `ui::render::wrap` (5 cases), `ui::terminal` panel state for the recover box/header/tallies (4 cases)
- [x] New integration test `auto_recovery_pass_resolves_several_concurrent_stubborn_misses`: 6 concurrent stubborn misses recovered via the parallel path, run 5x locally with no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFEhZohKqS92Acmjaaigof