### PR TITLE
fix(poster): do not block_in_place on the current-thread runtime

### DIFF
--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -13,6 +13,10 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 ## [Unreleased]
 
 ### Fixed
+- **Small-file ingest no longer calls `block_in_place` on the current-thread
+  runtime.** `#[tokio::test]` (and any `current_thread` runtime) panicked in
+  the five `dry_run_*` poster tests: `can call blocking only when running on
+  the multi-threaded runtime`. Those files now use `tokio::fs::read`.
 - **`TaskDispatcher` no longer pins articles to a stalled worker (#145).** Round-robin
   `send` used to `await` the chosen per-worker channel even when it was full, so a
   slow/erroring server (depth 4) blocked the producer and starved the fast workers.

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -2056,10 +2056,10 @@ async fn producer(
                 let mut reader_handle = None;
 
                 if meta.size <= CHUNK_SIZE {
-                    let path = meta.path.clone();
                     file_buf = Some(
-                        tokio::task::block_in_place(|| std::fs::read(&path))
-                            .with_context(|| format!("reading `{}`", path.display()))?,
+                        tokio::fs::read(&meta.path)
+                            .await
+                            .with_context(|| format!("reading `{}`", meta.path.display()))?,
                     );
                 } else {
                     let (rx, handle) =
@@ -2492,10 +2492,10 @@ async fn post_data_files(
         let mut reader_handle = None;
 
         if meta.size <= CHUNK_SIZE {
-            let path = meta.path.clone();
             file_buf = Some(
-                tokio::task::block_in_place(|| std::fs::read(&path))
-                    .with_context(|| format!("reading `{}`", path.display()))?,
+                tokio::fs::read(&meta.path)
+                    .await
+                    .with_context(|| format!("reading `{}`", meta.path.display()))?,
             );
         } else {
             let (rx, handle) =


### PR DESCRIPTION
CI `check` and `test-aarch64` failed on #156/#157 (`cargo test -p pesto-poster --lib`):

```
poster::tests::dry_run_* panicked at poster/mod.rs:
can call blocking only when running on the multi-threaded runtime
```

The ≤8 MiB ingest path added with #155 used `block_in_place(std::fs::read)`. `#[tokio::test]` is current-thread, so those five dry-run tests panic. Switch to `tokio::fs::read`.

Verified locally: `cargo test -p pesto-poster --lib -- dry_run` — 6 passed.