### PR TITLE
fix(pesto): panic-free UTF-8 truncation in NFO directory trees

### DIFF
--- a/crates/pesto/src/nfo.rs
+++ b/crates/pesto/src/nfo.rs
@@ -17,6 +17,17 @@ const VIDEO_EXTENSIONS: &[&str] = &[
 
 const MAX_FILENAME_LEN: usize = 42;
 
+/// Truncate `name` to at most `max_bytes` UTF-8 bytes, then append `...`.
+///
+/// Must never slice inside a multi-byte character (e.g. `é` is 2 bytes).
+fn truncate_filename(name: &str, max_bytes: usize) -> String {
+    if name.len() <= max_bytes {
+        return name.to_string();
+    }
+    let end = name.floor_char_boundary(max_bytes);
+    format!("{}...", &name[..end])
+}
+
 /// Generate NFO content for `paths` (the original input paths before any compression).
 ///
 /// Runs `mediainfo` when a media file can be identified; for generic directories
@@ -1425,11 +1436,7 @@ fn walk_tree(
             walk_tree(path, &new_prefix, nfo_name, file_sizes, state);
         } else {
             state.file_count += 1;
-            let display_name = if item_name.len() > MAX_FILENAME_LEN {
-                format!("{}...", &item_name[..MAX_FILENAME_LEN])
-            } else {
-                item_name.clone()
-            };
+            let display_name = truncate_filename(&item_name, MAX_FILENAME_LEN);
             let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
             let size = file_sizes.get(&canonical).copied().unwrap_or(0);
             let size_str = format_size(size);
@@ -1573,6 +1580,36 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    // ── truncate_filename ────────────────────────────────────────────────────
+
+    #[test]
+    fn truncate_filename_keeps_short_names() {
+        assert_eq!(
+            truncate_filename("short.mp4", MAX_FILENAME_LEN),
+            "short.mp4"
+        );
+    }
+
+    #[test]
+    fn truncate_filename_ascii_over_limit() {
+        let name = "a".repeat(MAX_FILENAME_LEN + 5);
+        let out = truncate_filename(&name, MAX_FILENAME_LEN);
+        assert_eq!(out, format!("{}...", "a".repeat(MAX_FILENAME_LEN)));
+    }
+
+    #[test]
+    fn truncate_filename_does_not_split_multibyte_at_limit() {
+        // Regression: pesto-rt panicked at nfo.rs walk_tree when a filename
+        // ended a 42-byte window inside `é` (bytes 41..43).
+        let prefix = "a".repeat(41);
+        let name = format!("{prefix}é-rest-of-a-very-long-filename.mp4");
+        assert!(!name.is_char_boundary(MAX_FILENAME_LEN));
+        let out = truncate_filename(&name, MAX_FILENAME_LEN);
+        assert!(out.ends_with("..."));
+        assert!(out.is_char_boundary(out.len()));
+        assert_eq!(out, format!("{prefix}..."));
+    }
 
     // ── is_series_folder ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

After a successful 37 GiB post, `pesto` 0.8.0 aborted while writing the `.nfo`:

```
wrote nzb: /home/batata/nzb/EstrategiaMED.Resumos.-.Cirurgia-CL.nzb
generating nfo...

thread 'pesto-rt' panicked at crates/pesto/src/nfo.rs:1429:44:
end byte index 42 is not a char boundary; it is inside 'é' (bytes 41..43 of string)
Aborted
```

The upload itself finished (`57702/57702` segments verified, NZB written). Release builds use `panic = "abort"`, so the NFO panic killed the process anyway.

### What went wrong

For generic folders (courses, documents, etc.) `nfo::walk_tree` pretty-prints a file tree and shortens long names to 42 bytes:

```rust
format!("{}...", &item_name[..MAX_FILENAME_LEN])  // MAX_FILENAME_LEN = 42
```

Rust `&str` indexes are **UTF-8 byte offsets**, not characters. Accented Portuguese names (`Cirúrgico`, `hemorrágico`, `Pediátrico`, …) contain `é` (U+00E9, two bytes `0xC3 0xA9`). When that pair straddled the 42-byte cut — start at byte 41 — the slice was illegal and `pesto-rt` panicked.

ASCII-only trees never hit this. The seedbox job did, because almost every lesson title is Portuguese.

### Fix

`truncate_filename` now walks back to `floor_char_boundary(max_bytes)` before slicing, then appends `...`. Short names are unchanged.

A regression test reconstructs the panic: 41 ASCII bytes + `é` + the rest of a long name, asserts that index 42 is **not** a char boundary, and checks the result is `{41 × 'a'}...` with no panic.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p pesto-poster --all-targets -- -D warnings`
- [x] `cargo test -p pesto-poster --lib nfo::` (36 passed, including the three new truncate tests)
- [ ] After merge, rebuild/deploy pesto on the seedbox. The existing NZB is valid; only the `.nfo` was missing. Re-run NFO generation or a post of a Portuguese-named tree to confirm no abort.