### PR TITLE
chore(release): bump pesto 0.8.0, parmesan-par2 0.5.0, penne 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "parmesan-par2"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1599,7 +1599,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "penne"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1623,7 +1623,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/crates/parmesan/CHANGELOG.md
+++ b/crates/parmesan/CHANGELOG.md
@@ -7,7 +7,49 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-18
+
+### Added
+- **`RecoveryDecoder::reconstruct` now parallelises across missing slices with `rayon`**, the same pattern
+  `RecoveryEncoder` already used for creation. Sub-linear but real: `mac()` over a slice is bandwidth-bound, so
+  threads contending for memory bandwidth don't scale linearly, but wall-clock repair still improved 20% on a
+  large single file and 53% on many small files in the reference benchmark — `many-small` repair now beats
+  `par2cmdline` instead of losing to it. Every reconstructed slice is still re-verified against its checksum
+  before writing, so a correctness bug here would have surfaced as a hard failure, not a silently wrong number.
+- **`ops::ingest_files` skips the per-file channel/task-spawn round-trip for files that fit in one read.** Every
+  file previously paid a fresh `tokio::sync::mpsc::channel` plus a `spawn_blocking` reader task and a channel
+  round-trip regardless of size — with thousands of small files, that ceremony dominated wall time (profiling
+  showed threads parking and waking far more than they computed). Files at or under the existing streaming
+  chunk size (8 MiB) now read in one `std::fs::read` inside a single `block_in_place` instead. `many-small`
+  create: 72.3 → 178.3 MiB/s (+147%), reversing a 47%-behind-parpar result into 31% ahead of it. Large-file
+  behavior is unchanged (still the streaming path) and byte-for-byte identical output either way.
+- **`RecoverySet::load_metadata`** indexes recovery blocks on disk as `(path, offset, len)` without reading their
+  bodies into memory, and **`load_recovery_blocks(max_blocks)`** loads only what repair actually needs — the
+  existing eager `load` (metadata + every block's body) is unchanged and still the right call when a caller
+  genuinely wants everything. `verify`, `health`, and deobfuscation only ever needed the file list, not gigabytes
+  of recovery data resident just to answer "does a recovery set exist"; `repair` now loads only
+  `total_bad_slices()` blocks instead of the whole set regardless of how much damage was actually found.
+- **`encoder::altmap_kernel_available()` / `encoder::shuffle2x_kernel_available()`** — whether this CPU has the
+  kernel behind each specialized buffer layout, i.e. whether `new_altmap`/`new_shuffle2x` will keep the layout
+  or fall back to the portable one. Only the encoder knows the exact condition (ALTMAP needs AVX2 *without*
+  GFNI; Shuffle2x runs on GFNI hardware too), and callers that want to *measure* a specific kernel need to know
+  before they time it.
+
 ### Fixed
+- **`parmesan create` could exhaust virtual address space on high-core machines independent of
+  `--memory-limit`**, panicking well inside the configured budget on hosts with a restrictive `RLIMIT_AS`
+  (`ulimit -v`, a real shared-host/HPC/container pattern). Not the recovery buffer itself — `ingest_files`
+  already streams input in chunks and only allocates the current pass's recovery buffer — but thread fan-out
+  that ran before either of those: `#[tokio::main]`'s default one-worker-thread-per-core runtime, combined with
+  glibc's up-to-`8×ncores` per-thread malloc arenas (each reserving tens of MiB of address space, counted in
+  full against `RLIMIT_AS`, never returned). Fixed by capping the tokio runtime to a fixed worker-thread count
+  and calling `mallopt(M_ARENA_MAX, 2)` before any thread exists (matching the value `pesto` itself already
+  uses for the same reason); the CPU-bound rayon pool is deliberately left sized to physical cores, since it's
+  the only one of the two doing real throughput-sensitive work. An 11× `VmPeak` reduction on a 12-core dev box;
+  reproduced and confirmed fixed on the original 128-core/`RLIMIT_AS` box the crash was reported on.
+- **A malformed or adversarial season PAR2 input could overflow the GF(2^16) exponent space instead of failing
+  with an actionable error.** Added an explicit bounds check on the slice index against the calculated
+  `total_slices`, with a message carrying the actual vs. expected counts, instead of an out-of-bounds panic.
 - **`RecoveryEncoder` could silently return all-zero recovery blocks.** Three code paths reacted to a
   buffer layout whose SIMD kernel was unavailable by draining the queued input slices *without processing
   them* and carrying on, so `finish()` handed back parity that no PAR2 client can repair with — no error,
