### PR TITLE
Document benchmark context and GFNI parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,9 @@ CPU feature detection:
 The dispatch happens in `RecoveryEncoder::flush()` (`src/par2/encoder.rs`).
 Measured throughput on an i5-14400 at 10 % redundancy, 256 MiB workload:
 
+> **Benchmark context:** these are historical microbenchmark results. CPU governor
+> and boost settings affect absolute throughput; do not compare these values directly with measurements taken under different conditions.
+
 | Path | PAR2 encode speed |
 |------|----------------:|
 | Scalar | 317 MiB/s |
@@ -538,6 +541,8 @@ pesto features a world-class yEnc encoder utilizing SIMD expansion tables
 memory bandwidth of modern CPUs.
 
 Measured throughput on an Intel i5-10400 (line length 128):
+
+> **Benchmark context:** this historical result does not record a performance-governor run. CPU governor and boost settings affect absolute throughput.
 
 | Tool | yEnc throughput |
 |------|----------------:|

--- a/bench/FINDINGS.md
+++ b/bench/FINDINGS.md
@@ -1269,6 +1269,22 @@ report:
    than the cache-overflow theory that motivated the sweep — flagged
    honestly as open. Details in §3.
 
+## 2026-08-21 release validation: GFNI large-file parity (#159)
+
+This supersedes the older GFNI conclusion above as the current c7i result. Release-validation runs used the performance governor, warm page cache, the standard scale-1.0 corpora, and official cross-tool correctness checks.
+
+| machine | SIMD | movie-1080p create result |
+|---|---|---|
+| medialab i5-10400, 6 cores | AVX2 | 17% behind ParPar; separate AVX2 work remains |
+| c5.2xlarge, 4 cores | AVX-512 without GFNI | 57% behind ParPar; not a primary target |
+| c7i.2xlarge, 4 cores | AVX-512 + GFNI | 553.2 MiB/s vs ParPar 577.8 MiB/s, 4.3% gap |
+
+The c7i target is met: movie-1080p is within 10% of ParPar, while many-small remains ahead at 464.3 versus 234.9 MiB/s.
+
+The proposed two-shuffle lead is closed: upstream ParPar uses four shuffles in its vector hot loop, matching Parmesan Shuffle2x. The shipped Affine512 packing, progressive prefetch, and batched SIMD checksum work reached parity without adding a misleading kernel.
+
+Raw release artifacts, methodology, and the matching end-to-end measurements are documented in docs/parity-roadmap.md and docs/hw-accel-roadmap.md.
+
 ---
 
 *Generated from `bench/results/medialab/20260817T015113Z/`. Reproduce with


### PR DESCRIPTION
Closes #159 and #147.

Record the current GFNI release-validation matrix in FINDINGS.md, including the c7i parity result and the resolved two-shuffle lead. Add governor context beside historical PAR2 and yEnc throughput tables in the README so their absolute figures are not read as directly comparable across CPU policies.