### PR TITLE
docs: record the line-length and empty-file decisions explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,6 +1322,14 @@ suite has not been run on since. The "neck-and-neck" framing that used to sit
 here matched an older `pesto` encoder and is no longer accurate on the
 i5-10400 — see the reproduction command below to check your own CPU.
 
+The numbers above use the default `--line-length 128` (Usenet convention, and
+what most indexers/tooling assume). `--line-length 256` encodes ~30% faster —
+3086 vs 2369 MiB/s AVX2 at the real article size (`bench/FINDINGS.md` §2) —
+at the cost of posting non-default-width lines. `pesto` keeps 128 as the
+default for compatibility (see `ROADMAP.new.md`'s "Deferred" section), but if
+you control both ends (private indexer, your own downstream tooling) and want
+the throughput, `--line-length 256` is there to opt in.
+
 ### PAR2 creation throughput
 
 10% recovery, ~1 000 input slices, random data files.

--- a/ROADMAP.new.md
+++ b/ROADMAP.new.md
@@ -311,7 +311,19 @@ Recorded so they are not re-litigated:
   stable release-wide `[N/M]` is exactly the correlation vector those modes exist
   to deny. On by default for `none`/`full-shared`, which already accept that
   correlation.
-- **`DEFAULT_LINE_LENGTH` stays 128.** Raising to 256 was benchmarked and rejected.
+- **`DEFAULT_LINE_LENGTH` stays 128** (issue #134). `--line-length 256` measures ~30% faster AVX2
+  encode at the real article size — 3086 vs 2369 MiB/s (`bench/FINDINGS.md` §2) — a real, non-trivial
+  win, not a rounding error. Kept at 128 anyway: some indexers/downstream tooling still assume the
+  Usenet-conventional 128-byte line, and the compatibility risk of changing the default for every
+  existing user outweighs the win. `--line-length 256` is the escape hatch for anyone who wants it
+  without that risk; see the README's "yEnc encoding throughput" section.
+- **`parmesan`'s empty-file handling matches `pesto`, not `par2cmdline`** (issue #135). A zero-byte
+  input gets a synthesized MD5-of-nothing and a full File Description packet, same as `pesto`'s
+  poster (`crates/pesto/src/poster/mod.rs`) — `par2cmdline` instead skips zero-length files entirely
+  and, on verify, flags a File Description entry it didn't write as damaged rather than absent.
+  Matching `pesto` keeps the recovery set a complete description of everything actually posted, at
+  the cost of that one cosmetic disagreement with `par2cmdline` on verify. See the `md5_empty`
+  comment in `crates/parmesan/src/main.rs`.
 - **The AVX2 yEnc encoder is not preferred over SSSE3** by the dispatcher —
   investigated and closed; SSSE3 wins on the measured hardware.
 - **yEnc SIMD escaping / multi-line encoding** (PSHUFB in-place escape insertion,

--- a/crates/parmesan/src/main.rs
+++ b/crates/parmesan/src/main.rs
@@ -355,6 +355,10 @@ async fn run_create(cli: CreateArgs) -> Result<()> {
             // a complete description of what was posted — the property `pesto`
             // needs, since the file is in the NZB either way — at the cost of
             // that one cosmetic disagreement on verify.
+            //
+            // Decision (issue #135): keep this behavior — match `pesto`, not
+            // `par2cmdline`. See `ROADMAP.new.md`'s "Deferred / intentionally
+            // not implemented" section for the recorded rationale.
             let md5_empty: [u8; 16] = Md5::digest([]).into();
             let mut worker_hashes = hashes.into_iter();
             let all_hashes: Vec<encoder::FileHashes> = input_files


### PR DESCRIPTION
## Summary
Both #134 and #135 were "decision needed" issues asking for a product call to be recorded explicitly instead of living as a vague note or an implicit code path. Both are resolved as keep-current-behavior:

- **#134 — yEnc line length.** `DEFAULT_LINE_LENGTH` stays 128. `ROADMAP.new.md`'s note used to just say "benchmarked and rejected" with no number attached; it now cites the actual figures from `bench/FINDINGS.md` §2 (3086 vs 2369 MiB/s AVX2 at the real article size, ~30% faster at `ll=256`). The README's "yEnc encoding throughput" section now also mentions `--line-length 256` as the opt-in escape hatch for anyone who controls both ends and wants the win.
- **#135 — parmesan's empty-file handling.** Keeps matching `pesto` (synthesized MD5-of-nothing + a full File Description packet for zero-byte files), not `par2cmdline` (which skips them entirely). The `md5_empty` comment in `crates/parmesan/src/main.rs` now states the decision explicitly instead of just describing the divergence, and `ROADMAP.new.md`'s "Deferred / intentionally not implemented" section gets its own recorded entry for it, alongside the line-length one.

Decision comments with the rationale are posted on both issues; they'll close automatically when this merges.

Closes #134
Closes #135

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p parmesan-par2` (comment-only change to `main.rs`)
- Docs-only otherwise (README.md, ROADMAP.new.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFEhZohKqS92Acmjaaigof