### PR TITLE
perf(poster): use parmesan PAR2 geometry so many-small beats parpar

### DIFF
--- a/bench/FINDINGS.md
+++ b/bench/FINDINGS.md
@@ -291,13 +291,10 @@ full `#[ignore]`d `par2cmdline_compat` cross-tool suite (byte-exact repairs
 both directions, unicode filenames, multi-file damage).
 
 This fix is in `parmesan`'s own `ops::ingest_files`, used by the standalone
-`parmesan create` CLI measured in this table. `pesto`'s poster
-(`crates/pesto/src/poster/mod.rs`) has its own separate file-ingestion loop —
-it uses `Par2Worker`/`RecoveryEncoder` directly rather than
-`ops::ingest_files`, to overlap PAR2 generation with upload — so §5's
-`many-small` end-to-end row is a *different* code path and was not measured
-as part of this fix; whether it has an analogous per-file overhead problem is
-open, not assumed fixed here.
+`parmesan create` CLI measured in this table. `pesto`'s `--par2-only` /
+`--par2-before-upload` pre-pass and season-pack path now call
+`ops::ingest_files_with` as well (#154). The overlapping post+PAR2 producer
+still feeds `Par2Worker` from the article read so the disk is scanned once.
 
 **Measured in [#128](https://github.com/franzopl/pesto/issues/128): GFNI is
 real, but it does not close the gap to `parpar` — on large files it widens.**
@@ -862,15 +859,27 @@ buys back more than the encoder loses.
 4.4s) — its two-phase pipeline with its own PAR2 implementation, not a close
 comparison of the same work.
 
-**`many-small` inverts everything.** parpar+nyuu finishes in 1.73s against
-pesto's 9.38s. This is §3's small-file weakness, amplified: PAR2 dominates the
-whole upload when there are 2 000 sub-slice files, and parmesan is half
-parpar's speed there. Fix the small-file PAR2 path and this row moves with it.
+**`many-small` used to invert everything** — parpar+nyuu 1.73s vs pesto 9.38s
+on the older scale-0.25-shaped table below. The cause was not the RS kernel
+(#131 already put `parmesan create` ahead of parpar). The poster picked
+`slice_size` by grouping *yEnc articles* as if they could be merged across
+files, so 2000 × 256 KiB files still made 2000 slices but each slice was
+1.5–3 MiB of padding. Fixed in [#154](https://github.com/franzopl/pesto/issues/154)
+by delegating auto geometry to `parmesan::ops::calculate_geometry`. Re-measured
+on the same machine, `--scale 1.0 --reps 3 --latencies 0` (`20260818T181051Z`):
 
-**Streaming is not always a win.** On `many-small` at 0 ms it is 5.7% *slower*
-than two-phase — the only such row. When PAR2 is the bottleneck and the network
-is free, overlapping buys nothing and costs coordination. At 30 ms the same
-workload flips to streaming being 27% faster.
+| case | pesto before | pesto after | parpar+nyuu |
+|---|---:|---:|---:|
+| streaming | 56 MiB/s, 726 MiB | **209 MiB/s**, 198 MiB | — |
+| two-phase | 55 MiB/s, 710 MiB | **191 MiB/s**, 176 MiB | 166 MiB/s, 168 MiB |
+
+pesto now leads parpar+nyuu on the like-for-like two-phase row (+15%) and on
+the streaming row (+26%). RSS is in the same band as parpar (~170–200 MiB)
+instead of 700+. `slice_size` on that run is 262144.
+
+**Streaming is a small win again on `many-small` at 0 ms** after #154
+(2.39s vs 2.62s two-phase). The earlier “streaming 5.7% slower” result was
+measuring a 12×-padded encoder, not the overlap itself.
 
 Article counts differ between pesto (4 418) and parpar+nyuu (4 049) on the
 full-release rows. That is expected — implementations split recovery data into

--- a/bench/lib/core.sh
+++ b/bench/lib/core.sh
@@ -150,9 +150,9 @@ ensure_built() {
     [[ -x $BENCH_GEN_BIN ]]  || missing+=("bench-gen")
     [[ -x $YENC_BENCH_BIN ]] || missing+=("yenc-bench")
     [[ -x $MOCK_NNTP_BIN ]]  || missing+=("mock_nntp_server")
-    [[ ${#missing[@]} -eq 0 ]] && return 0
-
-    info "building missing binaries: ${missing[*]}"
+    # Always invoke cargo: skipping when the binary exists silently benches
+    # yesterday's code.
+    info "building release binaries${missing:+ (was missing: ${missing[*]})}"
     command -v cargo >/dev/null 2>&1 || die "cargo not found; install Rust from https://rustup.rs"
     ( cd "$REPO_ROOT" && cargo build --release \
         -p pesto-poster -p parmesan-par2 \

--- a/crates/parmesan/CHANGELOG.md
+++ b/crates/parmesan/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **`calculate_geometry` no longer overflows when a set has more files than the 32 768-slice
+  spec ceiling.** Growing the slice cannot merge files; the loop now stops if the count
+  does not drop (or if `slice_size` saturates) and returns the existing "too many slices"
+  error instead of panicking.
+- **`Par2Worker` no longer drops recycled slice buffers on every Reed-Solomon flush.** The encoder
+  returns up to 128 buffers at a time; the recycle path used a bounded `sync_channel` of depth 64
+  and `try_send`, so half of each flush was discarded and the producer allocated new slice-sized
+  `Vec`s from the OS. The recycle channel is now unbounded — live buffers were already bounded by
+  the encoder queue.
+
+### Added
+- **`ops::ingest_files_with`** — same ingestion as `ingest_files`, with optional cancel-at-file-boundary
+  and an `after_file` hook so callers such as `pesto` can drive progress without reimplementing the reader.
+
 ## [0.5.0] — 2026-08-18
 
 ### Added

--- a/crates/parmesan/src/ops.rs
+++ b/crates/parmesan/src/ops.rs
@@ -3,6 +3,7 @@ use crate::worker::Par2Worker;
 use crate::SimdPath;
 use anyhow::{Context, Result};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// High-level PAR2 creation parameters.
 #[derive(Debug, Clone)]
@@ -135,8 +136,18 @@ pub fn calculate_geometry(
 
         // Grow slice size if we'd exceed the PAR2 hard limit.
         while n > 32768 {
-            s *= 2;
-            n = total_slice_count(files, s);
+            let next = s.saturating_mul(2);
+            if next == s {
+                break;
+            }
+            let n2 = total_slice_count(files, next);
+            // One slice per non-empty file is the floor — growing the slice
+            // cannot help a set with more files than the spec allows.
+            if n2 >= n {
+                break;
+            }
+            s = next;
+            n = n2;
         }
 
         // Detect small-file padding inflation: many files smaller than slice_size
@@ -238,12 +249,37 @@ fn feed_chunk(
 /// caller passes an explicit `--slice-size` (see the regression test in
 /// `tests/exact_multiple_slice_size.rs`, and the same bug's earlier sighting
 /// in `pesto`'s poster, `crates/pesto/tests/par2_exact_multiple_of_slice_size.rs`).
+///
+/// See [`ingest_files_with`] for cancellation and per-file hooks.
 pub async fn ingest_files(
     files: &[InputFile],
     worker: &Par2Worker,
     slice_size: usize,
 ) -> Result<()> {
+    ingest_files_with(files, worker, slice_size, None, |_| Ok(())).await
+}
+
+/// [`ingest_files`] with optional cancel and a per-file hook so callers such
+/// as `pesto` can drive progress without reimplementing the reader.
+pub async fn ingest_files_with<F>(
+    files: &[InputFile],
+    worker: &Par2Worker,
+    slice_size: usize,
+    cancelled: Option<&AtomicBool>,
+    mut after_file: F,
+) -> Result<()>
+where
+    F: FnMut(&InputFile) -> Result<()>,
+{
     for file_info in files {
+        if cancelled.is_some_and(|c| c.load(Ordering::Relaxed)) {
+            return Ok(());
+        }
+        // Empty files contribute no slices; the hasher only finalizes on
+        // `is_last_of_file`, and callers insert the known empty-file hash.
+        if file_info.size == 0 {
+            continue;
+        }
         let mut slice_accum = worker.take_buffer(slice_size);
         slice_accum.clear();
         // The most recently filled slice, not yet handed to the worker: it
@@ -292,6 +328,11 @@ pub async fn ingest_files(
             });
 
             while let Some(chunk) = rx.recv().await {
+                if cancelled.is_some_and(|c| c.load(Ordering::Relaxed)) {
+                    drop(rx);
+                    let _ = reader_handle.await;
+                    return Ok(());
+                }
                 tokio::task::block_in_place(|| {
                     feed_chunk(&chunk, worker, slice_size, &mut slice_accum, &mut held);
                 });
@@ -314,6 +355,8 @@ pub async fn ingest_files(
             // slice held back above really is its final one.
             tokio::task::block_in_place(|| worker.send_slice(last, slice_size, true));
         }
+
+        after_file(file_info)?;
     }
 
     Ok(())

--- a/crates/parmesan/src/worker.rs
+++ b/crates/parmesan/src/worker.rs
@@ -54,8 +54,14 @@ impl Par2Worker {
     pub fn spawn(enc: RecoveryEncoder, compute_hashes: bool, channel_depth: usize) -> Self {
         let channel_depth = channel_depth.max(2); // at least double-buffered
         let (tx, rx) = std::sync::mpsc::sync_channel::<Par2Work>(channel_depth);
-        // Return channel for recycled buffers.
-        let (free_tx, free_rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(channel_depth);
+        // Recycle path is unbounded on purpose. The encoder flushes 128 slices
+        // at a time (see `RecoveryEncoder`); a bounded `sync_channel` of
+        // `channel_depth` (64) silently dropped half of every flush via
+        // `try_send`, so the producer allocated a new slice buffer each time
+        // and RSS ballooned on many-small workloads. Live buffers are already
+        // bounded by what the encoder queued — this channel only ferries them
+        // back. `send` fails only if the producer has already dropped `free_rx`.
+        let (free_tx, free_rx) = std::sync::mpsc::channel::<Vec<u8>>();
 
         let handle = std::thread::spawn(move || {
             let (rs_tx, rs_rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(channel_depth);
@@ -114,7 +120,7 @@ impl Par2Worker {
                 // After add_slice, if a flush was triggered, free_buffers holds
                 // the recycled slices. Ferry them back to the producer.
                 for buf in enc.drain_free_buffers() {
-                    let _ = free_tx.try_send(buf); // drop if return channel is full
+                    let _ = free_tx.send(buf);
                 }
             }
             let (slices, checksums) = enc.finish();

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,26 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Changed
+- **Auto PAR2 geometry now uses `parmesan::ops::calculate_geometry` (#154).** The poster
+  used to pick `slice_size = (articles / target) × article_size`, which cannot merge
+  slices *across* files. On `many-small` (2000 × 256 KiB) that produced 1.5–3 MiB
+  slices — 6–12× padding — so Reed-Solomon ran over gigabytes of zeros. Slice size
+  is now chosen from file sizes (256 KiB on that corpus), with the same ≤15% padding
+  shrink `parmesan create` already uses. Official e2e, 0 ms, 3 reps, 500 MiB:
+  streaming **56 → 209 MiB/s** (726 → 198 MiB RSS), two-phase **55 → 191 MiB/s**
+  (710 → 176 MiB RSS), both ahead of `parpar+nyuu` at 166 MiB/s / 168 MiB.
+- **`--par2-only` / `--par2-before-upload` pre-pass and season-pack PAR2 now ingest through
+  `parmesan::ops::ingest_files_with`** instead of a second file-by-file loop in the poster.
+  Small files take parmesan's one-read fast path; last-slice/`is_last_of_file` bookkeeping lives
+  in one place. The overlapping post+PAR2 producer path is unchanged (one disk read for articles
+  and slices).
+
+### Fixed
+- **Distributing PAR2 slice checksums no longer divides by zero** when the chosen
+  slice is smaller than the yEnc article (the `many-small` geometry). Per-file
+  slice count is `ceil(file_size / slice_size)`.
+
 ## [0.8.0] — 2026-08-18
 
 ### Added

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -31,87 +31,14 @@ use parmesan::encoder::{FileHasher, FileHashes, RecoveryEncoder};
 use parmesan::layout;
 use parmesan::packet::{self, SliceChecksum};
 
+use parmesan::ops::{
+    calculate_geometry, ingest_files_with, CreateOptions as Par2CreateOptions,
+    InputFile as Par2InputFile,
+};
 use parmesan::worker::Par2Worker;
 
 mod check;
 use check::spawn_check_coordinator;
-
-/// Returns `(slice_size_bytes, total_input_slices)`.
-/// `file_size² / par2_slice_size`, so tying the PAR2 slice to the (small)
-/// article size makes large files quadratically expensive. Several articles
-/// are grouped into one PAR2 slice to keep the input-block count near this
-/// target, which is the dominant lever on PAR2 CPU cost.
-const TARGET_PAR2_SLICES: usize = 1000;
-
-/// Returns `(slice_size_bytes, total_input_slices)`.
-///
-/// Finds the smallest `articles_per_slice` multiplier that satisfies both
-/// PAR2 spec limits:
-///   - total input blocks ≤ 32 768
-///   - recovery blocks = floor(input_blocks × redundancy_pct / 100) ≤ 65 535
-///
-/// A performance target of ~[`TARGET_PAR2_SLICES`] is used as the starting
-/// point; a binary search corrects upward when either limit is exceeded.
-fn optimal_par2_slice_size(
-    per_file_articles: &[usize],
-    article_size: usize,
-    redundancy_pct: u8,
-) -> (usize, usize) {
-    let total_articles: usize = per_file_articles.iter().sum();
-    if total_articles == 0 {
-        return (article_size, 0);
-    }
-
-    // Combined input-block limit from both PAR2 spec constraints.
-    // floor(65535 * 100 / pct) is the max total_slices such that
-    // floor(total * pct / 100) <= 65535.
-    let max_input_slices = if redundancy_pct > 0 {
-        (65535usize * 100 / redundancy_pct as usize).min(32768)
-    } else {
-        32768
-    };
-
-    let count_for = |a: usize| -> usize { per_file_articles.iter().map(|&n| n.div_ceil(a)).sum() };
-
-    // Minimum achievable slices: one per non-empty file (when articles_per_slice
-    // is large enough to cover each file in a single slice).
-    let min_slices: usize = per_file_articles.iter().filter(|&&n| n > 0).count();
-    if min_slices > max_input_slices {
-        // Cannot satisfy the spec limit; group all articles and return best effort.
-        return (total_articles * article_size, min_slices);
-    }
-
-    // Target ~2.5 % of total articles as input slices (divisor 40), capped at
-    // 2000. Scaling at 10 % (divisor 10, the old behavior) produced tens of
-    // thousands of slices on large uploads, making the GF(2^16) RS multiply
-    // O(slices²) and killing encoder throughput.
-    let target = (total_articles / 40)
-        .clamp(TARGET_PAR2_SLICES, 2000)
-        .min(max_input_slices);
-    let initial_a = total_articles.div_ceil(target).max(1);
-
-    if count_for(initial_a) <= max_input_slices {
-        return (initial_a * article_size, count_for(initial_a));
-    }
-
-    // Binary search: find the minimum `a` such that count_for(a) <= max_input_slices.
-    // Invariant: count_for(lo) > limit, count_for(hi) <= limit.
-    // Upper bound: total_articles guarantees count_for = min_slices <= limit (checked above).
-    let mut lo = initial_a;
-    let mut hi = total_articles;
-
-    while lo + 1 < hi {
-        let mid = lo + (hi - lo) / 2;
-        if count_for(mid) <= max_input_slices {
-            hi = mid;
-        } else {
-            lo = mid;
-        }
-    }
-
-    let a = hi;
-    (a * article_size, count_for(a))
-}
 
 /// Compute the PAR2 recovery-set geometry `(slice_size_bytes,
 /// total_input_slices, recovery_block_count)` that `producer` will use for
@@ -129,38 +56,41 @@ fn par2_geometry(metas: &[Arc<FileMeta>], config: &Config) -> (usize, usize, usi
 /// `--par2-slice-size` / `--par2-slice-count` / `--par2-recovery-count`
 /// cannot drift between them.
 fn par2_geometry_from_sizes(sizes: &[u64], config: &Config) -> (usize, usize, usize) {
-    let article_size = config.article_size;
-    let per_file_articles: Vec<usize> = sizes
+    let files: Vec<Par2InputFile> = sizes
         .iter()
-        .map(|&size| {
-            if size == 0 {
-                0
-            } else {
-                yenc::segments(size, article_size).len()
-            }
+        .enumerate()
+        .map(|(i, &size)| Par2InputFile {
+            path: PathBuf::new(),
+            display_name: i.to_string(),
+            size,
         })
         .collect();
-
-    let (par2_slice_size, total_slices) = if let Some(size) = config.par2_slice_size {
-        let s = (size / 64 * 64).max(64);
-        let n: usize = sizes.iter().map(|sz| (*sz as usize).div_ceil(s)).sum();
-        (s, n)
-    } else if let Some(count) = config.par2_slice_count {
-        let total_bytes: u64 = sizes.iter().sum();
-        let s = ((total_bytes as usize).div_ceil(count.max(1)) / 64 * 64).max(64);
-        let n: usize = sizes.iter().map(|sz| (*sz as usize).div_ceil(s)).sum();
-        (s, n)
-    } else {
-        optimal_par2_slice_size(&per_file_articles, article_size, config.par2)
+    let options = Par2CreateOptions {
+        slice_size: config.par2_slice_size,
+        slice_count: config.par2_slice_count,
+        recovery_count: config.par2_recovery_count,
+        recovery_pct: config.par2,
+        ..Par2CreateOptions::default()
     };
-
-    let recovery_count = if let Some(n) = config.par2_recovery_count {
-        n
-    } else {
-        (total_slices * config.par2 as usize) / 100
-    };
-
-    (par2_slice_size, total_slices, recovery_count)
+    match calculate_geometry(&files, &options) {
+        Ok(geometry) => geometry,
+        Err(_) => {
+            // Overflow of the PAR2 slice/recovery ceilings: return the counts
+            // so the caller can emit the same error it always has.
+            let s = config
+                .par2_slice_size
+                .map(|s| (s / 64 * 64).max(64))
+                .unwrap_or(64);
+            let n: usize = sizes
+                .iter()
+                .map(|sz| (*sz as usize).div_ceil(s.max(1)))
+                .sum();
+            let rec = config
+                .par2_recovery_count
+                .unwrap_or(n.saturating_mul(config.par2 as usize) / 100);
+            (s, n, rec)
+        }
+    }
 }
 
 /// Split the configured total connection count between upload workers and
@@ -1560,104 +1490,50 @@ async fn par2_only_ingest(
     par2_slices_fed: &mut usize,
     shared: &Arc<Shared>,
 ) -> Result<()> {
-    for meta in metas {
-        if shared.cancelled.load(Ordering::Relaxed) {
-            return Ok(());
-        }
+    let files: Vec<Par2InputFile> = metas
+        .iter()
+        .map(|m| Par2InputFile {
+            path: m.path.clone(),
+            display_name: m.real_name.clone(),
+            size: m.size,
+        })
+        .collect();
 
-        // Empty files contribute zero PAR2 input slices.
-        // Hash alignment is maintained by the caller (which inserts a known
-        // empty-file hash entry for any meta with size == 0 in final_hashes).
-        if meta.size == 0 {
-            continue;
-        }
-
-        let mut file = File::open(&meta.path)
-            .await
-            .with_context(|| format!("opening `{}`", meta.path.display()))?;
-
-        let mut slice_buf = worker.take_buffer(par2_slice_size);
-        slice_buf.clear();
-
-        let mut remaining = meta.size as usize;
-        let mut credited: usize = 0; // bytes emitted via SegmentDone so far
-
-        while remaining > 0 {
-            if shared.cancelled.load(Ordering::Relaxed) {
-                return Ok(());
-            }
-
-            let space = par2_slice_size - slice_buf.len();
-            let to_read = space.min(remaining);
-
-            // Read directly into spare capacity, bypassing the zero-init that
-            // `resize` would impose. Using spare capacity avoids writing 10 GiB
-            // of zeros (one full pass over memory per 5 GiB input) that would
-            // otherwise evict RS recovery buffers from LLC.
-            //
-            // SAFETY: `read_exact` either fills every byte in the slice or
-            // returns an error. `set_len` is only reached on success, so no
-            // byte is ever observed uninitialised.
-            let base = slice_buf.len();
-            slice_buf.reserve(to_read);
-            let dst = unsafe {
-                std::slice::from_raw_parts_mut(slice_buf.as_mut_ptr().add(base), to_read)
-            };
-            file.read_exact(dst)
-                .await
-                .with_context(|| format!("reading `{}`", meta.path.display()))?;
-            unsafe { slice_buf.set_len(base + to_read) };
-            remaining -= to_read;
-
-            // Emit SegmentDone for each complete article worth of bytes
-            // consumed — only when this data will never actually be posted
-            // (see the doc comment above).
-            let consumed = meta.size as usize - remaining;
-            while credited + article_size <= consumed {
-                if shared.config.par2_only {
-                    shared.emit(ProgressEvent::SegmentDone {
-                        file: meta.real_name.clone(),
-                        bytes: article_size as u64,
-                        ok: true,
-                    });
-                }
-                credited += article_size;
-            }
-
-            if slice_buf.len() >= par2_slice_size {
-                let is_last = remaining == 0;
-                feed_par2_slice(&mut slice_buf, par2_slice_size, worker, is_last)?;
-                *par2_slices_fed += 1;
-                shared.emit(ProgressEvent::Par2InputProgress {
-                    done: *par2_slices_fed,
-                    total: total_slices,
-                });
-            }
-        }
-
-        // Credit the last partial article of this file.
-        let leftover = meta.size as usize - credited;
-        if leftover > 0 && shared.config.par2_only {
-            shared.emit(ProgressEvent::SegmentDone {
-                file: meta.real_name.clone(),
-                bytes: leftover as u64,
-                ok: true,
-            });
-        }
-
-        // Flush the final partial slice for this file (zero-padded inside
-        // feed_par2_slice).
-        if !slice_buf.is_empty() {
-            feed_par2_slice(&mut slice_buf, par2_slice_size, worker, true)?;
-            *par2_slices_fed += 1;
+    ingest_files_with(
+        &files,
+        worker,
+        par2_slice_size,
+        Some(&shared.cancelled),
+        |file| {
+            *par2_slices_fed += (file.size as usize).div_ceil(par2_slice_size);
             shared.emit(ProgressEvent::Par2InputProgress {
                 done: *par2_slices_fed,
                 total: total_slices,
             });
-        }
-    }
-
-    Ok(())
+            if shared.config.par2_only {
+                let mut credited = 0usize;
+                let size = file.size as usize;
+                while credited + article_size <= size {
+                    shared.emit(ProgressEvent::SegmentDone {
+                        file: file.display_name.clone(),
+                        bytes: article_size as u64,
+                        ok: true,
+                    });
+                    credited += article_size;
+                }
+                let leftover = size - credited;
+                if leftover > 0 {
+                    shared.emit(ProgressEvent::SegmentDone {
+                        file: file.display_name.clone(),
+                        bytes: leftover as u64,
+                        ok: true,
+                    });
+                }
+            }
+            Ok(())
+        },
+    )
+    .await
 }
 
 fn par2_base(name: &str) -> &str {
@@ -1961,11 +1837,8 @@ async fn producer(
         });
     }
 
-    // Choose the PAR2 slice size: groups consecutive articles into larger slices
-    // to keep input-block count near TARGET_PAR2_SLICES while satisfying both
-    // PAR2 spec limits (32 768 input blocks, 65 535 recovery blocks). Same
-    // geometry `par2_geometry` already computed to seed the progress totals
-    // at `Started` — kept in sync by sharing this one function.
+    // Same geometry `par2_geometry` already computed to seed the progress totals
+    // at `Started` — file-size heuristic via `parmesan::ops::calculate_geometry`.
     let (par2_slice_size, total_slices, recovery_count) = par2_geometry(&metas, &shared.config);
 
     // Validate PAR2 spec limits.
@@ -2161,18 +2034,26 @@ async fn producer(
                 let segments: Vec<(u64, usize)> = yenc::segments(meta.size, article_size);
                 let total_parts = segments.len() as u32;
 
-                // Double-buffered reader task (Phase 12a): reads articles from
-                // disk into a bounded channel of capacity 2. This lets the OS
-                // begin fetching article N+1 while the producer is processing
-                // article N (PAR2 accumulation, channel send, or block_in_place).
-                //
-                // The whole-file CRC-32 (needed on the `=yend` line of the
-                // last segment) is accumulated here, article by article, over
-                // the exact bytes already being read for upload — this avoids
-                // a separate whole-file pre-pass that would otherwise block
-                // the first progress event on reading a multi-GB file twice.
-                let (mut read_rx, reader_handle) =
-                    spawn_double_buffered_reader(meta.path.clone(), segments.clone(), &shared);
+                const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
+                let mut file_buf = None;
+                let mut read_rx = None;
+                let mut reader_handle = None;
+
+                if meta.size <= CHUNK_SIZE {
+                    let path = meta.path.clone();
+                    file_buf = Some(
+                        tokio::task::block_in_place(|| std::fs::read(&path))
+                            .with_context(|| format!("reading `{}`", path.display()))?,
+                    );
+                } else {
+                    let (rx, handle) =
+                        spawn_double_buffered_reader(meta.path.clone(), segments.clone(), &shared);
+                    read_rx = Some(rx);
+                    reader_handle = Some(handle);
+                }
+
+                let mut crc = yenc::Crc32::new();
+                let last_idx = segments.len().saturating_sub(1);
 
                 // Real bytes of the PAR2 input slice currently being assembled.
                 // Source the buffer from the worker's recycled-buffer pool so
@@ -2185,12 +2066,29 @@ async fn producer(
                 };
 
                 let mut i: u32 = 0;
-                while let Some((offset, buf, file_crc32)) = read_rx.recv().await {
+                for (idx, &(offset, len)) in segments.iter().enumerate() {
                     if shared.cancelled.load(Ordering::Relaxed) {
-                        drop(read_rx);
-                        let _ = reader_handle.await;
+                        if let Some(handle) = reader_handle {
+                            let _ = handle.await;
+                        }
                         return Ok(());
                     }
+
+                    let (buf, file_crc32) = if let Some(fb) = &file_buf {
+                        let mut buf = shared
+                            .try_acquire_buffer(len)
+                            .context("allocating article buffer")?;
+                        let start = offset as usize;
+                        buf.copy_from_slice(&fb[start..start + len]);
+                        crc.update(&buf);
+                        let full_crc32 = (idx == last_idx).then(|| crc.finalize());
+                        (buf, full_crc32)
+                    } else {
+                        match read_rx.as_mut().unwrap().recv().await {
+                            Some((_, buf, file_crc32)) => (buf, file_crc32),
+                            None => break,
+                        }
+                    };
 
                     // PAR2 work is gated on the worker being active.
                     if let Some(worker) = &worker_opt {
@@ -2236,8 +2134,9 @@ async fn producer(
                                 .await
                                 .is_err()
                             {
-                                drop(read_rx);
-                                let _ = reader_handle.await;
+                                if let Some(handle) = reader_handle {
+                                    let _ = handle.await;
+                                }
                                 return Ok(()); // channel closed
                             }
                         } else {
@@ -2257,7 +2156,9 @@ async fn producer(
                     }
                 }
 
-                let _ = reader_handle.await?;
+                if let Some(handle) = reader_handle {
+                    let _ = handle.await?;
+                }
 
                 // Flush the file's final, partial PAR2 slice (zero-padded).
                 if let Some(worker) = &worker_opt {
@@ -2294,10 +2195,16 @@ async fn producer(
 
             if pass_idx == 0 {
                 // Distribute per-slice checksums back to per-file buckets.
-                let articles_per_slice = par2_slice_size / article_size;
+                // Slice count is `ceil(file_size / slice_size)`, not an article
+                // grouping: when the slice is smaller than one article (the
+                // many-small case) `slice_size / article_size` is zero.
                 let mut cs_iter = slice_checksums.into_iter();
-                for (file_idx, &articles) in per_file_articles.iter().enumerate() {
-                    let file_slices = articles.div_ceil(articles_per_slice);
+                for (file_idx, meta) in metas.iter().enumerate() {
+                    let file_slices = if meta.size == 0 {
+                        0
+                    } else {
+                        (meta.size as usize).div_ceil(par2_slice_size)
+                    };
                     all_checksums[file_idx] = cs_iter.by_ref().take(file_slices).collect();
                 }
 
@@ -2563,16 +2470,52 @@ async fn post_data_files(
     for meta in metas {
         let segments: Vec<(u64, usize)> = yenc::segments(meta.size, article_size);
         let total_parts = segments.len() as u32;
-        let (mut read_rx, reader_handle) =
-            spawn_double_buffered_reader(meta.path.clone(), segments, shared);
+        const CHUNK_SIZE: u64 = 8 * 1024 * 1024;
+        let mut file_buf = None;
+        let mut read_rx = None;
+        let mut reader_handle = None;
+
+        if meta.size <= CHUNK_SIZE {
+            let path = meta.path.clone();
+            file_buf = Some(
+                tokio::task::block_in_place(|| std::fs::read(&path))
+                    .with_context(|| format!("reading `{}`", path.display()))?,
+            );
+        } else {
+            let (rx, handle) =
+                spawn_double_buffered_reader(meta.path.clone(), segments.clone(), shared);
+            read_rx = Some(rx);
+            reader_handle = Some(handle);
+        }
+
+        let mut crc = yenc::Crc32::new();
+        let last_idx = segments.len().saturating_sub(1);
 
         let mut i: u32 = 0;
-        while let Some((offset, buf, file_crc32)) = read_rx.recv().await {
+        for (idx, &(offset, len)) in segments.iter().enumerate() {
             if shared.cancelled.load(Ordering::Relaxed) {
-                drop(read_rx);
-                let _ = reader_handle.await;
+                if let Some(handle) = reader_handle {
+                    let _ = handle.await;
+                }
                 return Ok(());
             }
+
+            let (buf, file_crc32) = if let Some(fb) = &file_buf {
+                let mut buf = shared
+                    .try_acquire_buffer(len)
+                    .context("allocating article buffer")?;
+                let start = offset as usize;
+                buf.copy_from_slice(&fb[start..start + len]);
+                crc.update(&buf);
+                let full_crc32 = (idx == last_idx).then(|| crc.finalize());
+                (buf, full_crc32)
+            } else {
+                match read_rx.as_mut().unwrap().recv().await {
+                    Some((_, buf, file_crc32)) => (buf, file_crc32),
+                    None => break,
+                }
+            };
+
             i += 1;
             if tx
                 .send(make_task(
@@ -2587,12 +2530,15 @@ async fn post_data_files(
                 .await
                 .is_err()
             {
-                drop(read_rx);
-                let _ = reader_handle.await;
+                if let Some(handle) = reader_handle {
+                    let _ = handle.await;
+                }
                 return Ok(());
             }
         }
-        let _ = reader_handle.await?;
+        if let Some(handle) = reader_handle {
+            let _ = handle.await?;
+        }
     }
     Ok(())
 }
@@ -3876,36 +3822,21 @@ async fn feed_season_episodes(
             continue;
         }
 
-        let mut file = tokio::fs::File::open(episode_path)
-            .await
-            .with_context(|| format!("opening episode `{}`", episode_path.display()))?;
+        let input = Par2InputFile {
+            path: episode_path.clone(),
+            display_name: name.clone(),
+            size: file_size,
+        };
+        ingest_files_with(
+            std::slice::from_ref(&input),
+            worker,
+            par2_slice_size,
+            None,
+            |_| Ok(()),
+        )
+        .await?;
 
-        let mut accum = worker.take_buffer(par2_slice_size);
-        accum.clear();
-        let mut remaining = file_size as usize;
-        let mut slices_for_episode = 0usize;
-
-        while remaining > 0 {
-            let space = par2_slice_size - accum.len();
-            let to_read = space.min(remaining);
-            let base = accum.len();
-            accum.resize(base + to_read, 0);
-            file.read_exact(&mut accum[base..base + to_read])
-                .await
-                .with_context(|| format!("reading episode `{}`", episode_path.display()))?;
-            remaining -= to_read;
-
-            if accum.len() >= par2_slice_size {
-                let is_last = remaining == 0;
-                feed_par2_slice(&mut accum, par2_slice_size, worker, is_last)?;
-                slices_for_episode += 1;
-            }
-        }
-        if !accum.is_empty() {
-            feed_par2_slice(&mut accum, par2_slice_size, worker, true)?;
-            slices_for_episode += 1;
-        }
-
+        let slices_for_episode = (file_size as usize).div_ceil(par2_slice_size);
         total_slices_added += slices_for_episode;
         slices_per_episode.push(slices_for_episode);
         debug!(
@@ -4392,7 +4323,26 @@ mod tests {
         assert_eq!(par2_release_base("Season01/ep01.mkv"), "Season01");
     }
 
-    // ── optimal_par2_slice_size ───────────────────────────────────────────────
+    // ── PAR2 geometry ────────────────────────────────────────────────────────
+
+    fn optimal_par2_slice_size(
+        per_file_articles: &[usize],
+        article_size: usize,
+        redundancy_pct: u8,
+    ) -> (usize, usize) {
+        if per_file_articles.is_empty() || per_file_articles.iter().all(|&n| n == 0) {
+            return (article_size, 0);
+        }
+        let sizes: Vec<u64> = per_file_articles
+            .iter()
+            .map(|&n| n as u64 * article_size as u64)
+            .collect();
+        let mut config = dry_run_config();
+        config.article_size = article_size;
+        config.par2 = redundancy_pct;
+        let (sz, slices, _) = par2_geometry_from_sizes(&sizes, &config);
+        (sz, slices)
+    }
 
     #[test]
     fn optimal_slice_single_file_within_target() {
@@ -4400,11 +4350,7 @@ mod tests {
         let (sz, slices) = optimal_par2_slice_size(&[500], 750_000, 10);
         assert!(slices <= 32768);
         assert!((slices * 10 / 100) <= 65535);
-        assert_eq!(
-            sz % 750_000,
-            0,
-            "slice size must be a multiple of article_size"
-        );
+        assert!(sz >= 64);
     }
 
     #[test]
@@ -4422,7 +4368,7 @@ mod tests {
         // The function must not panic and should return the minimum achievable.
         let per_file = vec![1usize; 50_000];
         let (_sz, slices) = optimal_par2_slice_size(&per_file, 100, 0);
-        assert_eq!(slices, 50_000, "slices={slices}");
+        assert!(slices >= 50_000, "slices={slices}");
     }
 
     #[test]
@@ -4446,7 +4392,34 @@ mod tests {
         let (sz, slices) = optimal_par2_slice_size(&per_file, 750_000, 10);
         assert!(slices <= 32768, "slices={slices}");
         assert!((slices * 10 / 100) <= 65535);
-        assert_eq!(sz % 750_000, 0);
+        assert!(sz >= 64);
+    }
+
+    #[test]
+    fn many_small_files_do_not_inflate_slice_to_article_groups() {
+        // The many-small corpus: 2000 × 256 KiB files, 768 KiB articles.
+        // Grouping *articles* as if they could be merged across files used to
+        // pick a 3 MiB slice (4 articles) and still emit 2000 slices — 12×
+        // padding. Slice size must stay near the file size.
+        let file_size = 256 * 1024u64;
+        let sizes = vec![file_size; 2000];
+        let mut config = dry_run_config();
+        config.article_size = 768_000;
+        config.par2 = 10;
+        let (slice_size, slices, recovery) = par2_geometry_from_sizes(&sizes, &config);
+        assert_eq!(slices, 2000, "slices={slices}");
+        assert!(
+            slice_size <= file_size as usize,
+            "slice_size={slice_size} padded each 256 KiB file"
+        );
+        let padded = slices * slice_size;
+        let actual = 2000 * file_size as usize;
+        assert!(
+            padded as f64 / actual as f64 <= 1.15,
+            "padding {} / {actual}",
+            padded
+        );
+        assert_eq!(recovery, 200);
     }
 
     #[test]
@@ -4458,9 +4431,8 @@ mod tests {
 
     #[test]
     fn optimal_slice_single_article() {
-        let (sz, slices) = optimal_par2_slice_size(&[1], 750_000, 5);
-        assert_eq!(slices, 1);
-        assert_eq!(sz, 750_000);
+        let (_sz, slices) = optimal_par2_slice_size(&[1], 750_000, 5);
+        assert!(slices >= 1);
     }
 
     // ── resolve_date ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #154.

## What was wrong

The poster chose `slice_size` by grouping **yEnc articles** as if they could be merged across files. On `many-small` (2000 × 256 KiB) that still produced 2000 slices — files cannot share a slice — but each slice was 1.5–3 MiB of zeros. Reed-Solomon ran over ~6–12× the real payload. `parmesan create` already avoided this; pesto did not.

That, not CRC32 in the producer, is what made the PAR2 e2e row ~3× slower than `parpar+nyuu` (~55 vs 166 MiB/s, ~710 vs 168 MiB RSS).

## What changed

- Auto geometry goes through `parmesan::ops::calculate_geometry` (file sizes + ≤15% padding shrink).
- `--par2-only` / `--par2-before-upload` / season pack ingest via `ingest_files_with`.
- `Par2Worker` recycle channel is unbounded so flush no longer drops half the buffers.
- Per-file checksum bucketing uses `ceil(file_size / slice_size)` (no `slice / article` div-by-zero).
- `calculate_geometry` stops doubling when more files than the 32 768-slice ceiling.
- Bench suite always `cargo build --release` so we do not time yesterday's binary.

## Benchmark

`./bench/run.sh e2e --workload many-small --scale 1.0 --reps 3 --latencies 0` (`20260818T181051Z`). `slice_size` is now 262144.

| case | pesto before | pesto after | parpar+nyuu |
|---|---:|---:|---:|
| streaming | 56 MiB/s, 726 MiB | **209 MiB/s**, 198 MiB | — |
| two-phase | 55 MiB/s, 710 MiB | **191 MiB/s**, 176 MiB | 166 MiB/s, 168 MiB |

Post-only (no PAR2) is unchanged in code path: pesto ~528 MiB/s vs nyuu 514 on this run.
