### PR TITLE
fix: stream season PAR2 recovery per pass (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-08-20
+
+### Fixed
+- Season-mode global PAR2 streams each memory-budget pass to disk instead of concatenating the whole recovery set in RAM (#110).
+- CI: Clippy `-D warnings` and aarch64 compile of parmesan 0.5.2.
+
 ## [0.8.1] — 2026-08-20
 
 ### Performance (parmesan 0.5.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "parmesan-par2"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1677,7 +1677,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/crates/parmesan/CHANGELOG.md
+++ b/crates/parmesan/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.2] — 2026-08-20
+
+### Fixed
+- Clippy `-D warnings` and aarch64 build: `flush_avx512_affine2x` is gated on `x86_64` (it called a work function that only exists on that arch), `Md5State` copies no longer use `clone`, and constant-size `chunks_exact` loops use `as_chunks`.
+
+## [0.5.1] — 2026-08-20
+
+### Performance
+
+- **Affine512 packed kernel** (`srcCount=6`, 4 KiB tiles) is now the `smart` default on AVX-512+GFNI hardware. PAR2 create on `c7i.2xlarge movie-1080p`: 325 → 518 MiB/s after dynamic batching.
+- Affine AVX-512+GFNI and Affine AVX2+GFNI kernels; Shuffle AVX-512 nibble fallback; dynamic batch sizing (12 slices Affine512, 64 Shuffle2x/Normal).
+- SIMD MD5-MB 8/16-wide (`md5-many`) for slice and file checksums.
+
 ## [0.5.0] — 2026-08-18
 
 ### Added

--- a/crates/parmesan/Cargo.toml
+++ b/crates/parmesan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parmesan-par2"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.89"
 description = "Fast, standalone PAR2 (Reed-Solomon) creation, verification and repair tool"

--- a/crates/parmesan/src/affine.rs
+++ b/crates/parmesan/src/affine.rs
@@ -67,7 +67,12 @@ fn separate_low_high_avx2_lanes(chunk: &[u8]) -> [u8; 32] {
 }
 
 fn to_affine_scalar(src: &[u8], dst: &mut [u8]) {
-    for (cin, cout) in src.chunks_exact(64).zip(dst.chunks_exact_mut(64)) {
+    for (cin, cout) in src
+        .as_chunks::<64>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<64>().0)
+    {
         let a = separate_low_high_avx2_lanes(&cin[..32]);
         let b = separate_low_high_avx2_lanes(&cin[32..]);
         cout[..8].copy_from_slice(&a[8..16]);
@@ -82,7 +87,12 @@ fn to_affine_scalar(src: &[u8], dst: &mut [u8]) {
 }
 
 fn from_affine_scalar(src: &[u8], dst: &mut [u8]) {
-    for (cin, cout) in src.chunks_exact(64).zip(dst.chunks_exact_mut(64)) {
+    for (cin, cout) in src
+        .as_chunks::<64>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<64>().0)
+    {
         let ta = &cin[..32];
         let tb = &cin[32..];
         // unpacklo_epi8(tb, ta) then unpackhi_epi8(tb, ta), per 16-byte lane.
@@ -106,7 +116,12 @@ unsafe fn to_affine_avx2(src: &[u8], dst: &mut [u8]) {
         15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0, 15, 13, 11, 9, 7, 5, 3, 1, 14, 12,
         10, 8, 6, 4, 2, 0,
     );
-    for (cin, cout) in src.chunks_exact(64).zip(dst.chunks_exact_mut(64)) {
+    for (cin, cout) in src
+        .as_chunks::<64>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<64>().0)
+    {
         let ta = _mm256_shuffle_epi8(_mm256_loadu_si256(cin.as_ptr().cast()), sep);
         let tb = _mm256_shuffle_epi8(_mm256_loadu_si256(cin.as_ptr().add(32).cast()), sep);
         _mm256_storeu_si256(cout.as_mut_ptr().cast(), _mm256_unpackhi_epi64(ta, tb));
@@ -121,7 +136,12 @@ unsafe fn to_affine_avx2(src: &[u8], dst: &mut [u8]) {
 #[target_feature(enable = "avx2")]
 unsafe fn from_affine_avx2(src: &[u8], dst: &mut [u8]) {
     use std::arch::x86_64::*;
-    for (cin, cout) in src.chunks_exact(64).zip(dst.chunks_exact_mut(64)) {
+    for (cin, cout) in src
+        .as_chunks::<64>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<64>().0)
+    {
         let ta = _mm256_loadu_si256(cin.as_ptr().cast());
         let tb = _mm256_loadu_si256(cin.as_ptr().add(32).cast());
         _mm256_storeu_si256(cout.as_mut_ptr().cast(), _mm256_unpacklo_epi8(tb, ta));
@@ -181,7 +201,12 @@ pub(crate) unsafe fn affine512_prepare_block(src: *const u8, dst: *mut u8) {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f,avx512bw")]
 unsafe fn to_affine512_avx512(src: &[u8], dst: &mut [u8]) {
-    for (cin, cout) in src.chunks_exact(128).zip(dst.chunks_exact_mut(128)) {
+    for (cin, cout) in src
+        .as_chunks::<128>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<128>().0)
+    {
         affine512_prepare_block(cin.as_ptr(), cout.as_mut_ptr());
     }
 }
@@ -200,7 +225,12 @@ pub(crate) unsafe fn affine512_finish_block(src: *const u8, dst: *mut u8) {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f,avx512bw")]
 unsafe fn from_affine512_avx512(src: &[u8], dst: &mut [u8]) {
-    for (cin, cout) in src.chunks_exact(128).zip(dst.chunks_exact_mut(128)) {
+    for (cin, cout) in src
+        .as_chunks::<128>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<128>().0)
+    {
         affine512_finish_block(cin.as_ptr(), cout.as_mut_ptr());
     }
 }

--- a/crates/parmesan/src/affine2x.rs
+++ b/crates/parmesan/src/affine2x.rs
@@ -83,7 +83,12 @@ pub fn from_affine2x(src: &[u8], dst: &mut [u8]) {
 }
 
 fn to_affine2x_scalar(src: &[u8], dst: &mut [u8]) {
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         for lane in 0..2 {
             let base = lane * 16;
             for i in 0..8 {
@@ -95,7 +100,12 @@ fn to_affine2x_scalar(src: &[u8], dst: &mut [u8]) {
 }
 
 fn from_affine2x_scalar(src: &[u8], dst: &mut [u8]) {
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         for lane in 0..2 {
             let base = lane * 16;
             for i in 0..8 {
@@ -114,7 +124,12 @@ unsafe fn to_affine2x_avx2(src: &[u8], dst: &mut [u8]) {
         15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0, 15, 13, 11, 9, 7, 5, 3, 1, 14, 12,
         10, 8, 6, 4, 2, 0,
     );
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         let v = _mm256_loadu_si256(chunk_in.as_ptr().cast());
         let separated = _mm256_shuffle_epi8(v, sep_mask);
         _mm256_storeu_si256(chunk_out.as_mut_ptr().cast(), separated);
@@ -129,7 +144,12 @@ unsafe fn from_affine2x_avx2(src: &[u8], dst: &mut [u8]) {
         15, 7, 14, 6, 13, 5, 12, 4, 11, 3, 10, 2, 9, 1, 8, 0, 15, 7, 14, 6, 13, 5, 12, 4, 11, 3,
         10, 2, 9, 1, 8, 0,
     );
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         let v = _mm256_loadu_si256(chunk_in.as_ptr().cast());
         let result = _mm256_shuffle_epi8(v, interleave_mask);
         _mm256_storeu_si256(chunk_out.as_mut_ptr().cast(), result);

--- a/crates/parmesan/src/altmap.rs
+++ b/crates/parmesan/src/altmap.rs
@@ -103,7 +103,7 @@ fn to_altmap_scalar(src: &[u16], dst: &mut [u8]) {
     let n = src.len();
     let plane_bytes = n / 8; // bytes per plane section
 
-    for (g, chunk) in src.chunks_exact(16).enumerate() {
+    for (g, chunk) in src.as_chunks::<16>().0.iter().enumerate() {
         let byte_off = g * 2; // 2-byte position within each plane section
         for k in 0u32..16 {
             let mut bits: u16 = 0;
@@ -173,7 +173,7 @@ unsafe fn to_altmap_sse2(src: &[u16], dst: &mut [u8]) {
 
     let lo_mask = _mm_set1_epi16(0x00FF_u16 as i16);
 
-    for (g, chunk) in src.chunks_exact(16).enumerate() {
+    for (g, chunk) in src.as_chunks::<16>().0.iter().enumerate() {
         let byte_off = g * 2;
         let ptr = chunk.as_ptr();
 

--- a/crates/parmesan/src/encoder.rs
+++ b/crates/parmesan/src/encoder.rs
@@ -3178,6 +3178,7 @@ impl RecoveryEncoder {
         });
     }
 
+    #[cfg(target_arch = "x86_64")]
     unsafe fn flush_avx512_affine2x(&mut self) {
         let start_index = self.next_index;
         let queued = std::mem::take(&mut self.queued_slices);
@@ -6242,7 +6243,8 @@ impl RecoveryEncoder {
                     let slice_chunk = &slice[byte_offset..byte_offset + byte_len];
                     let (ref table_low, ref table_high) = tables[q_idx];
 
-                    for (word, chunk) in buffer_chunk.iter_mut().zip(slice_chunk.chunks_exact(2)) {
+                    for (word, chunk) in buffer_chunk.iter_mut().zip(slice_chunk.as_chunks::<2>().0)
+                    {
                         *word ^= table_low[chunk[0] as usize] ^ table_high[chunk[1] as usize];
                     }
                 }
@@ -6428,20 +6430,20 @@ impl FileHasher {
 
             if chunk_actual_len == chunk.len() {
                 // Entire chunk is unpadded data: hash simultaneously
-                let mut states = [self.full.clone(), slice_state.clone()];
+                let mut states = [self.full, slice_state];
                 self.many.update_many(&mut states, &[chunk, chunk]);
-                self.full = states[0].clone();
-                slice_state = states[1].clone();
+                self.full = states[0];
+                slice_state = states[1];
             } else if chunk_actual_len > 0 {
                 // Partial chunk: simultaneously hash the unpadded part, then individually hash the rest of the padding for the slice
                 let unpadded_part = &chunk[..chunk_actual_len];
                 let padded_part = &chunk[chunk_actual_len..];
 
-                let mut states = [self.full.clone(), slice_state.clone()];
+                let mut states = [self.full, slice_state];
                 self.many
                     .update_many(&mut states, &[unpadded_part, unpadded_part]);
-                self.full = states[0].clone();
-                slice_state = states[1].clone();
+                self.full = states[0];
+                slice_state = states[1];
 
                 slice_state.update(padded_part);
             } else {
@@ -6451,7 +6453,7 @@ impl FileHasher {
         }
 
         SliceChecksum {
-            md5: slice_state.finalize().into(),
+            md5: slice_state.finalize(),
             crc32: crc.finalize(),
         }
     }
@@ -6461,7 +6463,7 @@ impl FileHasher {
         let mut md5_16k = [0u8; 16];
         md5_16k.copy_from_slice(&self.head.finalize());
         FileHashes {
-            md5_full: self.full.finalize().into(),
+            md5_full: self.full.finalize(),
             md5_16k,
             length: self.length,
         }

--- a/crates/parmesan/src/gf16_mac.rs
+++ b/crates/parmesan/src/gf16_mac.rs
@@ -62,7 +62,12 @@ pub fn mac(gf: &Gf16, dst: &mut [u8], src: &[u8], coeff: u16) {
 }
 
 fn mac_scalar(gf: &Gf16, dst: &mut [u8], src: &[u8], coeff: u16) {
-    for (d, s) in dst.chunks_exact_mut(2).zip(src.chunks_exact(2)) {
+    for (d, s) in dst
+        .as_chunks_mut::<2>()
+        .0
+        .iter_mut()
+        .zip(src.as_chunks::<2>().0)
+    {
         let sv = u16::from_le_bytes([s[0], s[1]]);
         let dv = u16::from_le_bytes([d[0], d[1]]);
         let result = dv ^ gf.mul(sv, coeff);

--- a/crates/parmesan/src/main.rs
+++ b/crates/parmesan/src/main.rs
@@ -531,7 +531,7 @@ async fn run_create(cli: CreateArgs) -> Result<()> {
         // Serialize packets in batches to exploit SIMD MD5-MB
         let recovery_packets = packet::serialize_recovery_packets(&rsid, &recovery_slices);
 
-        for (slice, pkt) in recovery_slices.iter().zip(recovery_packets.into_iter()) {
+        for (slice, pkt) in recovery_slices.iter().zip(recovery_packets) {
             let abs_exp = slice.exponent;
             // Map the absolute exponent back to a position in the layout
             // (which was planned from 0, but our exponents start at recovery_offset).

--- a/crates/parmesan/src/recovery_set.rs
+++ b/crates/parmesan/src/recovery_set.rs
@@ -359,7 +359,7 @@ fn parse_ifsc_body(body: &[u8]) -> Result<([u8; 16], Vec<SliceChecksum>)> {
         "IFSC packet body has a partial slice-checksum entry"
     );
     let mut slices = Vec::with_capacity(rest.len() / 20);
-    for chunk in rest.chunks_exact(20) {
+    for chunk in rest.as_chunks::<20>().0 {
         let mut md5 = [0u8; 16];
         md5.copy_from_slice(&chunk[0..16]);
         let crc32 = u32::from_le_bytes(chunk[16..20].try_into().unwrap());

--- a/crates/parmesan/src/shuffle2x.rs
+++ b/crates/parmesan/src/shuffle2x.rs
@@ -112,7 +112,12 @@ pub fn from_shuffle2x(src: &[u8], dst: &mut [u8]) {
 fn to_shuffle2x_scalar(src: &[u8], dst: &mut [u8]) {
     // Each 32-byte chunk: reorder [lo0,hi0,lo1,hi1,...,lo15,hi15]
     //   → [lo0,lo1,...,lo15, hi0,hi1,...,hi15]
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         for i in 0..16 {
             chunk_out[i] = chunk_in[i * 2]; // lo byte of word i
             chunk_out[16 + i] = chunk_in[i * 2 + 1]; // hi byte of word i
@@ -123,7 +128,12 @@ fn to_shuffle2x_scalar(src: &[u8], dst: &mut [u8]) {
 fn from_shuffle2x_scalar(src: &[u8], dst: &mut [u8]) {
     // Each 32-byte chunk: [lo0,...,lo15, hi0,...,hi15]
     //   → [lo0,hi0, lo1,hi1, ..., lo15,hi15]
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         for i in 0..16 {
             chunk_out[i * 2] = chunk_in[i]; // lo byte of word i
             chunk_out[i * 2 + 1] = chunk_in[16 + i]; // hi byte of word i
@@ -168,7 +178,12 @@ unsafe fn to_shuffle2x_avx2(src: &[u8], dst: &mut [u8]) {
         15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0, // lane 0
     );
 
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         let v = _mm256_loadu_si256(chunk_in.as_ptr() as *const __m256i);
         // Step 1: separate lo/hi bytes within each 128-bit lane
         let separated = _mm256_shuffle_epi8(v, sep_mask);
@@ -195,7 +210,12 @@ unsafe fn from_shuffle2x_avx2(src: &[u8], dst: &mut [u8]) {
         15, 7, 14, 6, 13, 5, 12, 4, 11, 3, 10, 2, 9, 1, 8, 0, // lane 0
     );
 
-    for (chunk_in, chunk_out) in src.chunks_exact(32).zip(dst.chunks_exact_mut(32)) {
+    for (chunk_in, chunk_out) in src
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .zip(dst.as_chunks_mut::<32>().0)
+    {
         let v = _mm256_loadu_si256(chunk_in.as_ptr() as *const __m256i);
         // Step 1: undo the permq — inverse of 0xD8 is 0x72
         // Original permq: out[0]=src[0], out[1]=src[2], out[2]=src[1], out[3]=src[3]

--- a/crates/penne/Cargo.toml
+++ b/crates/penne/Cargo.toml
@@ -20,7 +20,7 @@ name = "penne"
 path = "src/bin/penne.rs"
 
 [dependencies]
-pesto = { package = "pesto-poster", path = "../pesto", version = "0.8.0" }
+pesto = { package = "pesto-poster", path = "../pesto", version = "0.8.2" }
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,23 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-08-20
+
+### Fixed
+- **Season-mode global PAR2 no longer holds the whole recovery set in RAM (#110).** The encoder was already split into memory-budgeted read passes, but every pass's recovery slices were concatenated into one `Vec` until all volumes were written. A ~120 GB `--season` pack at `--par2 10` is ~12 GiB of recovery data — Linux overcommit allowed the allocation, then the OOM killer took the process (~17 GiB RSS) after the upload had already finished. Each pass is now appended to the volume files and dropped, matching the per-file `producer` path.
+
+## [0.8.1] — 2026-08-20
+
+### Performance
+
+- **AVX2 yEnc** (nyuu `encoder_avx_base.h` style, VBMI2 `mask_expand` + `vpternlog 0xF8`) on non-hybrid CPUs. Measured ~2312 MiB/s on c7i.
+- **AVX-512 BW + VBMI2** yEnc path added (available but not default — AVX2 wins on current hardware).
+- **IEEE CRC-32 folded into yEnc encode**: CRC is now computed during the encode pass via `crc32fast`, eliminating a second walk over the payload.
+- **encode off the POST path**: yEnc encoding now runs on a dedicated pool thread with a ready-article queue, fully decoupling CPU-bound encode from I/O-bound NNTP posting.
+- One yEnc encode thread on CPUs with ≤4 cores to avoid starvation.
+
+medialab i5-10400 post-only (0 ms): ~1050 → **1477 MiB/s** (+41%).
+
 ## [0.8.0] — 2026-08-18
 
 ### Added

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pesto-poster"
 # pesto is versioned, published, and released independently of the rest of
 # the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."
@@ -22,7 +22,7 @@ name = "pesto"
 path = "src/bin/pesto.rs"
 
 [dependencies]
-parmesan = { package = "parmesan-par2", version = "0.5.1", path = "../parmesan", default-features = false }
+parmesan = { package = "parmesan-par2", version = "0.5.2", path = "../parmesan", default-features = false }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 md-5 = "0.10"

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -3726,7 +3726,10 @@ struct SeasonFileEntry {
 /// episode so the written volumes include real File Description/IFSC
 /// packets — see [`generate_season_par2`]'s doc comment for why that matters.
 struct SeasonPar2Set {
-    recovery_slices: Vec<parmesan::encoder::RecoverySlice>,
+    /// Number of recovery blocks written (or that would be written). The
+    /// slice *bodies* are streamed to disk per pass — holding them here
+    /// is what OOM-killed a 120 GB `--season` pack (#110).
+    recovery_count: usize,
     par2_slice_size: usize,
     files: Vec<SeasonFileEntry>,
 }
@@ -3734,52 +3737,29 @@ struct SeasonPar2Set {
 impl SeasonPar2Set {
     fn empty() -> Self {
         Self {
-            recovery_slices: Vec::new(),
+            recovery_count: 0,
             par2_slice_size: 0,
             files: Vec::new(),
         }
     }
 }
 
-/// Write season PAR2 recovery volumes to disk.
-///
-/// Serializes `season` into PAR2 packet format and writes it to volume files
-/// (`{name}.vol000+001.par2`, `{name}.vol001+002.par2`, …) in the output
-/// directory. Every volume carries the full base packet set — Main (with
-/// every episode's real File ID), Creator, and one File Description + IFSC
-/// pair per episode — not just its own Recovery packets, so any single
-/// volume is self-describing. Returns (index_packet_bytes, volume_file_paths)
-/// for use in NZB generation.
-async fn write_season_par2_volumes(
-    season: &SeasonPar2Set,
-    release_name: &str,
-    output_dir: &Path,
-) -> Result<(Vec<u8>, Vec<PathBuf>)> {
-    if season.recovery_slices.is_empty() {
-        return Ok((Vec::new(), Vec::new()));
-    }
-
-    // Main packet lists every episode's real File ID — without this the
-    // recovery set describes no files at all (see `generate_season_par2`'s
-    // doc comment), and no PAR2 client can verify, repair, or de-obfuscate
-    // against it.
-    let file_ids: Vec<[u8; 16]> = season.files.iter().map(|f| f.file_id).collect();
-    let main_b = packet::main_body(season.par2_slice_size as u64, &file_ids);
+/// Packet prefix every season volume carries: Main (with every episode's
+/// File ID), Creator, and one File Description + IFSC pair per episode.
+/// Without this the recovery set describes no files at all (see
+/// `generate_season_par2`'s doc comment).
+fn season_base_packets(files: &[SeasonFileEntry], par2_slice_size: usize) -> ([u8; 16], Vec<u8>) {
+    let file_ids: Vec<[u8; 16]> = files.iter().map(|f| f.file_id).collect();
+    let main_b = packet::main_body(par2_slice_size as u64, &file_ids);
     let rsid = packet::recovery_set_id(&main_b);
 
-    // Serialize base packets (Main + Creator).
     let pkt_main = packet::serialize_packet(&rsid, &packet::TYPE_MAIN, &main_b);
     let pkt_creator =
         packet::serialize_packet(&rsid, &packet::TYPE_CREATOR, &packet::creator_body("pesto"));
     let mut base_packets = pkt_main;
     base_packets.extend(pkt_creator);
 
-    // File Description + IFSC packets, one pair per episode, each carrying
-    // its real (never obfuscated) file name — the same mechanism the
-    // per-file PAR2 path already uses (see the `FileMeta`-based loop above)
-    // so a downloader's PAR2-based de-obfuscation step works the same way
-    // for a season pack as it does for a single upload.
-    for file in &season.files {
+    for file in files {
         let pkt_file_desc = packet::serialize_packet(
             &rsid,
             &packet::TYPE_FILE_DESC,
@@ -3799,20 +3779,20 @@ async fn write_season_par2_volumes(
         base_packets.extend(pkt_file_desc);
         base_packets.extend(pkt_ifsc);
     }
+    (rsid, base_packets)
+}
 
-    // Plan volume layout.
-    let volumes = layout::plan_volumes(season.recovery_slices.len() as u32);
-    let mut volume_paths = Vec::new();
-
-    // `plan_volumes` keys "write the base packets now" off the first
-    // exponent of each volume. The worker normally emits slices in
-    // ascending exponent order; sort so a future change cannot produce a
-    // volume with no Main packet.
-    let mut slices: Vec<_> = season.recovery_slices.iter().collect();
-    slices.sort_by_key(|s| s.exponent);
-
-    let mut open: Option<(PathBuf, tokio::fs::File)> = None;
-
+/// Append one pass of recovery slices to the on-disk volume files, then drop
+/// the slice bodies. Same append-as-we-go pattern as `producer`: peak RAM is
+/// one pass of recovery data, not the whole set (#110).
+async fn append_season_recovery_slices(
+    slices: Vec<parmesan::encoder::RecoverySlice>,
+    volumes: &[layout::VolumeChunk],
+    release_name: &str,
+    output_dir: &Path,
+    rsid: &[u8; 16],
+    base_packets: &[u8],
+) -> Result<()> {
     for slice in slices {
         let vol = volumes
             .iter()
@@ -3822,32 +3802,25 @@ async fn write_season_par2_volumes(
         let vol_name = layout::volume_name(release_name, *vol);
         let vol_path = output_dir.join(&vol_name);
 
-        let need_new = open.as_ref().is_none_or(|(p, _)| p != &vol_path);
-        if need_new {
-            let mut file = tokio::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&vol_path)
-                .await?;
-            file.write_all(&base_packets).await?;
-            volume_paths.push(vol_path.clone());
-            open = Some((vol_path, file));
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(&vol_path)
+            .await?;
+
+        if slice.exponent == vol.first {
+            file.write_all(base_packets).await?;
         }
 
         let pkt = packet::serialize_packet(
-            &rsid,
+            rsid,
             &packet::TYPE_RECOVERY,
             &packet::recovery_body(slice.exponent, &slice.data),
         );
-        open.as_mut()
-            .expect("volume file opened above")
-            .1
-            .write_all(&pkt)
-            .await?;
+        file.write_all(&pkt).await?;
     }
-
-    Ok((base_packets, volume_paths))
+    Ok(())
 }
 
 /// Read every episode into `worker` as PAR2 input slices. Empty files
@@ -3903,11 +3876,13 @@ async fn feed_season_episodes(
 
 /// Generate a global PAR2 recovery set that covers all episodes in a season.
 ///
-/// Reads the episode files once, accumulates input slices into a single PAR2
-/// encoder, and returns the recovery slices *and* per-episode File IDs/hashes
-/// needed to write real File Description + IFSC packets. These can then be
-/// posted separately and combined with data segments in a consolidated
-/// season NZB.
+/// Reads the episode files (once per memory-budget pass), feeds them into a
+/// PAR2 encoder, and streams each pass's recovery slices to `output_dir`
+/// immediately — the same append-as-we-go pattern as `producer`. Holding
+/// every recovery block until the end is what OOM-killed a 120 GB `--season`
+/// pack even after the encoder itself was split into passes (#110). Also
+/// returns per-episode File IDs/hashes so each volume's base packets carry
+/// real File Description + IFSC data.
 ///
 /// This enables a coherent PAR2 recovery set ID (rsid) that covers the entire
 /// season, rather than multiple independent rsids for individual episodes —
@@ -3919,7 +3894,12 @@ async fn feed_season_episodes(
 /// — under `--obfuscate` — de-obfuscate a season pack's episodes against it.
 /// Per-episode PAR2 sets *did* carry the real name correctly, but got
 /// discarded once merged into the season NZB in favor of this global set.
-async fn generate_season_par2(episode_paths: &[PathBuf], config: &Config) -> Result<SeasonPar2Set> {
+async fn generate_season_par2(
+    episode_paths: &[PathBuf],
+    config: &Config,
+    release_name: &str,
+    output_dir: &Path,
+) -> Result<SeasonPar2Set> {
     if episode_paths.is_empty() {
         return Ok(SeasonPar2Set::empty());
     }
@@ -4009,11 +3989,15 @@ async fn generate_season_par2(episode_paths: &[PathBuf], config: &Config) -> Res
         "season PAR2 memory plan"
     );
 
-    let mut all_recovery_slices = Vec::new();
-    let mut episode_names = Vec::new();
-    let mut slices_per_episode = Vec::new();
-    let mut slice_checksums = Vec::new();
-    let mut hashes = Vec::new();
+    let volumes = layout::plan_volumes(recovery_count as u32);
+    let mut files = Vec::new();
+    let mut rsid = [0u8; 16];
+    let mut base_packets = Vec::new();
+    let mut written = 0usize;
+
+    tokio::fs::create_dir_all(output_dir)
+        .await
+        .with_context(|| format!("creating season PAR2 output dir `{}`", output_dir.display()))?;
 
     for (pass_idx, (exp_start, rec_count)) in passes.iter().copied().enumerate() {
         if rec_count == 0 {
@@ -4039,56 +4023,61 @@ async fn generate_season_par2(episode_paths: &[PathBuf], config: &Config) -> Res
             "season PAR2 pass fed"
         );
 
-        let (recovery, checksums, pass_hashes) = worker.finish();
-        all_recovery_slices.extend(recovery);
+        let (recovery, checksums, pass_hashes) = tokio::task::block_in_place(|| worker.finish());
+        written += recovery.len();
+
         if pass_idx == 0 {
-            episode_names = names;
-            slices_per_episode = slices;
-            slice_checksums = checksums;
-            hashes = pass_hashes;
+            // Reassemble per-episode File ID/hash/checksum data — same
+            // reconstruction the per-file path uses, including empty files.
+            let md5_empty: [u8; 16] = packet::md5(b"");
+            let mut hashes_iter = pass_hashes.into_iter();
+            let mut checksums_cursor = 0usize;
+            files = Vec::with_capacity(names.len());
+            for (name, slice_count) in names.into_iter().zip(slices) {
+                let fh = if slice_count == 0 {
+                    FileHashes {
+                        md5_full: md5_empty,
+                        md5_16k: md5_empty,
+                        length: 0,
+                    }
+                } else {
+                    hashes_iter
+                        .next()
+                        .expect("par2 worker returned fewer hashes than non-empty episodes")
+                };
+                let file_checksums =
+                    checksums[checksums_cursor..checksums_cursor + slice_count].to_vec();
+                checksums_cursor += slice_count;
+                let file_id = packet::compute_file_id(&fh.md5_16k, fh.length, &name);
+                files.push(SeasonFileEntry {
+                    file_id,
+                    name,
+                    hashes: fh,
+                    slice_checksums: file_checksums,
+                });
+            }
+            (rsid, base_packets) = season_base_packets(&files, par2_slice_size);
         }
+
+        append_season_recovery_slices(
+            recovery,
+            &volumes,
+            release_name,
+            output_dir,
+            &rsid,
+            &base_packets,
+        )
+        .await?;
     }
 
-    let recovery_slices = all_recovery_slices;
     info!(
-        recovery_slices = recovery_slices.len(),
+        recovery_slices = written,
+        passes = passes.len(),
         "season PAR2 generation complete"
     );
 
-    // Reassemble the per-episode File ID/hash/checksum data the caller needs
-    // to write real File Description + IFSC packets — mirroring exactly how
-    // the per-file PAR2 path (above) reconstructs `final_hashes`/`file_ids`
-    // from the worker's flat output, including the same empty-file handling.
-    let md5_empty: [u8; 16] = packet::md5(b"");
-    let mut hashes_iter = hashes.into_iter();
-    let mut checksums_cursor = 0usize;
-    let mut files = Vec::with_capacity(episode_names.len());
-    for (name, slice_count) in episode_names.into_iter().zip(slices_per_episode) {
-        let fh = if slice_count == 0 {
-            FileHashes {
-                md5_full: md5_empty,
-                md5_16k: md5_empty,
-                length: 0,
-            }
-        } else {
-            hashes_iter
-                .next()
-                .expect("par2 worker returned fewer hashes than non-empty episodes")
-        };
-        let file_checksums =
-            slice_checksums[checksums_cursor..checksums_cursor + slice_count].to_vec();
-        checksums_cursor += slice_count;
-        let file_id = packet::compute_file_id(&fh.md5_16k, fh.length, &name);
-        files.push(SeasonFileEntry {
-            file_id,
-            name,
-            hashes: fh,
-            slice_checksums: file_checksums,
-        });
-    }
-
     Ok(SeasonPar2Set {
-        recovery_slices,
+        recovery_count: written,
         par2_slice_size,
         files,
     })
@@ -4115,21 +4104,21 @@ pub async fn generate_and_write_season_par2(
 
     debug!(episodes = episode_paths.len(), "generating season PAR2");
 
-    let season = generate_season_par2(episode_paths, config).await?;
+    let season = generate_season_par2(episode_paths, config, release_name, output_dir).await?;
 
-    if season.recovery_slices.is_empty() {
+    if season.recovery_count == 0 {
         return Ok(output_dir.to_path_buf());
     }
 
     info!(
-        recovery_slices = season.recovery_slices.len(),
+        episodes = season.files.len(),
+        recovery_slices = season.recovery_count,
+        slice_size = season.par2_slice_size,
         output_dir = %output_dir.display(),
-        "writing season PAR2 volumes"
+        "season PAR2 volumes written"
     );
 
-    write_season_par2_volumes(&season, release_name, output_dir)
-        .await
-        .map(|(_, _)| output_dir.to_path_buf())
+    Ok(output_dir.to_path_buf())
 }
 
 #[cfg(test)]

--- a/crates/pesto/tests/season_par2_file_desc.rs
+++ b/crates/pesto/tests/season_par2_file_desc.rs
@@ -211,6 +211,88 @@ async fn season_par2_verifies_and_repairs_under_the_real_episode_names() {
     std::fs::remove_dir_all(&root).ok();
 }
 
+/// #110: encoder pass-splitting is not enough if every pass's recovery
+/// slices are concatenated in RAM until the end. A tiny `--par2-memory-limit`
+/// forces several passes; the volumes must still verify (and the process
+/// must not try to hold the whole recovery set at once).
+#[tokio::test(flavor = "multi_thread")]
+async fn season_par2_multi_pass_still_verifies() {
+    let root = std::env::temp_dir().join(format!(
+        "pesto_season_par2_multipass_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+
+    let episodes = [
+        ("S01E01.mkv", 0u8),
+        ("S01E02.mkv", 1u8),
+        ("S01E03.mkv", 2u8),
+    ];
+    let episode_paths: Vec<_> = episodes
+        .iter()
+        .map(|(name, seed)| {
+            let path = root.join(name);
+            std::fs::write(&path, content(*seed, 50_000)).unwrap();
+            path
+        })
+        .collect();
+
+    let mut config = season_config(4_096);
+    config.par2 = 100;
+    // 3 × 13 slices × 4 KiB ≈ 156 KiB of recovery; 32 KiB/pass → ≥5 passes.
+    config.par2_memory_limit = Some(32 * 1024);
+    config.memory_limit = Some(2_000_000);
+    let par2_dir = root.join("par2out");
+    std::fs::create_dir_all(&par2_dir).unwrap();
+
+    generate_and_write_season_par2(&episode_paths, "Season01", &par2_dir, &config)
+        .await
+        .unwrap();
+
+    let volume_files: Vec<_> = std::fs::read_dir(&par2_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("par2"))
+        .collect();
+    assert!(
+        !volume_files.is_empty(),
+        "multi-pass season PAR2 must still produce volume files"
+    );
+    for vol in &volume_files {
+        std::fs::rename(vol, root.join(vol.file_name().unwrap())).unwrap();
+    }
+    let any_volume = volume_files[0].file_name().unwrap().to_owned();
+
+    let verify = Command::new("par2")
+        .arg("verify")
+        .arg("-q")
+        .arg(&any_volume)
+        .current_dir(&root)
+        .output();
+    let verify = match verify {
+        Err(_) => {
+            eprintln!("par2cmdline not found, skipping");
+            std::fs::remove_dir_all(&root).ok();
+            return;
+        }
+        Ok(out) if out.status.code() == Some(127) => {
+            eprintln!("par2cmdline not found (exit 127), skipping");
+            std::fs::remove_dir_all(&root).ok();
+            return;
+        }
+        Ok(out) => out,
+    };
+    assert!(
+        verify.status.success(),
+        "par2 verify failed after multi-pass season generate: {}",
+        String::from_utf8_lossy(&verify.stderr)
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
 /// Regression test: the season path shares `par2_geometry_from_sizes` with
 /// the per-file path (fixing the "ignores --par2-slice-count/
 /// --par2-recovery-count" bug), but that refactor dropped the season path's

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -564,7 +564,10 @@ The budget model itself was re-derived ahead of this phase — see
    season-mode global PAR2 path (`generate_season_par2`) uses the same
    `par2_memory_plan` helper, with a connection reserve of 0 (no NNTP pool
    is open during generation), so `--memory-limit` splits the season
-   encoder into the same multi-pass schedule as a per-file run.
+   encoder into the same multi-pass schedule as a per-file run. Each pass's
+   recovery slices are appended to the volume files and dropped immediately
+   (the per-file `producer` already did this); concatenating every pass in
+   RAM until the end is what OOM-killed a 120 GB `--season` pack (#110).
 4. ⚠️ **The one correctness trap found while implementing this**:
    `Ceiling::effective` already haircuts RLIMIT_AS (`× 0.60`); naively taking
    `share_of(ceiling.effective, Par2)` and combining it with


### PR DESCRIPTION
pesto 0.8.2 / parmesan 0.5.2.

## #110

`generate_season_par2` already split the encoder by `--memory-limit` / `--par2-memory-limit` (Phase 1 / #121). After each pass it still did `all_recovery_slices.extend(recovery)` and only wrote volumes at the end.

A ~120 GB `--season` pack at `--par2 10` is ~12 GiB of recovery bodies held in RAM. Linux overcommit lets `try_new_smart` succeed; the OOM killer then takes the process (~17 GiB RSS) after every episode has already been uploaded.

Each pass is now appended to the volume files and dropped, matching the per-file `producer` path. Regression: `season_par2_multi_pass_still_verifies` forces ≥5 passes with a 32 KiB `--par2-memory-limit` and still `par2 verify`s.

## CI

Unblocks `main` after the 0.8.1 tag:

- Clippy `-D warnings`: `as_chunks` instead of constant `chunks_exact`, no `clone` on `Copy` `Md5State`
- aarch64: `flush_avx512_affine2x` is `cfg(target_arch = "x86_64")` so it no longer calls a work function that only exists on x86_64
- `crates/pesto/CHANGELOG.md` now has a `## [0.8.1]` section (the pesto-v0.8.1 GitHub Release failed on this)

Closes #110.