@@ -29,13 +71,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SimdPath` for Normal-layout buffers, falling through to auto-detection otherwise (the same behaviour an
   unavailable path already had). The three silent-drain arms are now hard failures carrying the invariant
   they broke, so a future regression cannot go quiet again.
+- **A malformed IFSC packet whose slice count didn't match the file's actual length was accepted anyway.**
+  Length/slice-count agreement is now checked at load time; `verify` flags trailing junk data past a file's
+  recorded length instead of silently ignoring it; repair `set_len`s a reconstructed file to its recorded length
+  rather than leaving it however long the last written slice happened to make it; and slice byte-writes now
+  saturate instead of panicking on a length that doesn't divide evenly.
 
-### Added
-- **`encoder::altmap_kernel_available()` / `encoder::shuffle2x_kernel_available()`** — whether this CPU has the
-  kernel behind each specialized buffer layout, i.e. whether `new_altmap`/`new_shuffle2x` will keep the layout
-  or fall back to the portable one. Only the encoder knows the exact condition (ALTMAP needs AVX2 *without*
-  GFNI; Shuffle2x runs on GFNI hardware too), and callers that want to *measure* a specific kernel need to know
-  before they time it.
+### Security
+- **A PAR2 File Description name could escape the intended destination directory.** `RecoverySet::load` (and
+  `load_metadata`) parses file names out of PAR2 packets — data that, by construction, comes from whatever wrote
+  the `.par2` file, not from this process. A name containing `..`, an absolute path, or a drive prefix was
+  joined onto the destination directory unchanged, and nothing stopped the join from landing outside it. Names
+  are now sanitized on load, and the join itself goes through a new `contained_path(base, name)` that
+  hard-fails if the result isn't actually under `base` — belt-and-braces in case a future caller skips
+  sanitization. `pesto`'s `--check` repost path and `penne`'s deobfuscation both read PAR2 file names through
+  this same function, so the fix covers every consumer, not just `parmesan`'s own CLI.
 
 ### Changed
 - `new_altmap_produces_correct_recovery_data` no longer skips GFNI hardware — that skip was hiding the bug

--- a/crates/parmesan/Cargo.toml
+++ b/crates/parmesan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parmesan-par2"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Fast, standalone PAR2 (Reed-Solomon) creation, verification and repair tool"

--- a/crates/penne/CHANGELOG.md
+++ b/crates/penne/CHANGELOG.md
@@ -7,8 +7,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-18
+
 ### Added
 
+- **`penne repair` loads only the recovery blocks it actually needs**, via `parmesan`'s new
+  `RecoverySet::load_metadata` + `load_recovery_blocks(Some(total_bad_slices))` instead of `load`'s old
+  eager everything-into-memory behavior — `health` and deobfuscation, which only ever needed the file list,
+  get the same metadata-only treatment. Lower peak memory on a repair of a large release with only a small
+  amount of actual damage.
 - **`penne download` exit codes distinguishing fully complete, complete
   after repair, and incomplete.** Previously any `Result<()>` `Ok` exited 0
   regardless of whether PAR2 had to repair something, or whether data was
@@ -35,6 +42,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   destination, unchanged from before this flag accepted more than one
   path. The overall exit code is the worst of any individual release's own
   code.
+
+### Security
+
+- **A PAR2 file name from a downloaded `.par2` could escape the download destination directory during
+  deobfuscation.** `deobfuscate.rs` joined a PAR2 File Description's `name` field — untrusted data, sourced
+  from whatever NZB/indexer/uploader produced the release being downloaded, exactly the kind of external
+  input `penne` handles by design — straight onto `dest_dir`; a `..`, an absolute path, or a drive prefix in
+  that name reached the filesystem unchecked. Now routed through `parmesan`'s sanitization plus its
+  `contained_path` check (see `parmesan`'s own `0.5.0` changelog entry), which hard-fails a name that would
+  land outside `dest_dir` instead of writing there. This is the consumer where the fix matters most: `penne`
+  processes PAR2 content it never generated, from releases posted by parties it has no reason to trust.
 
 ## [0.4.1] — 2026-08-12
 

--- a/crates/penne/Cargo.toml
+++ b/crates/penne/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penne"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast NZB downloader: fetches articles over NNTP, reassembles files, verifies and repairs with PAR2."
@@ -20,7 +20,7 @@ name = "penne"
 path = "src/bin/penne.rs"
 
 [dependencies]
-pesto = { package = "pesto-poster", path = "../pesto", version = "0.7.0" }
+pesto = { package = "pesto-poster", path = "../pesto", version = "0.8.0" }
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,7 +12,28 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-08-18
+
 ### Added
+- **Real pause/resume in the poster.** New public `post_pausable` (alongside `post`/`post_cancelable`) takes an
+  `external_pause: Arc<AtomicBool>`; setting it suspends every posting worker at the next segment-batch boundary
+  — connections stay open and are kept alive via the same `MODE READER` keepalive already used for idle time —
+  and clearing it resumes immediately with no reconnect. A producer racing ahead while paused naturally blocks
+  on the bounded article channel, so pause propagates to the encode side for free. New
+  `ProgressEvent::Paused`/`Resumed`. This is the library-side mechanism `upapasta`'s TUI needs for its pause key;
+  `upapasta` had removed its own pause UI specifically because this didn't exist yet (a "paused" state that only
+  froze the stats display while the upload kept running underneath was judged dishonest).
+- **`upload::run_upload` takes a new `pause: Option<Arc<AtomicBool>>` parameter**,
+  threaded straight through to `poster::post_files_inner`'s `external_pause` above. Existing callers pass `None`
+  for the same behavior as before; the CLI's own `season-par2` sub-upload does this, since PAR2 volumes have no
+  pause UI to drive it.
+- **Connections are reused across `--each`/`--season` episodes instead of reconnecting for every one.** New
+  `nntp::pool::ConnectionBroker`: a long-lived set of connections checked out per episode and checked back in
+  (instead of `QUIT`) when a worker finishes, kept alive between episodes by the same keepalive mechanism workers
+  already use within a run. `--jobs N` shares one broker across its concurrent episodes via a semaphore, which
+  also fixes those episodes independently over-opening up to `N × --connections` real sockets — usage is now
+  capped at the configured budget. `--watch` and the single-file path are unaffected (no broker, exact prior
+  behavior) and are a candidate for the same win as a follow-up.
 - **`--tvdb-id`/`--tvdb` accepts a media kind: `movie/<id>` or `series/<id>`** (`tv/<id>` accepted as an alias
   for `series/<id>`; `:` also accepted as the separator, matching `--tmdb`'s convention). TheTVDB catalogs both
   movies and series, but the `.nfo` dereferrer link needs the right URL segment
@@ -20,12 +41,6 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
   ID produced a broken link. A bare numeric ID (e.g. `81189`) is still accepted and defaults to `series`, so
   existing configs and scripts keep working unchanged. When `--nzb-category` and `--tmdb` are both unset, the
   category now also defaults to `movies`/`tv` from `--tvdb-id`'s kind, same as `--tmdb` already does.
-- **`upload::run_upload` takes a new `pause: Option<Arc<AtomicBool>>` parameter**,
-  threaded straight through to `poster::post_files_inner`'s `external_pause`
-  (added in `0.7.0`'s `post_pausable`). Existing callers pass `None` for the
-  same behavior as before; the CLI's own `season-par2` sub-upload does this,
-  since PAR2 volumes have no pause UI to drive it. This is the library-side
-  half of real pause/resume in `upapasta`'s TUI — see its `ROADMAP.md` Phase 46.
 - **The final automatic recovery pass (`check::recover_missing`) gets its own "recover" box and phase label in
   the terminal panel**, instead of leaving it to look frozen. Before this, once the streaming check queue
   drained, `CheckDone` already turned `check_active` off — so the panel had nothing to show but a static 100%
@@ -54,14 +69,56 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
   another) with the upload already sitting at 100% and every connection idle.
 
 ### Fixed
-- **The panel header no longer claims "writing PAR2" during the final recovery pass.** The fallback branch that
-  shows once the upload and streaming check are both done (`!self.files.is_empty() && !self.finished`) used to
-  be the only thing left once `check_active` turned off, regardless of whether PAR2 writing was actually
-  running.
-- **A confirmed recovery now corrects the final summary's "missing"/"reposted" tallies.** `CheckDone` snapshots
-  the missing count before the recovery pass gets a chance to fix anything; a successful recovery used to leave
-  that snapshot stale, so the run summary could go on reporting an article as missing after it had actually been
-  confirmed present.
+- **Connection-pool contention capped single-file posting throughput at ~0.5× nyuu, and regressed instead of
+  scaling past 4 connections.** Every posting worker dequeued from one shared `mpsc::Receiver<PostTask>` behind
+  a single `tokio::sync::Mutex`; at low latency, where a ~768 KB article encodes and posts in sub-millisecond
+  time, dequeues happen thousands of times per second — frequent enough for that one lock to become the
+  bottleneck once connection count passed ~4 (`perf stat` confirmed the mechanism directly: total instructions
+  executed stayed flat across every connection count tested, while measured CPU parallelism fell as more workers
+  were added, the signature of coordination overhead rather than a capacity limit). Fixed by giving each worker
+  its own channel with round-robin dispatch instead, so no lock sits on the dequeue hot path. `movie-1080p`
+  posting-only throughput: 618 → 1236.7 MiB/s (+100%), now ahead of nyuu instead of behind it; the
+  connection-scaling curve no longer regresses. See `bench/FINDINGS.md` §5/§6 for full before/after tables.
+  (issue #129)
+- **A connect that got a TCP accept but stalled inside the TLS handshake hung forever, at ~0% CPU.**
+  `Connection::connect` ran the TCP connect and TLS handshake before `read_timeout` was ever set on the
+  connection, so neither was actually bounded by it — a peer that accepted the socket but never completed (or
+  never continued) the handshake left the connecting task parked indefinitely, with the socket sitting
+  `ESTABLISHED` the whole time. `read_timeout` only ever protected operations after this point. Observed in
+  practice against a real provider that drops a sustained connection mid-batch and then stalls the automatic
+  reconnect's handshake. (issue #108)
+- **Season PAR2 generation could overflow the GF(2^16) exponent space instead of failing with an actionable
+  error.** Unifying season and per-file PAR2 geometry onto one shared `par2_geometry_from_sizes` dropped the
+  season path's old silent `.min(65535)` clamp on `recovery_count` without carrying over the
+  `total_slices`/`recovery_count` spec-limit checks the per-file path already enforced, so an oversized season
+  could exceed the PAR2 spec's block-count limits silently rather than `bail!`ing.
+- **A resumed run could reuse a Message-ID recorded under posting parameters that had since changed.**
+  `RunFingerprint` (the record `--resume` compares the current run's settings against before trusting saved
+  segments) didn't track `--par2-slice-size`/`--par2-slice-count`/`--par2-recovery-count`,
+  `--compress-volume-size`, the compression password, or `--line-length` — a resume across a change to any of
+  those looked identical to the fingerprint and was trusted anyway, even though the recorded segments no longer
+  describe what the new run would actually post. All now included (the compression password is hashed with
+  SHA-256, never stored in the plaintext state file).
+- **A corrupt or partially-written resume state file could abort the run instead of starting fresh.** `load` now
+  treats a file that exists but fails to parse the same as a missing one (empty state, fresh start) rather than
+  a hard error; `save` writes to a temp file and renames it into place, so a crash mid-write can no longer leave
+  a half-written state file behind for the next run to trip over.
+- **NEON's `encoded_size` underflowed on an empty input**, an edge case the x86 SIMD backends' differential
+  tests already covered but the NEON path didn't have an equivalent test for. Fixed alongside a new
+  `test-aarch64` CI job so an aarch64-only regression like this doesn't require an ARM box to catch again.
+
+### Security
+- **PAR2 File Description names are sanitized before touching the filesystem.** A name from a PAR2 index or
+  volume — data that, for `--check`'s repost path and for any tool reading back a posted release, originates
+  outside this process — could previously contain `..`, an absolute path, or a drive prefix and escape the
+  intended destination directory when joined onto it. Every read now goes through sanitization plus a
+  belt-and-braces `contained_path` check (`parmesan::recovery_set`) that rejects a joined path landing outside
+  its base, hard-failing instead of writing outside the intended directory.
+- **Header and subject injection from untrusted file names closed.** C0 control characters are now stripped from
+  input file names at the point they're read from disk; NNTP header values have CR/LF neutralized before being
+  written to the wire (a file or NZB name containing a literal newline could previously inject extra header
+  lines); `nzb::escape` drops XML-illegal control characters instead of passing them through; and a literal `"`
+  in a subject is replaced with `'` so it can't break the `"{name}" yEnc (n/m)` format indexers parse it with.
 
 ## [0.7.0] — 2026-08-11
 

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pesto-poster"
 # pesto is versioned, published, and released independently of the rest of
 # the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."
