### PR TITLE
perf(parmesan): fix 47% many-small gap via per-file overhead removal

### DIFF
--- a/bench/FINDINGS.md
+++ b/bench/FINDINGS.md
@@ -231,6 +231,74 @@ no real gain" (#126). These numbers do not contradict that — verify is already
 ahead — but they do suggest **repair** deserves the same experiment, and it is
 a different code path.
 
+**Fixed in [#131](https://github.com/franzopl/pesto/issues/131).** The 47%
+`many-small` create gap above was root-caused by profiling (`perf record` +
+`strace -f -c`), not assumed, and the actual mechanism was neither of the two
+things it was easiest to suspect:
+
+- **Not the encoder's flush cache-blocking.** `RecoveryEncoder::add_slice`
+  flushes every 128 queued slices or `flush_limit_bytes` (256 MiB),
+  whichever comes first — for `many-small`'s 64 KiB slices that is the
+  128-slice branch, well short of the byte budget. Tested removing the count
+  cap entirely (byte limit only): wall time got *worse* (2.05s → 2.1–2.5s)
+  and peak RSS went up 7.7× (79 MiB → 611 MiB). The cache-blocking is
+  correctly tuned, not a bug — ruled out.
+- **Not the #137 tokio worker-pool cap.** With `#[tokio::main]`'s old
+  default (one worker per core — 12 here — instead of #137's fixed 4),
+  the same workload measured 2.2–2.46s: slightly *slower* than the current
+  2.05s baseline, not faster. #137 did not regress this path — ruled out.
+
+`perf record -g` (cycles) on `many-small` showed ~63% of *executed* cycles
+inside the RS SIMD kernel (real work) but only ~300% average CPU use out of
+a 600% ceiling (`-t 6`); `strace -f -c` on the same run showed **22,270
+`futex` calls (3.29s cumulative) and 7,578 `sched_yield`** in a 2.05s
+wall-clock run — threads parking and waking far more than they compute.
+`ops::ingest_files` processes its `for file_info in files` loop strictly one
+file at a time: each file pays a fresh `tokio::sync::mpsc::channel` plus a
+`spawn_blocking` reader task and a channel round-trip, even when the entire
+file is one syscall — with 2 000 files, that ceremony is paid 2 000 times
+regardless of size, while the rayon pool sits idle except during the rare
+flush bursts big enough to need it.
+
+**Fix** (`crates/parmesan/src/ops.rs`): files that fit in one read (≤
+`CHUNK_SIZE`, 8 MiB — the same constant the streaming reader already chunks
+by) skip the channel and task-spawn entirely and are read with a single
+`std::fs::read` inside one `block_in_place`, then fed through the same
+slice-accumulation logic (extracted into `feed_chunk`, shared verbatim with
+the unchanged streaming path so large-file behavior — and the `held`/
+`is_last_of_file` bookkeeping this module's doc comment warns about — is
+byte-for-byte identical to before). Slice order and per-file sequencing are
+untouched, so this is an I/O-strategy change only, not a reordering: PAR2's
+Reed-Solomon coefficients are positional (see `sort_files_by_file_id`'s
+doc comment), and the hasher thread still consumes slices in the same order.
+
+Official suite numbers, `./bench/run.sh par2 --workload many-small --scale
+0.25 --reps 5` (the exact repro command from #131), median of 5:
+
+| tool | before | after | vs before |
+|---|---:|---:|---:|
+| parmesan | 72.3 MiB/s | **178.3 MiB/s** | **+147%** |
+| parpar | 136.6 MiB/s | 135.6 MiB/s (noise) | — |
+
+**parmesan now beats parpar by 31% on `many-small`** (178.3 vs 135.6 MiB/s),
+a full reversal from being 47% behind. `mixed-folder` and `movie-1080p` — both
+already on the streaming (unchanged) code path — were re-measured to confirm
+no regression; the ~5–10% deltas seen there are within this machine's
+`powersave`-governor noise (see "Two caveats" at the top of this file), not a
+code-path change, since neither workload's files are small enough to take the
+new branch. All 9 checks in `bench/suites/60-correctness.sh` pass, plus the
+full `#[ignore]`d `par2cmdline_compat` cross-tool suite (byte-exact repairs
+both directions, unicode filenames, multi-file damage).
+
+This fix is in `parmesan`'s own `ops::ingest_files`, used by the standalone
+`parmesan create` CLI measured in this table. `pesto`'s poster
+(`crates/pesto/src/poster/mod.rs`) has its own separate file-ingestion loop —
+it uses `Par2Worker`/`RecoveryEncoder` directly rather than
+`ops::ingest_files`, to overlap PAR2 generation with upload — so §5's
+`many-small` end-to-end row is a *different* code path and was not measured
+as part of this fix; whether it has an analogous per-file overhead problem is
+open, not assumed fixed here.
+
 ---
 
 ## 4. Pipeline stages: where the time actually goes
@@ -545,9 +613,12 @@ report:
    [#130](https://github.com/franzopl/pesto/issues/130): 20-53% wall-clock
    gain (sub-linear, bandwidth-bound — see §3), `many-small` repair now beats
    par2cmdline instead of losing to it. Details above.
-2. **Investigate the small-file PAR2 path.** 47% behind parpar on
-   `many-small`, and it is what makes the only end-to-end row pesto loses.
-   — [#131](https://github.com/franzopl/pesto/issues/131), blocked on (5)
+2. ~~Investigate the small-file PAR2 path.~~ — done,
+   [#131](https://github.com/franzopl/pesto/issues/131): root-caused by
+   profiling to per-file task/channel overhead in `ops::ingest_files`, not
+   the encoder's flush cadence or the #137 thread tuning (both tested and
+   ruled out). `many-small` create: 72.3 → 178.3 MiB/s (+147%), now 31%
+   *ahead* of parpar instead of 47% behind. Details above.
 3. **Look at posting a single large file, and the connection-pool regression
    past 4 connections.** 0.54× nyuu at 0 ms on one big file, while being
    2.7× nyuu on many small files; the connection curve peaking then falling

--- a/crates/parmesan/src/ops.rs
+++ b/crates/parmesan/src/ops.rs
@@ -187,6 +187,41 @@ pub fn calculate_geometry(
     Ok((slice_size, total_slices, recovery_count))
 }
 
+/// Chunk size for the streaming reader below, and the cutoff under which a
+/// file is read as a single blocking call instead — see `ingest_files`.
+const CHUNK_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
+
+/// Split `chunk` into `slice_size` pieces, handing each completed-and-since-
+/// superseded slice to `worker` (holding the newest one back — see
+/// `ingest_files`'s doc comment for why). Pure and synchronous: callers doing
+/// this from async context are responsible for wrapping the call in
+/// `tokio::task::block_in_place`, since `Par2Worker::send_slice` blocks.
+fn feed_chunk(
+    chunk: &[u8],
+    worker: &Par2Worker,
+    slice_size: usize,
+    slice_accum: &mut Vec<u8>,
+    held: &mut Option<Vec<u8>>,
+) {
+    let mut chunk_pos = 0;
+    while chunk_pos < chunk.len() {
+        let space = slice_size - slice_accum.len();
+        let take = space.min(chunk.len() - chunk_pos);
+        slice_accum.extend_from_slice(&chunk[chunk_pos..chunk_pos + take]);
+        chunk_pos += take;
+
+        if slice_accum.len() >= slice_size {
+            let next = worker.take_buffer(slice_size);
+            let padded = std::mem::replace(slice_accum, next);
+            // A new full slice exists, so whatever was held is definitely
+            // not this file's last one.
+            if let Some(previous) = held.replace(padded) {
+                worker.send_slice(previous, slice_size, false);
+            }
+        }
+    }
+}
+
 /// Ingests files into a PAR2 worker.
 ///
 /// Exactly one slice per file is flagged `is_last_of_file`, and it must be the
@@ -209,57 +244,61 @@ pub async fn ingest_files(
     slice_size: usize,
 ) -> Result<()> {
     for file_info in files {
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
-        let path = file_info.path.clone();
-
-        // Double-buffered reader task: fetch data while we process previous chunks.
-        let reader_handle = tokio::task::spawn_blocking(move || {
-            use std::fs::File;
-            use std::io::Read;
-            let mut file = File::open(&path)?;
-            loop {
-                let mut buf = vec![0u8; 8 * 1024 * 1024]; // 8 MiB chunks
-                let n = file.read(&mut buf)?;
-                if n == 0 {
-                    break;
-                }
-                buf.truncate(n);
-                if tx.blocking_send(buf).is_err() {
-                    break;
-                }
-            }
-            Ok::<_, anyhow::Error>(())
-        });
-
         let mut slice_accum = worker.take_buffer(slice_size);
         slice_accum.clear();
         // The most recently filled slice, not yet handed to the worker: it
         // cannot be sent until we know whether another slice follows it.
         let mut held: Option<Vec<u8>> = None;
 
-        while let Some(chunk) = rx.recv().await {
-            let mut chunk_pos = 0;
-            while chunk_pos < chunk.len() {
-                let space = slice_size - slice_accum.len();
-                let take = space.min(chunk.len() - chunk_pos);
-                slice_accum.extend_from_slice(&chunk[chunk_pos..chunk_pos + take]);
-                chunk_pos += take;
+        // A file that fits in one chunk has nothing for the double-buffered
+        // path below to overlap — reading it is one syscall either way — so
+        // route it through a single blocking read instead of paying a
+        // spawn_blocking task and an mpsc channel for that one syscall.
+        // Skipping this matters at scale: a corpus of thousands of
+        // sub-slice files (see `bench/FINDINGS.md` §5, issue #131) pays that
+        // task-spawn/channel-handoff cost once per file regardless of size,
+        // and profiling showed it dominating wall time — most cores sitting
+        // idle between the rare flushes big enough to need them — even
+        // though the per-file work is tiny.
+        if (file_info.size as usize) <= CHUNK_SIZE {
+            let path = file_info.path.clone();
+            tokio::task::block_in_place(|| -> Result<()> {
+                let buf = std::fs::read(&path)
+                    .with_context(|| format!("reading `{}`", path.display()))?;
+                feed_chunk(&buf, worker, slice_size, &mut slice_accum, &mut held);
+                Ok(())
+            })?;
+        } else {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+            let path = file_info.path.clone();
 
-                if slice_accum.len() >= slice_size {
-                    let next = worker.take_buffer(slice_size);
-                    let padded = std::mem::replace(&mut slice_accum, next);
-                    // A new full slice exists, so whatever was held is
-                    // definitely not this file's last one.
-                    if let Some(previous) = held.replace(padded) {
-                        tokio::task::block_in_place(|| {
-                            worker.send_slice(previous, slice_size, false);
-                        });
+            // Double-buffered reader task: fetch data while we process previous chunks.
+            let reader_handle = tokio::task::spawn_blocking(move || {
+                use std::fs::File;
+                use std::io::Read;
+                let mut file = File::open(&path)?;
+                loop {
+                    let mut buf = vec![0u8; CHUNK_SIZE];
+                    let n = file.read(&mut buf)?;
+                    if n == 0 {
+                        break;
+                    }
+                    buf.truncate(n);
+                    if tx.blocking_send(buf).is_err() {
+                        break;
                     }
                 }
-            }
-        }
+                Ok::<_, anyhow::Error>(())
+            });
 
-        reader_handle.await??;
+            while let Some(chunk) = rx.recv().await {
+                tokio::task::block_in_place(|| {
+                    feed_chunk(&chunk, worker, slice_size, &mut slice_accum, &mut held);
+                });
+            }
+
+            reader_handle.await??;
+        }
 
         if !slice_accum.is_empty() {
             // A partial trailing slice: it is the last one, and anything held


### PR DESCRIPTION
## Summary

- `ops::ingest_files` spawned a fresh `tokio::sync::mpsc::channel` and a `spawn_blocking` reader task for **every** input file, even when the whole file fit in one `read()` call. The double-buffered pipeline exists to overlap *this* file's next chunk read with processing the previous one — with only one chunk, there's nothing to overlap, just ceremony.
- Files `<= CHUNK_SIZE` (8 MiB) now go through a single blocking `std::fs::read` instead, feeding the same slice-accumulation logic (extracted into `feed_chunk`, shared byte-for-byte with the unchanged streaming path for larger files). Slice order and per-file sequencing (`held`/`is_last_of_file` bookkeeping) are untouched — this is an I/O-strategy change only, not a reordering.

## Root cause (profiled, not assumed — issue #131)

`perf record -g` on the `many-small` workload (2000×64 KiB files) showed ~63% of *executed* cycles in the RS SIMD kernel (real work) but only ~300% average CPU use out of a 600% ceiling (`-t 6`). `strace -f -c` on the same run: **22,270 `futex` calls (3.29s cumulative) and 7,578 `sched_yield`** in a 2.05s wall-clock run — threads parking/waking far more than computing.

Two more obvious suspects were tested and ruled out before landing on this:
- **Encoder flush cache-blocking** (`add_slice`'s 128-slice cap): removing it entirely made things *worse* (2.05s → 2.1–2.5s wall, 79 MiB → 611 MiB peak RSS). Correctly tuned, not the bug.
- **#137's tokio worker-pool cap** (4 workers instead of `nproc`): the pre-#137 binary (12 workers) measured *slower* (2.2–2.46s) on the identical workload. Not a regression from that fix.

## Results

Official suite numbers, `./bench/run.sh par2 --workload many-small --scale 0.25 --reps 5` (the exact repro command from #131), median of 5:

| tool | before | after | vs before |
|---|---:|---:|---:|
| parmesan | 72.3 MiB/s | **178.3 MiB/s** | **+147%** |
| parpar | 136.6 MiB/s | 135.6 MiB/s (noise) | — |

**parmesan now beats parpar by 31% on `many-small`**, a full reversal from being 47% behind.

`mixed-folder` and `movie-1080p` (both already on the unchanged streaming code path — their files are all > 8 MiB) were re-measured to confirm no regression; the small deltas seen there are within this machine's `powersave`-governor noise, not a code-path change. Full writeup, including the disproven hypotheses, in `bench/FINDINGS.md` §3.

**Scope note:** this fixes `parmesan`'s own `ops::ingest_files`, used by the standalone `parmesan create` CLI. `pesto`'s poster (`crates/pesto/src/poster/mod.rs`) has its own separate ingest loop (`Par2Worker`/`RecoveryEncoder` used directly, to overlap PAR2 generation with upload) — not touched here, and whether it has an analogous per-file overhead problem is open, not assumed fixed.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` (workspace) — clean
- [x] `cargo test --workspace` — all green, 0 failures (including `exact_multiple_slice_size.rs`'s slice-boundary edge cases)
- [x] `bench/suites/60-correctness.sh` — all 9 cross-tool checks pass
- [x] `par2cmdline_compat.rs --ignored` (full cross-tool suite: byte-exact repairs both directions, unicode filenames, multi-file damage) — all pass
- [x] Official bench run confirming the fix and no regression on larger-file workloads (numbers above)

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFEhZohKqS92Acmjaaigof