### PR TITLE
Release parmesan-par2 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "parmesan-par2"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/parmesan/CHANGELOG.md
+++ b/crates/parmesan/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-08-22
+
+### Added
+
+- Added byte-level `ingest_files_with_progress` callbacks so library users can report responsive progress while PAR2 sources are read.
+
+### Fixed
+
+- Kept the progress-aware ingestion API available to published pesto consumers.
+
 ## [0.5.5] — 2026-08-21
 
 ### Performance

--- a/crates/parmesan/Cargo.toml
+++ b/crates/parmesan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parmesan-par2"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 rust-version = "1.89"
 description = "Fast, standalone PAR2 (Reed-Solomon) creation, verification and repair tool"


### PR DESCRIPTION
Publish the progress-aware ingestion API required by pesto-poster 0.8.6. Full workspace pre-commit tests passed.