@@ -22,7 +22,7 @@ name = "pesto"
 path = "src/bin/pesto.rs"
 
 [dependencies]
-parmesan = { package = "parmesan-par2", version = "0.4.1", path = "../parmesan", default-features = false }
+parmesan = { package = "parmesan-par2", version = "0.5.0", path = "../parmesan", default-features = false }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 md-5 = "0.10"

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -187,11 +187,11 @@ pub enum ProgressEvent {
     /// pool that looked identical whether it was working through a
     /// backlog or sitting on 20-second STAT-retry backoffs.
     CheckConnectionBusy { conn: usize },
-    /// The check worker named by [`CheckConnectionBusy`] went back to
+    /// The check worker named by [`Self::CheckConnectionBusy`] went back to
     /// waiting for its next ready item (queue empty, or every ready item
     /// still inside its retry/repost delay).
     CheckConnectionIdle { conn: usize },
-    /// The check pool grew past the size announced in [`Started`]'s
+    /// The check pool grew past the size announced in [`Self::Started`]'s
     /// `check_connections` — see `CheckCoordinatorHandle::scale_up`: once
     /// the upload's own connections go idle, they get reused to help drain
     /// any remaining check backlog instead of sitting unused. `check_connections`


### PR DESCRIPTION
## Summary

Prep-only — does **not** tag or publish. `CHANGELOG.md`'s `[Unreleased]` section in each of the three released crates was missing entries for commits landed since their last tag; this fills them in and bumps versions accordingly.

- **pesto 0.7.0 → 0.8.0**: new public API (`post_pausable` real pause/resume, `ConnectionBroker` connection reuse across `--each`/`--season`), a stricter resume-fingerprint validation, and correctness/security fixes — including #129 (connection-pool contention, just merged) and #108 (unbounded TLS-handshake hang).
- **parmesan-par2 0.4.1 → 0.5.0**: #130 (parallel repair) and #131 (many-small ingestion) perf wins already documented in `bench/FINDINGS.md`, #137's `RLIMIT_AS` crash fix, a slice-index bounds-check panic fix, and a path-traversal fix in `RecoverySet`'s PAR2 file-name handling.
- **penne 0.4.1 → 0.5.0**: consumes the same path-traversal fix on its deobfuscation path (the highest-risk consumer — it processes PAR2 content from untrusted external releases), plus lazy recovery-block loading that lowers repair's peak memory.

Version bump follows each crate's own established convention (0.x.0 for a batch of substantial fixes/features, 0.x.y reserved for single-item patches — see prior `CHANGELOG.md` entries).

## Also included

- Updated the `pesto-poster`/`parmesan-par2` version pins in dependent workspace `Cargo.toml` files (`penne` → pesto 0.8.0, `pesto` → parmesan-par2 0.5.0) — required for the workspace to resolve at all once these bump.
- Fixed two pre-existing broken rustdoc intra-doc links in `crates/pesto/src/progress.rs` that were failing pesto's own `RELEASING.md` checklist step (`cargo doc --no-deps -p pesto-poster` must produce zero warnings).
- `sugo` and `upapasta` are unreleased (no tags, no release workflow) and untouched here.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all crates, 0 failures)
- [x] `cargo doc --no-deps -p pesto-poster` — zero warnings
- [ ] Not run: `cargo publish --dry-run` for any of the three — deliberately left for the actual release step, not this prep PR

https://claude.ai/code/session_01EFEhZohKqS92Acmjaaigof