### PR TITLE
Release pesto-poster 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/README.md
+++ b/README.md
@@ -592,6 +592,12 @@ pesto --season ./Season01/
 pesto --season --jobs 2 ./Season01/
 ```
 
+The combined season NZB is written only when every episode is complete and
+the batch was not cancelled. `--allow-incomplete-nzb` can permit an individual
+episode NZB with confirmed-missing articles, but it never permits a partial
+combined season NZB. POST failures and inconclusive checks also block the
+combined NZB in both the CLI and UpaPasta.
+
 ### `--watch` — daemon mode
 
 ```bash
@@ -660,6 +666,14 @@ resume from a finished upload. `--resume` controls the other half: whether a
 *prior* run's saved state is actually loaded and its already-posted segments
 skipped. Without it, `pesto` always starts fresh, even if a `.pesto-state` file
 is sitting right there.
+
+Resume state also records whether each segment was confirmed and whether
+checking was disabled. A confirmed segment is skipped. With `--no-check`, a
+segment saved by a no-check run is also skipped. In every other case —
+including state written by older pesto versions before these fields existed —
+`--resume --check` first sends `STAT` for the saved `Message-ID`: `223` skips
+the segment, `430` posts it again, and an inconclusive reply leaves it
+unverified without posting a duplicate.
 
 ```bash
 pesto --resume movie.mkv
@@ -741,11 +755,31 @@ changes. This runs concurrently with the upload rather than as a separate
 pass afterward, so by the time the last file finishes posting most of the
 run's articles are typically already confirmed.
 
+The connection budget is strict. With `--connections N`, at least one slot is
+kept for posting and the check pool is capped at `N - 1`; for example,
+`--connections 10 --check-connections 10` runs with 9 check connections and
+1 posting connection. Checking therefore requires at least two total
+connections. Reposts and the final recovery pass reuse slots already held by
+the check pool and never open sockets beyond `--connections`.
+
 A miss is retried up to `--check-retries` times (default **3**, **20 s**
 apart). If it's still missing, pesto reposts it under a fresh `Message-ID`
 (so the `.nzb` stays valid) and queues the new copy for another round of
 checks. `--check-post-retries` (default **1**) caps how many times a single
 article can be reposted before it's given up on as permanently missing.
+
+Each check ends in one of three states: `223` is confirmed present; `430`
+after all retry and recovery rounds is confirmed missing; and a timeout,
+connection failure, authentication failure, or other unexpected server reply
+is **inconclusive**. An inconclusive check is not evidence that the article is
+missing, so pesto does not repost it as a confirmed miss. It blocks the NZB,
+post-upload hooks, cleanup, and a successful exit so that `--resume --check`
+can retry `STAT` for the same `Message-ID` without another `POST`.
+
+`--allow-incomplete-nzb` applies only to articles confirmed missing by `430`.
+It may publish that incomplete per-upload NZB and runs its hooks with
+`PESTO_INCOMPLETE=1`; it never overrides a POST failure or an inconclusive
+check.
 
 Disable the whole thing with `--no-check` if you'd rather skip verification
 entirely — faster, but you won't find out about missing articles until

--- a/config.example.toml
+++ b/config.example.toml
@@ -144,17 +144,22 @@ groups = ["alt.binaries.test"]
 # check_connections — number of dedicated parallel NNTP connections for the
 # streaming check queue, carved out of the connections above (not opened on
 # top of them, so the total connections used never exceeds what you
-# configured). Default: 0 (a small pool, e.g. connections=50 uses 46 for
-# posting and 4 for checking).
+# configured). At least one connection remains available for posting, so an
+# explicit value is capped at connections - 1; checking therefore requires
+# connections >= 2. Reposts and recovery reuse these slots. Default: 0 (a
+# small pool, e.g. connections=50 uses 46 for posting and 4 for checking).
 # check_connections = 0
 
 # check_post_retries — number of times to re-post an article the check queue
 # still can't find. Default: 1.
 # check_post_retries = 1
 
-# allow_incomplete_nzb — publish the NZB (and run post-upload hooks) even
-# when some articles are still confirmed missing after every
-# check_post_retries round. Default: false.
+# allow_incomplete_nzb — publish the per-upload NZB (and run post-upload hooks
+# with PESTO_INCOMPLETE=1) when articles are confirmed missing by STAT 430
+# after every retry/recovery round. It never overrides a POST failure or an
+# inconclusive check (timeout, connection/authentication failure, or an
+# unexpected server reply), and never permits a partial combined season NZB.
+# Default: false.
 # allow_incomplete_nzb = false
 
 # check_recover_percent / check_recover_max — after every check_post_retries

--- a/crates/penne/Cargo.toml
+++ b/crates/penne/Cargo.toml
@@ -20,7 +20,7 @@ name = "penne"
 path = "src/bin/penne.rs"
 
 [dependencies]
-pesto = { package = "pesto-poster", path = "../pesto", version = "0.9.0" }
+pesto = { package = "pesto-poster", path = "../pesto", version = "0.9.1" }
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,8 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-08-25
+
 ### Changed
 
 - Streaming STAT checks, reposts, and final recovery now share the strict

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,28 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Changed
+
+- Streaming STAT checks, reposts, and final recovery now share the strict
+  `--connections` budget. The check pool is capped at one fewer than the total
+  so at least one posting connection remains available; checking with only one
+  total connection is rejected.
+- Resume state now records confirmed and no-check segments. `--resume --check`
+  rechecks unconfirmed and legacy-state Message-IDs with STAT before deciding
+  whether another POST is necessary.
+- Combined `--season` NZBs are now written only when every episode is complete;
+  `--allow-incomplete-nzb` remains limited to individual episode NZBs.
+
+### Fixed
+
+- Failed STAT paths are now reported as Inconclusive instead of confirmed
+  missing. Timeouts, connection/authentication failures, and unexpected server
+  replies no longer trigger a duplicate repost, cannot be overridden by
+  `--allow-incomplete-nzb`, and block NZB output and post-upload hooks.
+- Check connections are returned to the shared pool exactly once after the
+  final drain/recovery pass, preventing both temporary socket-budget overruns
+  and lost pool capacity.
+
 ## [0.9.0] — 2026-08-24
 
 ### Changed

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -62,6 +62,7 @@ par2-avx2-gfni-unsafe = ["parmesan/par2-avx2-gfni-unsafe"]
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "macros", "time"] }
 tempfile = "3"
 proptest = "1.11.0"
+serde_json = "1"
 
 [[bench]]
 name = "par2_encoder"

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pesto-poster"
 # pesto is versioned, published, and released independently of the rest of
 # the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -1039,6 +1039,10 @@ struct UploadResult {
     groups: Vec<String>,
     cancelled: bool,
     had_failures: bool,
+    /// STAT path failed without a 430. Split from `had_failures` so a later
+    /// season-pack gate can refuse independently of MissingConfirmed.
+    #[allow(dead_code)]
+    inconclusive: Vec<String>,
     total_bytes: u64,
     nzb_path: Option<PathBuf>,
     /// The files actually posted for this entry — post-compression when
@@ -1183,6 +1187,7 @@ async fn run_single_upload(
             imdb_id: config.imdb_id.as_deref(),
             tvdb_id: config.tvdb_id.as_deref(),
             mal_id: config.mal_id.as_deref(),
+            incomplete: false,
         };
 
         // Explicit --pre-hook always runs (not suppressed by --no-hooks).
@@ -1511,13 +1516,18 @@ async fn run_single_upload(
     // `post_files_with_progress_and_cancel` already retried in-run POST
     // failures (repost_failed_tasks) and ran the streaming STAT check +
     // repost internally, concurrently with the upload. `outcome.still_missing`
-    // is the final list of articles that never got confirmed after every
-    // repost attempt.
+    // is MissingConfirmed (430); `outcome.inconclusive` is a failed check
+    // path, not a confirmed gap. Cancel drain is Inconclusive, not missing.
     let cancelled = outcome.cancelled || cancel.is_some_and(|f| f.load(Ordering::Relaxed));
     let check_missing: Vec<String> = if cancelled {
         Vec::new()
     } else {
         outcome.still_missing.clone()
+    };
+    let check_inconclusive: Vec<String> = if cancelled {
+        Vec::new()
+    } else {
+        outcome.inconclusive.clone()
     };
 
     if !params.json_mode && config.par2_only {
@@ -1578,6 +1588,20 @@ async fn run_single_upload(
                 "check: articles still missing after every repost attempt"
             );
         }
+        if !check_inconclusive.is_empty() {
+            eprintln!(
+                "check: {} article(s) inconclusive (check path failed — not a confirmed gap):",
+                check_inconclusive.len()
+            );
+            for id in &check_inconclusive {
+                eprintln!("  - {id}");
+            }
+            error!(
+                count = check_inconclusive.len(),
+                ids = ?check_inconclusive,
+                "check: articles inconclusive (check path failed — not a confirmed gap)"
+            );
+        }
     }
 
     // If segments still failed after retry, refuse to write the NZB — it
@@ -1585,14 +1609,17 @@ async fn run_single_upload(
     // posted segments so the user can continue with --resume.
     let has_post_failures =
         !outcome.failed_tasks.is_empty() && !config.dry_run && !config.par2_only;
-    // Set when a STAT pass still can't find some articles after every
-    // --check-post-retries round — a *different* kind of incompleteness
-    // than a POST that never got acknowledged at all. `--allow-incomplete-nzb`
-    // opts back into publishing only this kind of gap (e.g. relying on PAR2
-    // recovery); a genuine POST failure always blocks regardless of the flag.
+    // STAT 430-exhausted after every --check-post-retries round.
+    // `--allow-incomplete-nzb` opts back into publishing only this kind of
+    // gap; POST failures and Inconclusive always block.
     let has_confirmed_missing = !check_missing.is_empty() && !config.dry_run && !config.par2_only;
-    let has_unrecoverable_failures =
-        has_post_failures || (has_confirmed_missing && !config.allow_incomplete_nzb);
+    let has_inconclusive = !check_inconclusive.is_empty() && !config.dry_run && !config.par2_only;
+    let has_unrecoverable_failures = pesto::poster::nzb_write_decision(
+        has_post_failures,
+        has_confirmed_missing,
+        has_inconclusive,
+        config.allow_incomplete_nzb,
+    ) == pesto::poster::NzbWriteDecision::Refuse;
     let files_str = || {
         entry_paths
             .iter()
@@ -1654,6 +1681,25 @@ async fn run_single_upload(
                 eprintln!("  {}", state_path.display());
                 eprintln!("  pesto {} --resume {}", files_str(), resume_flags_str());
             }
+        }
+        eprintln!();
+    }
+    if has_inconclusive {
+        let n = check_inconclusive.len();
+        eprintln!();
+        eprintln!("error: {n} article(s) inconclusive (check path failed — not a confirmed gap).");
+        eprintln!(
+            "The NZB will NOT be written — --allow-incomplete-nzb does not apply to \
+             an unverified check path."
+        );
+        if let Some(ref state_path) = resume_path {
+            eprintln!();
+            eprintln!(
+                "Retry with --resume --check to re-STAT the same Message-IDs \
+                 (no second POST):"
+            );
+            eprintln!("  {}", state_path.display());
+            eprintln!("  pesto {} --resume {}", files_str(), resume_flags_str());
         }
         eprintln!();
     }
@@ -1814,8 +1860,10 @@ async fn run_single_upload(
         // Reflects true completeness, independent of --allow-incomplete-nzb —
         // the notification should say "not fully ok" even when the user
         // chose to publish anyway.
-        let had_failures =
-            !outcome.failures.is_empty() || has_post_failures || has_confirmed_missing;
+        let had_failures = !outcome.failures.is_empty()
+            || has_post_failures
+            || has_confirmed_missing
+            || has_inconclusive;
         pesto::notify::send_all(&pesto::notify::NotifyConfig {
             webhook_url: config.notify_webhook.as_deref(),
             ntfy_topic: config.notify_ntfy.as_deref(),
@@ -1942,6 +1990,7 @@ async fn run_single_upload(
             imdb_id: config.imdb_id.as_deref(),
             tvdb_id: config.tvdb_id.as_deref(),
             mal_id: config.mal_id.as_deref(),
+            incomplete: has_confirmed_missing,
         };
 
         run_all_hooks(config, &hook_env);
@@ -1985,8 +2034,10 @@ async fn run_single_upload(
     }
 
     // Apply cleanup only if upload succeeded completely (no failures/cancellation).
-    let no_failures =
-        outcome.failures.is_empty() && check_missing.is_empty() && !has_unrecoverable_failures;
+    let no_failures = outcome.failures.is_empty()
+        && check_missing.is_empty()
+        && check_inconclusive.is_empty()
+        && !has_unrecoverable_failures;
     let should_cleanup = !cancelled && no_failures;
 
     if should_cleanup {
@@ -2003,7 +2054,9 @@ async fn run_single_upload(
         cancelled,
         had_failures: !outcome.failures.is_empty()
             || !check_missing.is_empty()
+            || !check_inconclusive.is_empty()
             || has_unrecoverable_failures,
+        inconclusive: check_inconclusive,
         total_bytes,
         nzb_path: nzb_reported_path,
         posted_paths,
@@ -2705,6 +2758,7 @@ async fn run_batch(
                 imdb_id: config.imdb_id.as_deref(),
                 tvdb_id: config.tvdb_id.as_deref(),
                 mal_id: config.mal_id.as_deref(),
+                incomplete: false,
             };
             // Skip hooks for --dry-run / --par2-only: no real upload happened.
             if !config.dry_run && !config.par2_only {
@@ -3924,6 +3978,8 @@ struct HookEnv<'a> {
     tvdb_id: Option<&'a str>,
     /// MyAnimeList ID (`--mal-id`).
     mal_id: Option<&'a str>,
+    /// True when the NZB was published despite MissingConfirmed.
+    incomplete: bool,
 }
 
 fn apply_hook_env(child: &mut std::process::Command, env: &HookEnv<'_>) {
@@ -3960,6 +4016,7 @@ fn apply_hook_env(child: &mut std::process::Command, env: &HookEnv<'_>) {
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_default(),
     );
+    child.env("PESTO_INCOMPLETE", if env.incomplete { "1" } else { "0" });
 }
 
 /// Execute a shell command as a pre-upload hook.

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -1039,9 +1039,8 @@ struct UploadResult {
     groups: Vec<String>,
     cancelled: bool,
     had_failures: bool,
-    /// STAT path failed without a 430. Split from `had_failures` so a later
+    /// STAT path failed without a 430. Split from `had_failures` so the
     /// season-pack gate can refuse independently of MissingConfirmed.
-    #[allow(dead_code)]
     inconclusive: Vec<String>,
     total_bytes: u64,
     nzb_path: Option<PathBuf>,
@@ -2529,7 +2528,11 @@ async fn run_batch(
                 if result.cancelled {
                     any_cancelled = true;
                 }
-                if result.had_failures {
+                // Pack completeness is independent of --allow-incomplete-nzb
+                // (that flag is per-episode). had_failures already covers
+                // MissingConfirmed; inconclusive is OR'd so Inconclusive
+                // still blocks if the two ever diverge.
+                if result.had_failures || !result.inconclusive.is_empty() {
                     any_failures = true;
                 }
                 posted_episode_paths.extend(result.posted_paths);
@@ -2556,10 +2559,13 @@ async fn run_batch(
     info!(entries = total_entries, "--each complete");
 
     // Write consolidated season NZB (and matching .nfo + hooks) when requested.
+    // The pack is a distinct artefact: --allow-incomplete-nzb never unlocks it.
     if let Some(season_path) = season_nzb {
-        if any_cancelled {
-            eprintln!("interrupted — skipping season nzb output");
-        } else if !all_segments.is_empty() {
+        if pesto::poster::should_write_season_nzb(
+            any_cancelled,
+            any_failures,
+            all_segments.is_empty(),
+        ) {
             info!(entries = total_entries, path = %season_path.display(), "season merge starting");
             let config = &params.config;
             let season_name = config.nzb_title.clone().or_else(|| {
@@ -2764,6 +2770,8 @@ async fn run_batch(
             if !config.dry_run && !config.par2_only {
                 run_all_hooks(config, &hook_env);
             }
+        } else if any_cancelled {
+            eprintln!("interrupted — skipping season nzb output");
         } else if any_failures {
             eprintln!("error: season pack was not created due to earlier upload failures");
         } else {

--- a/crates/pesto/src/config/types.rs
+++ b/crates/pesto/src/config/types.rs
@@ -642,19 +642,19 @@ impl Config {
 
     /// Desired number of dedicated connections for the streaming check
     /// queue, before the caller bounds it against the configured total
-    /// (`post_files_with_progress_and_cancel` carves this out of
-    /// `total_connections()` rather than opening it on top — see there for
-    /// why). `0` resolves to a small pool sized as a *fraction* of the
-    /// total (roughly 8%, capped at 4) rather than a flat number — a flat
-    /// cap of 4 is a sensible ~8% at a real-world `connections=50` (checked
-    /// against production traffic: STAT's cost is small enough relative to
-    /// POST that 4 dedicated connections comfortably keep up with 46
-    /// posting connections), but at a low total like `connections=4` a flat
-    /// 4 would try to reserve the *entire* pool for checking and leave
-    /// nothing for uploading. Scaling with the total avoids that: checking
-    /// gets at least 1 connection once there's more than one to spare, and
-    /// tops out at 4 once the total is large enough that 4 is already a
-    /// small slice of it.
+    /// (`split_connections` carves this out of `total_connections()` rather
+    /// than opening it on top — explicit N is `N.min(total.saturating_sub(1))`,
+    /// never additive). `0` means auto, not off: a small pool sized as a
+    /// *fraction* of the total (roughly 8%, capped at 4) rather than a flat
+    /// number — a flat cap of 4 is a sensible ~8% at a real-world
+    /// `connections=50` (checked against production traffic: STAT's cost is
+    /// small enough relative to POST that 4 dedicated connections
+    /// comfortably keep up with 46 posting connections), but at a low total
+    /// like `connections=4` a flat 4 would try to reserve the *entire* pool
+    /// for checking and leave nothing for uploading. Scaling with the total
+    /// avoids that: checking gets at least 1 connection once there's more
+    /// than one to spare, and tops out at 4 once the total is large enough
+    /// that 4 is already a small slice of it. Off is `check == false`.
     pub fn effective_check_connections(&self) -> usize {
         if self.check_connections == 0 {
             let total = self.total_connections();

--- a/crates/pesto/src/hooks.rs
+++ b/crates/pesto/src/hooks.rs
@@ -12,7 +12,7 @@
 //! `PESTO_NAME`, `PESTO_BYTES`, `PESTO_INPUT_PATHS`, `PESTO_SERVER`,
 //! `PESTO_SERVERS`, `PESTO_GROUP`, `PESTO_GROUPS`, `PESTO_PASSWORD`, `PESTO_NZB`, `PESTO_NFO`,
 //! `PESTO_CATEGORY`, `PESTO_NZB_TITLE`, `PESTO_OBFUSCATE`, `PESTO_PAR2`,
-//! `PESTO_TAGS`, `PESTO_WIRE_SUBJECT`. `PESTO_NZB_NAME` is also set, as a
+//! `PESTO_TAGS`, `PESTO_WIRE_SUBJECT`, `PESTO_INCOMPLETE`. `PESTO_NZB_NAME` is also set, as a
 //! deprecated alias of `PESTO_NZB_TITLE` with the same value — see
 //! [`HookContext::nzb_title`].
 
@@ -56,6 +56,9 @@ pub struct HookContext {
     /// this differs from the real filename the `.nzb` carries; empty when
     /// no segments were posted.
     pub wire_subject: String,
+    /// True when the NZB was published despite MissingConfirmed
+    /// (`--allow-incomplete-nzb`). Hooks see `PESTO_INCOMPLETE=1`.
+    pub incomplete: bool,
 }
 
 /// Run all configured post-upload hooks.
@@ -252,7 +255,8 @@ fn apply_env(cmd: &mut Command, ctx: &HookContext) {
         .env("PESTO_TAGS", &ctx.tags)
         .env("PESTO_NZB", &ctx.nzb_path)
         .env("PESTO_NFO", &ctx.nfo_path)
-        .env("PESTO_WIRE_SUBJECT", &ctx.wire_subject);
+        .env("PESTO_WIRE_SUBJECT", &ctx.wire_subject)
+        .env("PESTO_INCOMPLETE", if ctx.incomplete { "1" } else { "0" });
 }
 
 #[cfg(unix)]

--- a/crates/pesto/src/nntp/pool.rs
+++ b/crates/pesto/src/nntp/pool.rs
@@ -8,7 +8,7 @@
 //! shifts to a healthy server automatically.
 
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Instant;
 
 use anyhow::Result;
@@ -35,6 +35,12 @@ pub struct ConnectionSlot {
     slot_id: usize,
     /// Reason for the next connection attempt; "initial" until first invalidate.
     next_connect_reason: &'static str,
+    /// Set while this slot is checked out of a [`ConnectionBroker`]. Drop
+    /// replenishes the idle pool if the slot never makes it back through
+    /// [`ConnectionBroker::checkin`] (a panicking worker), so `--jobs`
+    /// cannot deadlock on a leaked permit. `Weak` so an idle slot that
+    /// still holds this cannot keep the broker alive.
+    broker: Option<Weak<ConnectionBroker>>,
 }
 
 impl ConnectionSlot {
@@ -49,6 +55,7 @@ impl ConnectionSlot {
             server_idx: primary_idx,
             slot_id,
             next_connect_reason: "initial",
+            broker: None,
         }
     }
 
@@ -165,6 +172,37 @@ impl ConnectionSlot {
     }
 }
 
+impl Drop for ConnectionSlot {
+    fn drop(&mut self) {
+        let Some(weak) = self.broker.take() else {
+            return;
+        };
+        let Some(broker) = weak.upgrade() else {
+            return;
+        };
+        // The live TCP, if any, is abandoned — this path is a panic or a
+        // forgotten checkin, not a clean shutdown.
+        self.conn = None;
+        let replacement =
+            ConnectionSlot::with_id(Arc::clone(&self.servers), self.server_idx, self.slot_id);
+        if let Ok(mut idle) = broker.idle.try_lock() {
+            idle.push_back((replacement, Instant::now()));
+            broker.permits.add_permits(1);
+            return;
+        }
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                broker
+                    .idle
+                    .lock()
+                    .await
+                    .push_back((replacement, Instant::now()));
+                broker.permits.add_permits(1);
+            });
+        }
+    }
+}
+
 /// A fixed set of [`ConnectionSlot`]s — one per posting worker — distributed
 /// across the configured servers by connection quota.
 pub struct ConnectionPool {
@@ -212,7 +250,9 @@ const BROKER_IDLE_POLL: Duration = Duration::from_secs(2);
 /// only after drain + recover. Two sequential checkouts of the same episode
 /// deadlock `--jobs` (FIFO `acquire_many`): the next episode can sneak a
 /// partial checkout in between. Checkin-then-checkout of the post slots
-/// for `scale_up` is the same trap.
+/// for `scale_up` is the same trap. A panicking worker that drops its slot
+/// without checkin is covered by [`ConnectionSlot`]'s Drop, which puts a
+/// replacement in the idle pool so the next episode is not stuck forever.
 ///
 /// Known limitation: a check worker may [`ConnectionSlot::retarget`] onto
 /// the server that accepted a given article, so the process-wide cap of
@@ -271,13 +311,19 @@ impl ConnectionBroker {
     /// broker's whole capacity is currently checked out elsewhere (this is
     /// how concurrent `--jobs` episodes end up sharing one fixed connection
     /// budget instead of each opening their own).
-    pub async fn checkout(&self, n: usize) -> Vec<ConnectionSlot> {
+    ///
+    /// Each returned slot holds a weak pointer back to this broker. If the
+    /// slot is dropped without [`checkin`][Self::checkin] (a panicking
+    /// worker), [`ConnectionSlot`]'s Drop puts a fresh idle slot back so
+    /// the next episode's `checkout` cannot wait forever.
+    pub async fn checkout(self: &Arc<Self>, n: usize) -> Vec<ConnectionSlot> {
         if n == 0 {
             return Vec::new();
         }
         // Acquired permits are intentionally leaked (not held/released via
         // guard) — capacity is returned to the semaphore explicitly by
-        // `checkin`, once each slot actually comes back.
+        // `checkin`, once each slot actually comes back. Drop of a
+        // checked-out slot also returns a permit, via the idle replenish.
         self.permits
             .acquire_many(n as u32)
             .await
@@ -286,9 +332,12 @@ impl ConnectionBroker {
         let mut idle = self.idle.lock().await;
         (0..n)
             .map(|_| {
-                idle.pop_front()
+                let mut slot = idle
+                    .pop_front()
                     .expect("permits guarantee a matching idle slot")
-                    .0
+                    .0;
+                slot.broker = Some(Arc::downgrade(self));
+                slot
             })
             .collect()
     }
@@ -296,7 +345,8 @@ impl ConnectionBroker {
     /// Return a checked-out connection to the idle pool instead of closing
     /// it, so a later `checkout` (the next episode, or another concurrent
     /// one) can reuse it without reconnecting.
-    pub async fn checkin(&self, slot: ConnectionSlot) {
+    pub async fn checkin(&self, mut slot: ConnectionSlot) {
+        slot.broker = None;
         self.idle.lock().await.push_back((slot, Instant::now()));
         self.permits.add_permits(1);
     }
@@ -509,6 +559,19 @@ mod tests {
 
         let slots_again = broker.checkout(1).await;
         assert_eq!(slots_again.len(), 1);
+        keepalive.abort();
+    }
+
+    #[tokio::test]
+    async fn dropping_a_checked_out_slot_returns_capacity() {
+        let (broker, keepalive) = ConnectionBroker::new(arc(vec![server(1)]), 1, 0);
+        let slots = broker.checkout(1).await;
+        drop(slots);
+        let resumed = tokio::time::timeout(Duration::from_millis(100), broker.checkout(1)).await;
+        assert!(
+            resumed.is_ok(),
+            "dropping a checked-out slot must replenish the broker so --jobs cannot deadlock"
+        );
         keepalive.abort();
     }
 

--- a/crates/pesto/src/nntp/pool.rs
+++ b/crates/pesto/src/nntp/pool.rs
@@ -38,10 +38,6 @@ pub struct ConnectionSlot {
 }
 
 impl ConnectionSlot {
-    pub(crate) fn new(servers: Arc<Vec<ServerEntry>>, primary_idx: usize) -> Self {
-        ConnectionSlot::with_id(servers, primary_idx, 0)
-    }
-
     pub(crate) fn with_id(
         servers: Arc<Vec<ServerEntry>>,
         primary_idx: usize,
@@ -210,6 +206,19 @@ const BROKER_IDLE_POLL: Duration = Duration::from_secs(2);
 /// task sends periodic keepalives to slots sitting idle in the broker
 /// between episodes, the same way a posting worker already does for slots
 /// idle *within* a run.
+///
+/// Callers must check out an episode's full budget (`check + upload`) in
+/// **one** [`checkout`][Self::checkout] and check the whole set back in
+/// only after drain + recover. Two sequential checkouts of the same episode
+/// deadlock `--jobs` (FIFO `acquire_many`): the next episode can sneak a
+/// partial checkout in between. Checkin-then-checkout of the post slots
+/// for `scale_up` is the same trap.
+///
+/// Known limitation: a check worker may [`ConnectionSlot::retarget`] onto
+/// the server that accepted a given article, so the process-wide cap of
+/// `capacity` sockets can still concentrate on one `[[servers]]` host whose
+/// own `connections` quota is smaller. Per-server carve-out would need a
+/// new knob; this broker only enforces the process total.
 pub struct ConnectionBroker {
     idle: Mutex<VecDeque<(ConnectionSlot, Instant)>>,
     permits: Semaphore,
@@ -290,6 +299,14 @@ impl ConnectionBroker {
     pub async fn checkin(&self, slot: ConnectionSlot) {
         self.idle.lock().await.push_back((slot, Instant::now()));
         self.permits.add_permits(1);
+    }
+
+    /// Return every slot in `slots` to the idle pool. One call at episode
+    /// end, after drain + recover — never between post-join and `scale_up`.
+    pub async fn checkin_all(&self, slots: impl IntoIterator<Item = ConnectionSlot>) {
+        for slot in slots {
+            self.checkin(slot).await;
+        }
     }
 
     /// Send `QUIT` on every idle connection. Call once, after every checked
@@ -415,13 +432,13 @@ mod tests {
 
     #[test]
     fn slot_starts_at_primary_server() {
-        let slot = ConnectionSlot::new(arc(vec![server(2), server(2)]), 1);
+        let slot = ConnectionSlot::with_id(arc(vec![server(2), server(2)]), 1, 0);
         assert_eq!(slot.server_idx(), 1);
     }
 
     #[test]
     fn slot_invalidate_rotates_to_next_server() {
-        let mut slot = ConnectionSlot::new(arc(vec![server(1), server(1), server(1)]), 0);
+        let mut slot = ConnectionSlot::with_id(arc(vec![server(1), server(1), server(1)]), 0, 0);
         slot.invalidate("test");
         assert_eq!(slot.server_idx(), 1);
         slot.invalidate("test");
@@ -435,7 +452,7 @@ mod tests {
         let mut servers = vec![server(1), server(1)];
         servers[0].retry_delay = 5;
         servers[1].retry_delay = 10;
-        let mut slot = ConnectionSlot::new(arc(servers), 0);
+        let mut slot = ConnectionSlot::with_id(arc(servers), 0, 0);
         assert_eq!(slot.retry_delay(), Duration::from_secs(5));
         slot.invalidate("test");
         assert_eq!(slot.retry_delay(), Duration::from_secs(10));
@@ -444,7 +461,7 @@ mod tests {
     #[test]
     fn slot_quit_when_not_connected_is_noop() {
         // Should not panic when there is no open connection.
-        let slot = ConnectionSlot::new(arc(vec![server(1)]), 0);
+        let slot = ConnectionSlot::with_id(arc(vec![server(1)]), 0, 0);
         // Can't call async quit in a sync test, but we can verify the slot
         // has no connection to begin with.
         assert!(slot.conn.is_none());

--- a/crates/pesto/src/nntp/pool.rs
+++ b/crates/pesto/src/nntp/pool.rs
@@ -345,9 +345,15 @@ impl ConnectionBroker {
     /// Return a checked-out connection to the idle pool instead of closing
     /// it, so a later `checkout` (the next episode, or another concurrent
     /// one) can reuse it without reconnecting.
+    ///
+    /// The Drop lease stays armed until the slot is in `idle`. Cancelling
+    /// this call at `idle.lock()` therefore still replenishes via Drop,
+    /// instead of leaking a `--jobs` permit.
     pub async fn checkin(&self, mut slot: ConnectionSlot) {
+        let mut idle = self.idle.lock().await;
         slot.broker = None;
-        self.idle.lock().await.push_back((slot, Instant::now()));
+        idle.push_back((slot, Instant::now()));
+        drop(idle);
         self.permits.add_permits(1);
     }
 
@@ -571,6 +577,32 @@ mod tests {
         assert!(
             resumed.is_ok(),
             "dropping a checked-out slot must replenish the broker so --jobs cannot deadlock"
+        );
+        keepalive.abort();
+    }
+
+    #[tokio::test]
+    async fn cancelled_checkin_still_returns_capacity() {
+        let (broker, keepalive) = ConnectionBroker::new(arc(vec![server(1)]), 1, 0);
+        let mut slots = broker.checkout(1).await;
+        let slot = slots.pop().unwrap();
+
+        // Hold idle so checkin blocks on the mutex; aborting then drops the
+        // slot while the lease is still armed.
+        let hold = broker.idle.lock().await;
+        let broker_for_checkin = broker.clone();
+        let checkin_task = tokio::spawn(async move {
+            broker_for_checkin.checkin(slot).await;
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        checkin_task.abort();
+        let _ = checkin_task.await;
+        drop(hold);
+
+        let resumed = tokio::time::timeout(Duration::from_millis(200), broker.checkout(1)).await;
+        assert!(
+            resumed.is_ok(),
+            "aborting checkin while idle is locked must still replenish via Drop"
         );
         keepalive.abort();
     }

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -119,6 +119,9 @@ struct Inner {
     groups: Vec<String>,
     results: Arc<Mutex<Vec<PostedSegment>>>,
     still_missing: Mutex<Vec<String>>,
+    /// STAT transport/auth/timeout/unexpected-code exhausted retries, or
+    /// a cancel drain of the queue. Distinct from `still_missing` (430).
+    inconclusive: Mutex<Vec<String>>,
     events: Option<ProgressSender>,
     cancel: Option<Arc<AtomicBool>>,
     servers: Arc<Vec<crate::config::ServerEntry>>,
@@ -133,8 +136,6 @@ struct Inner {
     /// simplicity.
     first_checks: AtomicUsize,
     first_misses: AtomicUsize,
-    /// Articles whose STAT path exhausted retries with `Err`, not 430.
-    inconclusive_count: AtomicUsize,
     resume: Option<Arc<Mutex<ResumeState>>>,
 }
 
@@ -264,14 +265,10 @@ impl CheckCoordinatorHandle {
 
     /// Close the input (no more segments will be queued) and wait for every
     /// queued/in-flight article to resolve — verified, reposted-and-verified,
-    /// or given up on. Returns the Message-IDs that could never be confirmed
-    /// and the slots every worker held, still in budget, for the caller to
-    /// hand to [`recover_missing`] or check in as a single set.
-    ///
-    /// A panicking worker's `JoinError` drops its slot; if that slot was
-    /// broker-checked-out, [`ConnectionSlot`]'s Drop replenishes the idle
-    /// pool so `--jobs` cannot deadlock on a leaked permit.
-    pub async fn finish_and_drain(mut self) -> (Vec<String>, Vec<ConnectionSlot>) {
+    /// given up on as a confirmed 430 miss, or left inconclusive. `failed`
+    /// on `CheckDone` is the MissingConfirmed count only. The slots remain
+    /// checked out for recovery and are returned to the caller as one set.
+    pub async fn finish_and_drain(mut self) -> CheckDrain {
         drop(self.tx.take());
         let _ = self.feeder.await;
         let mut slots = Vec::with_capacity(self.workers.len());
@@ -281,11 +278,27 @@ impl CheckCoordinatorHandle {
             }
         }
         let still_missing = self.inner.still_missing.lock().unwrap().clone();
+        let inconclusive = self.inner.inconclusive.lock().unwrap().clone();
         self.inner.emit(ProgressEvent::CheckDone {
             failed: still_missing.len() as u64,
         });
-        (still_missing, slots)
+        CheckDrain {
+            still_missing,
+            inconclusive,
+            slots,
+        }
     }
+}
+
+/// Result of draining the streaming STAT queue.
+#[derive(Default)]
+pub struct CheckDrain {
+    /// STAT 430 exhausted every retry/repost. MissingConfirmed.
+    pub still_missing: Vec<String>,
+    /// STAT path failed without a 430 (transport, timeout, 480/502, cancel).
+    pub inconclusive: Vec<String>,
+    /// Slots owned by the completed workers, still within the run's budget.
+    pub slots: Vec<ConnectionSlot>,
 }
 
 /// Spawn the streaming check coordinator: a feeder task that queues incoming
@@ -316,6 +329,7 @@ pub fn spawn_check_coordinator(
         groups,
         results,
         still_missing: Mutex::new(Vec::new()),
+        inconclusive: Mutex::new(Vec::new()),
         events,
         cancel,
         servers,
@@ -323,7 +337,6 @@ pub fn spawn_check_coordinator(
         reposted_count: AtomicUsize::new(0),
         first_checks: AtomicUsize::new(0),
         first_misses: AtomicUsize::new(0),
-        inconclusive_count: AtomicUsize::new(0),
         resume,
     });
 
@@ -379,13 +392,14 @@ async fn check_worker(
 
     loop {
         if inner.is_cancelled() {
-            // Drain whatever remains without further network calls so
-            // `finish_and_drain` doesn't hang waiting on cancelled work.
+            // Drain without further network calls so `finish_and_drain`
+            // doesn't hang. Cancel is Inconclusive, not MissingConfirmed:
+            // the check simply did not finish, so `--resume --check` re-STATs.
             for heap in &inner.heaps {
                 let mut heap = heap.lock().unwrap();
                 while let Some(item) = heap.pop() {
                     inner
-                        .still_missing
+                        .inconclusive
                         .lock()
                         .unwrap()
                         .push(item.seg.message_id.clone());
@@ -543,15 +557,28 @@ async fn process_item(
                 });
                 return;
             }
-            // Distinct from a 430 miss: STAT itself never completed.
-            let count = inner.inconclusive_count.fetch_add(1, Ordering::Relaxed) + 1;
-            inner.emit(ProgressEvent::CheckInconclusive {
-                count: count as u64,
-                reason: "connection error",
-            });
-            handle_confirmed_miss(inner, slot, worker_idx, item).await;
+            // Exhausted STAT retries without ever seeing 430 — the article
+            // may well be on the server; the check path died. Do not repost
+            // and do not classify as MissingConfirmed.
+            mark_inconclusive(inner, item.seg.message_id, "connection error");
         }
     }
+}
+
+fn mark_inconclusive(inner: &Inner, message_id: String, reason: &'static str) {
+    let count = {
+        let mut list = inner.inconclusive.lock().unwrap();
+        list.push(message_id);
+        list.len()
+    };
+    warn!(
+        count,
+        reason, "check: article inconclusive (check path failed — not a confirmed gap)"
+    );
+    inner.emit(ProgressEvent::Status {
+        text: format!("check: {count} inconclusive (check path failed — not a confirmed gap)"),
+    });
+    inner.in_flight.fetch_sub(1, Ordering::AcqRel);
 }
 
 /// An article's current posted copy has exhausted its STAT attempts. Repost
@@ -617,17 +644,22 @@ async fn handle_confirmed_miss(
                 error = %e,
                 "check: repost failed; giving up on this article"
             );
-            inner
-                .still_missing
-                .lock()
-                .unwrap()
-                .push(item.seg.message_id.clone());
-            let checked = inner.checked_count.fetch_add(1, Ordering::Relaxed) + 1;
-            inner.emit(ProgressEvent::CheckProgress {
-                checked: checked as u64,
-                ok: false,
-            });
-            inner.in_flight.fetch_sub(1, Ordering::AcqRel);
+            if is_post_refusal(&e) {
+                inner
+                    .still_missing
+                    .lock()
+                    .unwrap()
+                    .push(item.seg.message_id.clone());
+                let checked = inner.checked_count.fetch_add(1, Ordering::Relaxed) + 1;
+                inner.emit(ProgressEvent::CheckProgress {
+                    checked: checked as u64,
+                    ok: false,
+                });
+                inner.in_flight.fetch_sub(1, Ordering::AcqRel);
+            } else {
+                // Transport/timeout on the POST itself is not a 430 gap.
+                mark_inconclusive(inner, item.seg.message_id, "repost connection error");
+            }
         }
     }
 }
@@ -738,6 +770,24 @@ async fn repost_one(
     Err(last_err)
 }
 
+/// True when a repost failed because the server refused the article (441/4xx),
+/// not because the check/post path itself died. Refusals stay MissingConfirmed;
+/// transport errors are Inconclusive.
+fn is_post_refusal(err: &anyhow::Error) -> bool {
+    let s = err.to_string();
+    s.contains("441") || s.contains("rejected by server") || s.contains("unexpected POST")
+}
+
+/// Recovered (STAT 223) vs STAT-`Err` subsets of a recovery pass.
+/// Anything in neither is still MissingConfirmed (430, or the recovery POST
+/// itself failed). Recovery never runs on articles that were already
+/// Inconclusive — the caller only passes MissingConfirmed.
+pub(crate) struct RecoverOutcome {
+    pub recovered: Vec<PostedSegment>,
+    pub inconclusive: Vec<PostedSegment>,
+    pub slots: Vec<ConnectionSlot>,
+}
+
 /// One extra, bounded recovery attempt for articles that are still missing
 /// after every `check_post_retries` round already ran out — the caller (see
 /// `poster::maybe_recover_missing`) has already decided this batch is small
@@ -768,9 +818,13 @@ pub(crate) async fn recover_missing(
     segments: Vec<PostedSegment>,
     events: Option<&ProgressSender>,
     mut slots: Vec<ConnectionSlot>,
-) -> (Vec<PostedSegment>, Vec<ConnectionSlot>) {
+) -> RecoverOutcome {
     if segments.is_empty() || slots.is_empty() {
-        return (Vec::new(), slots);
+        return RecoverOutcome {
+            recovered: Vec::new(),
+            inconclusive: Vec::new(),
+            slots,
+        };
     }
 
     let total = segments.len() as u64;
@@ -784,6 +838,7 @@ pub(crate) async fn recover_missing(
     let queue = Arc::new(Mutex::new(segments));
     let done = Arc::new(AtomicUsize::new(0));
     let recovered = Arc::new(Mutex::new(Vec::with_capacity(total as usize)));
+    let inconclusive = Arc::new(Mutex::new(Vec::new()));
 
     let mut workers = Vec::with_capacity(n_workers);
     for mut slot in work_slots {
@@ -792,6 +847,7 @@ pub(crate) async fn recover_missing(
         let queue = Arc::clone(&queue);
         let done = Arc::clone(&done);
         let recovered = Arc::clone(&recovered);
+        let inconclusive = Arc::clone(&inconclusive);
         let events = events.cloned();
 
         workers.push(tokio::spawn(async move {
@@ -804,19 +860,38 @@ pub(crate) async fn recover_missing(
                 let ok = match repost_one(&config, &mut slot, &seg, &groups).await {
                     Ok(new_seg) => {
                         tokio::time::sleep(Duration::from_secs(config.check_delay_secs)).await;
-                        let confirmed = match slot.ensure_connected().await {
-                            Ok(conn) => conn.stat(&new_seg.message_id).await.unwrap_or(false),
-                            Err(_) => false,
-                        };
-                        if confirmed {
-                            recovered.lock().unwrap().push(new_seg);
-                            true
-                        } else {
-                            warn!(
-                                id = %new_seg.message_id,
-                                "check: recovery repost accepted but not confirmed on final STAT"
-                            );
-                            false
+                        match slot.ensure_connected().await {
+                            Ok(conn) => match conn.stat(&new_seg.message_id).await {
+                                Ok(true) => {
+                                    recovered.lock().unwrap().push(new_seg);
+                                    true
+                                }
+                                Ok(false) => {
+                                    warn!(
+                                        id = %new_seg.message_id,
+                                        "check: recovery repost accepted but STAT 430 on final check"
+                                    );
+                                    false
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        id = %new_seg.message_id,
+                                        error = %e,
+                                        "check: recovery STAT error; classifying as inconclusive"
+                                    );
+                                    inconclusive.lock().unwrap().push(new_seg);
+                                    false
+                                }
+                            },
+                            Err(e) => {
+                                warn!(
+                                    id = %new_seg.message_id,
+                                    error = %e,
+                                    "check: recovery STAT connect error; classifying as inconclusive"
+                                );
+                                inconclusive.lock().unwrap().push(new_seg);
+                                false
+                            }
                         }
                     }
                     Err(e) => {
@@ -850,11 +925,17 @@ pub(crate) async fn recover_missing(
         }
     }
 
-    let recovered = Arc::try_unwrap(recovered)
-        .expect("every worker task has finished by now")
-        .into_inner()
-        .unwrap();
-    (recovered, slots)
+    RecoverOutcome {
+        recovered: Arc::try_unwrap(recovered)
+            .expect("every worker task has finished by now")
+            .into_inner()
+            .unwrap(),
+        inconclusive: Arc::try_unwrap(inconclusive)
+            .expect("every worker task has finished by now")
+            .into_inner()
+            .unwrap(),
+        slots,
+    }
 }
 
 #[cfg(test)]

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -132,6 +132,8 @@ struct Inner {
     /// simplicity.
     first_checks: AtomicUsize,
     first_misses: AtomicUsize,
+    /// Articles whose STAT path exhausted retries with `Err`, not 430.
+    inconclusive_count: AtomicUsize,
 }
 
 impl Inner {
@@ -300,6 +302,7 @@ pub fn spawn_check_coordinator(
         reposted_count: AtomicUsize::new(0),
         first_checks: AtomicUsize::new(0),
         first_misses: AtomicUsize::new(0),
+        inconclusive_count: AtomicUsize::new(0),
     });
 
     let (tx, mut rx) = mpsc::unbounded_channel::<PostedSegment>();
@@ -454,6 +457,15 @@ async fn process_item(
                     // simply behind on indexing, so skip the remaining
                     // patient retries (which would just delay an
                     // already-correct verdict) and repost right away.
+                    inner.emit(ProgressEvent::CheckFastRepost {
+                        first_checks: checks as u64,
+                        first_misses: misses as u64,
+                    });
+                    info!(
+                        first_checks = checks,
+                        first_misses = misses,
+                        "check: fast-repost of isolated miss"
+                    );
                     handle_confirmed_miss(inner, slot, worker_idx, item).await;
                     return;
                 }
@@ -501,6 +513,12 @@ async fn process_item(
                 });
                 return;
             }
+            // Distinct from a 430 miss: STAT itself never completed.
+            let count = inner.inconclusive_count.fetch_add(1, Ordering::Relaxed) + 1;
+            inner.emit(ProgressEvent::CheckInconclusive {
+                count: count as u64,
+                reason: "connection error",
+            });
             handle_confirmed_miss(inner, slot, worker_idx, item).await;
         }
     }

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -279,8 +279,15 @@ impl CheckCoordinatorHandle {
         }
         let still_missing = self.inner.still_missing.lock().unwrap().clone();
         let inconclusive = self.inner.inconclusive.lock().unwrap().clone();
+        if !inconclusive.is_empty() {
+            self.inner.emit(ProgressEvent::CheckInconclusive {
+                count: inconclusive.len() as u64,
+                reason: "check path failed",
+            });
+        }
         self.inner.emit(ProgressEvent::CheckDone {
             failed: still_missing.len() as u64,
+            inconclusive: inconclusive.len() as u64,
         });
         CheckDrain {
             still_missing,
@@ -575,8 +582,9 @@ fn mark_inconclusive(inner: &Inner, message_id: String, reason: &'static str) {
         count,
         reason, "check: article inconclusive (check path failed — not a confirmed gap)"
     );
-    inner.emit(ProgressEvent::Status {
-        text: format!("check: {count} inconclusive (check path failed — not a confirmed gap)"),
+    inner.emit(ProgressEvent::CheckInconclusive {
+        count: count as u64,
+        reason,
     });
     inner.in_flight.fetch_sub(1, Ordering::AcqRel);
 }
@@ -770,17 +778,43 @@ async fn repost_one(
     Err(last_err)
 }
 
-/// True when a repost failed because the server refused the article (441/4xx),
-/// not because the check/post path itself died. Refusals stay MissingConfirmed;
-/// transport errors are Inconclusive.
-fn is_post_refusal(err: &anyhow::Error) -> bool {
+/// NNTP response code embedded in a POST error, if any.
+fn nntp_error_code(err: &anyhow::Error) -> Option<u16> {
     let s = err.to_string();
-    s.contains("441") || s.contains("rejected by server") || s.contains("unexpected POST")
+    for prefix in [
+        "article rejected by server (",
+        "authentication rejected by server (code ",
+        "unexpected POST response: ",
+        "unexpected POST response (pipelined): ",
+        "POST not permitted: ",
+        "POST not permitted (pipelined): ",
+    ] {
+        if let Some(rest) = s.split_once(prefix).map(|(_, r)| r) {
+            let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(code) = digits.parse::<u16>() {
+                if (200..600).contains(&code) {
+                    return Some(code);
+                }
+            }
+        }
+    }
+    None
 }
 
-/// Recovered (STAT 223) vs STAT-`Err` subsets of a recovery pass.
-/// Anything in neither is still MissingConfirmed (430, or the recovery POST
-/// itself failed). Recovery never runs on articles that were already
+/// True when a repost failed because the server refused the article (441 or
+/// other 4xx except AUTH 480). Connect/timeout/5xx/AUTH are Inconclusive.
+fn is_post_refusal(err: &anyhow::Error) -> bool {
+    match nntp_error_code(err) {
+        Some(480) => false,
+        Some(code) if (400..500).contains(&code) => true,
+        _ => false,
+    }
+}
+
+/// Recovered (STAT 223) vs Inconclusive (STAT `Err`, or recovery POST
+/// transport/AUTH/5xx) subsets of a recovery pass.
+/// Anything in neither is still MissingConfirmed (430, or a 441/4xx recovery
+/// POST refusal). Recovery never runs on articles that were already
 /// Inconclusive — the caller only passes MissingConfirmed.
 pub(crate) struct RecoverOutcome {
     pub recovered: Vec<PostedSegment>,
@@ -895,8 +929,22 @@ pub(crate) async fn recover_missing(
                         }
                     }
                     Err(e) => {
-                        warn!(id = %seg.message_id, error = %e, "check: final recovery repost failed");
-                        false
+                        if is_post_refusal(&e) {
+                            warn!(
+                                id = %seg.message_id,
+                                error = %e,
+                                "check: final recovery repost refused; still missing"
+                            );
+                            false
+                        } else {
+                            warn!(
+                                id = %seg.message_id,
+                                error = %e,
+                                "check: recovery POST path failed; classifying as inconclusive"
+                            );
+                            inconclusive.lock().unwrap().push(seg);
+                            false
+                        }
                     }
                 };
 
@@ -966,5 +1014,33 @@ mod tests {
         // A third of checks missing is a server having a bad time, not a
         // handful of unlucky articles.
         assert!(!should_fast_repost(300, 100));
+    }
+
+    fn err(msg: &str) -> anyhow::Error {
+        anyhow::anyhow!("{msg}")
+    }
+
+    #[test]
+    fn post_refusal_is_441_and_other_4xx_except_auth() {
+        assert!(is_post_refusal(&err(
+            "article rejected by server (441): 435 Already exists in history"
+        )));
+        assert!(is_post_refusal(&err(
+            "POST not permitted: 440 Posting Not Allowed"
+        )));
+        assert!(is_post_refusal(&err(
+            "unexpected POST response: 441 article rejected"
+        )));
+        assert!(!is_post_refusal(&err(
+            "authentication rejected by server (code 502); check the configured username and password"
+        )));
+        assert!(!is_post_refusal(&err(
+            "POST not permitted: 480 Authentication required"
+        )));
+        assert!(!is_post_refusal(&err(
+            "unexpected POST response: 502 Permission denied"
+        )));
+        assert!(!is_post_refusal(&err("connection reset by peer")));
+        assert!(!is_post_refusal(&err("timed out")));
     }
 }

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -35,6 +35,7 @@ use crate::article::{default_subject, generate_message_id, Article};
 use crate::config::Config;
 use crate::nntp::pool::ConnectionSlot;
 use crate::progress::{ProgressEvent, ProgressSender};
+use crate::resume::{ResumeState, SegmentRecord};
 use crate::yenc;
 
 use super::PostedSegment;
@@ -134,6 +135,7 @@ struct Inner {
     first_misses: AtomicUsize,
     /// Articles whose STAT path exhausted retries with `Err`, not 430.
     inconclusive_count: AtomicUsize,
+    resume: Option<Arc<Mutex<ResumeState>>>,
 }
 
 impl Inner {
@@ -191,7 +193,8 @@ impl Inner {
     }
 
     /// Replace `results`' entry for `(file_name, part)` — used after a
-    /// repost changes an article's Message-ID.
+    /// repost changes an article's Message-ID. Also overwrites the resume
+    /// record so a later `--resume` does not re-inject the cursed id.
     fn splice(&self, seg: &PostedSegment) {
         let mut results = self.results.lock().unwrap();
         if let Some(existing) = results
@@ -199,6 +202,20 @@ impl Inner {
             .find(|s| s.file_name == seg.file_name && s.part == seg.part)
         {
             *existing = seg.clone();
+        }
+        drop(results);
+        if let Some(resume) = &self.resume {
+            resume.lock().unwrap().record_with(
+                &seg.file_name,
+                seg.part,
+                SegmentRecord {
+                    message_id: seg.message_id.clone(),
+                    bytes: seg.bytes,
+                    confirmed: false,
+                    check_disabled: false,
+                    server_idx: seg.server_idx,
+                },
+            );
         }
     }
 }
@@ -280,6 +297,7 @@ pub fn spawn_check_coordinator(
     events: Option<ProgressSender>,
     cancel: Option<Arc<AtomicBool>>,
     check_connections: usize,
+    resume: Option<Arc<Mutex<ResumeState>>>,
 ) -> CheckCoordinatorHandle {
     let servers: Arc<Vec<_>> = Arc::new(config.all_servers().collect());
     let n_workers = check_connections;
@@ -303,6 +321,7 @@ pub fn spawn_check_coordinator(
         first_checks: AtomicUsize::new(0),
         first_misses: AtomicUsize::new(0),
         inconclusive_count: AtomicUsize::new(0),
+        resume,
     });
 
     let (tx, mut rx) = mpsc::unbounded_channel::<PostedSegment>();
@@ -436,6 +455,12 @@ async fn process_item(
             }
             if is_first_attempt {
                 inner.first_checks.fetch_add(1, Ordering::Relaxed);
+            }
+            if let Some(resume) = &inner.resume {
+                resume
+                    .lock()
+                    .unwrap()
+                    .mark_confirmed(&item.seg.file_name, item.seg.part);
             }
             let checked = inner.checked_count.fetch_add(1, Ordering::Relaxed) + 1;
             inner.emit(ProgressEvent::CheckProgress {

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -802,10 +802,15 @@ fn nntp_error_code(err: &anyhow::Error) -> Option<u16> {
 }
 
 /// True when a repost failed because the server refused the article (441 or
-/// other 4xx except AUTH 480). Connect/timeout/5xx/AUTH are Inconclusive.
+/// other 4xx except the AUTH 48x class). Connect/timeout/5xx/AUTH 480–489
+/// are Inconclusive.
 fn is_post_refusal(err: &anyhow::Error) -> bool {
+    let s = err.to_string();
+    if s.contains("authentication rejected by server") {
+        return false;
+    }
     match nntp_error_code(err) {
-        Some(480) => false,
+        Some(480..=489) => false,
         Some(code) if (400..500).contains(&code) => true,
         _ => false,
     }
@@ -1035,7 +1040,16 @@ mod tests {
             "authentication rejected by server (code 502); check the configured username and password"
         )));
         assert!(!is_post_refusal(&err(
+            "authentication rejected by server (code 481); check the configured username and password"
+        )));
+        assert!(!is_post_refusal(&err(
+            "authentication rejected by server (code 482); check the configured username and password"
+        )));
+        assert!(!is_post_refusal(&err(
             "POST not permitted: 480 Authentication required"
+        )));
+        assert!(!is_post_refusal(&err(
+            "unexpected POST response: 481 Authentication failed"
         )));
         assert!(!is_post_refusal(&err(
             "unexpected POST response: 502 Permission denied"

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -22,7 +22,7 @@
 //! answered by flooding an already-struggling server with reposts.
 
 use std::cmp::Ordering as CmpOrdering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -227,7 +227,7 @@ pub struct CheckCoordinatorHandle {
     tx: Option<mpsc::UnboundedSender<PostedSegment>>,
     inner: Arc<Inner>,
     feeder: tokio::task::JoinHandle<()>,
-    workers: Vec<tokio::task::JoinHandle<()>>,
+    workers: Vec<tokio::task::JoinHandle<ConnectionSlot>>,
 }
 
 impl CheckCoordinatorHandle {
@@ -238,20 +238,17 @@ impl CheckCoordinatorHandle {
         self.tx.clone().expect("sender available before drain")
     }
 
-    /// Spawn `additional` more check workers on the same queue, reusing
-    /// connections that just freed up — e.g. once the upload's own worker
-    /// pool has finished and would otherwise sit idle while a small
-    /// dedicated check pool drains whatever backlog is left. Safe to call
-    /// any time, including when the queue is already empty or draining has
-    /// finished: idle workers just poll harmlessly and exit once there's
-    /// nothing left, without ever opening a connection (connections are
-    /// opened lazily, only when a worker actually has an article to check).
-    pub fn scale_up(&mut self, additional: usize) {
+    /// Move idle post slots that just finished posting onto the check
+    /// queue. Already in the connection budget — never opens TCP, never
+    /// checkins to the broker. Safe to call when the queue is already
+    /// empty: idle workers poll and exit without connecting.
+    pub fn scale_up(&mut self, slots: Vec<ConnectionSlot>) {
+        let additional = slots.len();
         let base_idx = self.workers.len();
-        for i in 0..additional {
+        for (i, slot) in slots.into_iter().enumerate() {
             let inner = Arc::clone(&self.inner);
             self.workers.push(tokio::spawn(async move {
-                check_worker(inner, base_idx + i).await;
+                check_worker(inner, base_idx + i, slot).await
             }));
         }
         if additional > 0 {
@@ -267,40 +264,42 @@ impl CheckCoordinatorHandle {
 
     /// Close the input (no more segments will be queued) and wait for every
     /// queued/in-flight article to resolve — verified, reposted-and-verified,
-    /// or given up on. Returns the Message-IDs that could never be confirmed.
-    pub async fn finish_and_drain(mut self) -> Vec<String> {
+    /// or given up on. Returns the Message-IDs that could never be confirmed
+    /// and the slots every worker held, still in budget, for the caller to
+    /// hand to [`recover_missing`] or check in as a single set.
+    pub async fn finish_and_drain(mut self) -> (Vec<String>, Vec<ConnectionSlot>) {
         drop(self.tx.take());
         let _ = self.feeder.await;
+        let mut slots = Vec::with_capacity(self.workers.len());
         for w in self.workers {
-            let _ = w.await;
+            if let Ok(slot) = w.await {
+                slots.push(slot);
+            }
         }
         let still_missing = self.inner.still_missing.lock().unwrap().clone();
         self.inner.emit(ProgressEvent::CheckDone {
             failed: still_missing.len() as u64,
         });
-        still_missing
+        (still_missing, slots)
     }
 }
 
 /// Spawn the streaming check coordinator: a feeder task that queues incoming
-/// segments with a per-article delay, and `check_connections` worker tasks
-/// that drain the queue via dedicated NNTP connections. `check_connections`
-/// is the caller's responsibility to size — see
-/// `post_files_with_progress_and_cancel`, which carves it out of the
-/// configured total connection count so the run never exceeds what the user
-/// asked for (e.g. `-n 50` means 50 connections total, split between
-/// posting and checking, not 50 + a check pool on top).
+/// segments with a per-article delay, and one worker per already-checked-out
+/// slot. The caller carves those slots out of the configured total (see
+/// `post_files_with_progress_and_cancel`) so the run never exceeds what the
+/// user asked for — workers never open their own TCP.
 pub fn spawn_check_coordinator(
     config: Config,
     groups: Vec<String>,
     results: Arc<Mutex<Vec<PostedSegment>>>,
     events: Option<ProgressSender>,
     cancel: Option<Arc<AtomicBool>>,
-    check_connections: usize,
+    check_slots: Vec<ConnectionSlot>,
     resume: Option<Arc<Mutex<ResumeState>>>,
 ) -> CheckCoordinatorHandle {
     let servers: Arc<Vec<_>> = Arc::new(config.all_servers().collect());
-    let n_workers = check_connections;
+    let n_workers = check_slots.len();
     let n_heaps = servers.len().max(1);
 
     let inner = Arc::new(Inner {
@@ -342,10 +341,10 @@ pub fn spawn_check_coordinator(
     });
 
     let mut workers = Vec::with_capacity(n_workers);
-    for worker_idx in 0..n_workers {
+    for (worker_idx, slot) in check_slots.into_iter().enumerate() {
         let inner = Arc::clone(&inner);
         workers.push(tokio::spawn(async move {
-            check_worker(inner, worker_idx).await;
+            check_worker(inner, worker_idx, slot).await
         }));
     }
 
@@ -357,22 +356,22 @@ pub fn spawn_check_coordinator(
     }
 }
 
-async fn check_worker(inner: Arc<Inner>, worker_idx: usize) {
-    // Each worker has a "home" server whose queue it drains preferentially,
-    // spread round-robin across the configured servers so every server gets
-    // a fair share of home workers regardless of how the check pool size
-    // relates to the server count (the pool is often smaller than the
-    // server count, since it's deliberately kept small — see
-    // `effective_check_connections`). A worker only steals from another
-    // server's queue (`Inner::try_pop_ready`) once its own is empty, which
-    // keeps the connection on one server for as long as there's real work
-    // there instead of retargeting on every item.
+async fn check_worker(
+    inner: Arc<Inner>,
+    worker_idx: usize,
+    mut slot: ConnectionSlot,
+) -> ConnectionSlot {
+    // Prefer the queue matching the slot's current server so a worker that
+    // was assigned (or just posted on) one host doesn't retarget on every
+    // item. Stealing from another server's queue (`Inner::try_pop_ready`)
+    // still happens once the home queue is empty; that can concentrate
+    // every live socket on one `[[servers]]` host even though the process
+    // total stays in budget — a documented limitation, not a new knob.
     let home_idx = if inner.servers.is_empty() {
         0
     } else {
-        worker_idx % inner.servers.len()
+        slot.server_idx().min(inner.servers.len() - 1)
     };
-    let mut slot = ConnectionSlot::with_id(Arc::clone(&inner.servers), home_idx, worker_idx);
 
     loop {
         if inner.is_cancelled() {
@@ -415,7 +414,7 @@ async fn check_worker(inner: Arc<Inner>, worker_idx: usize) {
         inner.emit(ProgressEvent::CheckConnectionIdle { conn: worker_idx });
     }
 
-    slot.quit().await;
+    slot
 }
 
 async fn process_item(
@@ -743,25 +742,29 @@ async fn repost_one(
 /// after `check_delay_secs` — one round trip per article, not the full
 /// `check_retries`-attempt cycle.
 ///
-/// Runs the batch across up to `config.effective_check_connections()` worker
-/// tasks pulling from a shared queue — the same connection budget the
-/// streaming check itself uses, never more than there is work to do. This
-/// used to be a strict one-article-at-a-time loop: with `check_recover_max`
-/// defaulting to 50 and each article costing a repost round trip plus
-/// `check_delay_secs`, a stubborn batch could take minutes with the upload
-/// already at 100% and every upload connection sitting idle — the exact
-/// "why is this frozen" case the recovery pass exists to resolve *quickly*.
+/// Runs the batch across the supplied slots (already in the connection
+/// budget — typically those returned by
+/// [`CheckCoordinatorHandle::finish_and_drain`]), never more workers than
+/// there is work or slots. Unused slots stay held so `--jobs` cannot start
+/// the next episode until this pass is done. This used to be a strict
+/// one-article-at-a-time loop: with `check_recover_max` defaulting to 50
+/// and each article costing a repost round trip plus `check_delay_secs`, a
+/// stubborn batch could take minutes with the upload already at 100% and
+/// every upload connection sitting idle — the exact "why is this frozen"
+/// case the recovery pass exists to resolve *quickly*.
 ///
 /// Returns the subset of `segments` that got reposted *and* confirmed
-/// present; anything not in the returned list is still genuinely missing.
+/// present, plus the same slots (caller checkins the whole set). Anything
+/// not in the recovered list is still genuinely missing.
 pub(crate) async fn recover_missing(
     config: &Config,
     groups: &[String],
     segments: Vec<PostedSegment>,
     events: Option<&ProgressSender>,
-) -> Vec<PostedSegment> {
-    if segments.is_empty() {
-        return Vec::new();
+    mut slots: Vec<ConnectionSlot>,
+) -> (Vec<PostedSegment>, Vec<ConnectionSlot>) {
+    if segments.is_empty() || slots.is_empty() {
+        return (Vec::new(), slots);
     }
 
     let total = segments.len() as u64;
@@ -769,42 +772,30 @@ pub(crate) async fn recover_missing(
         let _ = tx.send(ProgressEvent::CheckRecoverStarted { total });
     }
 
-    let servers: Arc<Vec<_>> = Arc::new(config.all_servers().collect());
-    let n_workers = config
-        .effective_check_connections()
-        .max(1)
-        .min(segments.len());
+    let n_workers = slots.len().min(segments.len());
+    let work_slots: Vec<_> = slots.drain(..n_workers).collect();
 
     let queue = Arc::new(Mutex::new(segments));
     let done = Arc::new(AtomicUsize::new(0));
     let recovered = Arc::new(Mutex::new(Vec::with_capacity(total as usize)));
 
     let mut workers = Vec::with_capacity(n_workers);
-    for _ in 0..n_workers {
+    for mut slot in work_slots {
         let config = config.clone();
         let groups = groups.to_vec();
-        let servers = Arc::clone(&servers);
         let queue = Arc::clone(&queue);
         let done = Arc::clone(&done);
         let recovered = Arc::clone(&recovered);
         let events = events.cloned();
 
         workers.push(tokio::spawn(async move {
-            // One connection per distinct server this worker happens to
-            // draw a segment for, reused across whatever it pulls from the
-            // shared queue instead of reconnecting per article.
-            let mut slots: HashMap<usize, ConnectionSlot> = HashMap::new();
-
             loop {
                 let seg = queue.lock().unwrap().pop();
                 let Some(seg) = seg else { break };
 
-                let idx = seg.server_idx.min(servers.len().saturating_sub(1));
-                let slot = slots
-                    .entry(idx)
-                    .or_insert_with(|| ConnectionSlot::new(Arc::clone(&servers), idx));
+                slot.retarget(seg.server_idx);
 
-                let ok = match repost_one(&config, slot, &seg, &groups).await {
+                let ok = match repost_one(&config, &mut slot, &seg, &groups).await {
                     Ok(new_seg) => {
                         tokio::time::sleep(Duration::from_secs(config.check_delay_secs)).await;
                         let confirmed = match slot.ensure_connected().await {
@@ -843,21 +834,21 @@ pub(crate) async fn recover_missing(
                     });
                 }
             }
-
-            for (_, mut slot) in slots {
-                slot.quit().await;
-            }
+            slot
         }));
     }
 
     for w in workers {
-        let _ = w.await;
+        if let Ok(slot) = w.await {
+            slots.push(slot);
+        }
     }
 
-    Arc::try_unwrap(recovered)
+    let recovered = Arc::try_unwrap(recovered)
         .expect("every worker task has finished by now")
         .into_inner()
-        .unwrap()
+        .unwrap();
+    (recovered, slots)
 }
 
 #[cfg(test)]

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -267,6 +267,10 @@ impl CheckCoordinatorHandle {
     /// or given up on. Returns the Message-IDs that could never be confirmed
     /// and the slots every worker held, still in budget, for the caller to
     /// hand to [`recover_missing`] or check in as a single set.
+    ///
+    /// A panicking worker's `JoinError` drops its slot; if that slot was
+    /// broker-checked-out, [`ConnectionSlot`]'s Drop replenishes the idle
+    /// pool so `--jobs` cannot deadlock on a leaked permit.
     pub async fn finish_and_drain(mut self) -> (Vec<String>, Vec<ConnectionSlot>) {
         drop(self.tx.take());
         let _ = self.feeder.await;
@@ -469,7 +473,9 @@ async fn process_item(
             inner.in_flight.fetch_sub(1, Ordering::AcqRel);
         }
         Ok(false) => {
-            slot.invalidate("stat_430");
+            // 430 is a definitive miss on this connection, not a dead
+            // socket. Invalidating here would open a replacement TCP per
+            // miss and break the process-wide connection budget.
             item.stat_attempts += 1;
             if is_first_attempt {
                 let checks = inner.first_checks.fetch_add(1, Ordering::Relaxed) + 1;

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -22,7 +22,7 @@ use crate::article::{
 use crate::config::{types::MAX_AUTO_PIPELINE_DEPTH, Config, ObfuscateMode};
 use crate::nntp::pool::{ConnectionBroker, ConnectionPool, ConnectionSlot};
 use crate::progress::{FileEntry, ProgressEvent, ProgressSender, RunMode};
-use crate::resume::ResumeState;
+use crate::resume::{resume_action, ResumeAction, ResumeState, SegmentRecord};
 use crate::walk::{natural_cmp, InputFile};
 use crate::yenc;
 use parmesan::encoder::{FileHasher, FileHashes, RecoveryEncoder};
@@ -167,10 +167,10 @@ pub struct PostedSegment {
     /// server the article was posted to, instead of guessing — with a
     /// multi-server failover config, different articles from the same run
     /// can legitimately land on different servers, and a provider that
-    /// never received an article obviously can't confirm it. Meaningless
-    /// (left as `0`) for segments that never go through the check queue:
-    /// resume-skipped segments (already confirmed in a prior run) and
-    /// dry-run segments (nothing was actually posted).
+    /// never received an article obviously can't confirm it. Copied from
+    /// `.pesto-state` on a resume re-STAT so the check targets the same host.
+    /// Left as `0` for dry-run segments (nothing was actually posted) and
+    /// pre-schema resume records.
     pub server_idx: usize,
     /// This file's 1-based position among every file in the release, and the
     /// release's total file count — the `--file-counter` subject prefix.
@@ -445,6 +445,11 @@ struct Shared {
     /// before PAR2 encoding actually starts. `0` when `config.file_counter`
     /// is off, which callers treat as "no counter" (see `FileMeta::file_index`).
     total_files: u32,
+    /// Sender into the streaming STAT queue. `prepare_ready` arm 2
+    /// (re-STAT a stored id, no POST) needs this; the POST path uses it
+    /// after a 240. Taken (dropped) before `finish_and_drain` so the
+    /// feeder observes end-of-stream.
+    check_tx: Mutex<Option<tokio::sync::mpsc::UnboundedSender<PostedSegment>>>,
 }
 
 impl Shared {
@@ -997,6 +1002,7 @@ pub async fn post_files_inner(
         release_from,
         run_id,
         total_files,
+        check_tx: Mutex::new(None),
     });
 
     // Announce the work plan: one `FileEntry` per source file, with the
@@ -1144,11 +1150,14 @@ pub async fn post_files_inner(
             shared.events.clone(),
             Some(Arc::clone(&shared.cancelled)),
             check_conns,
+            shared.resume.clone(),
         ))
     } else {
         None
     };
-    let check_tx = check_coordinator.as_ref().map(|c| c.sender());
+    if let Some(c) = check_coordinator.as_ref() {
+        *shared.check_tx.lock().unwrap() = Some(c.sender());
+    }
 
     crate::memory::set_phase(crate::memory::Phase::Posting);
     let t_post_start = std::time::Instant::now();
@@ -1175,7 +1184,6 @@ pub async fn post_files_inner(
                 rx,
                 idx,
                 slot,
-                check_tx.clone(),
                 broker.clone(),
             )));
         }
@@ -1258,18 +1266,16 @@ pub async fn post_files_inner(
         coordinator.scale_up(upload_conns);
     }
 
-    cancel_handle.abort();
-
     let mut failures = std::mem::take(&mut *shared.failures.lock().unwrap());
     let mut failed_tasks = std::mem::take(&mut *shared.failed_tasks.lock().unwrap());
-    let cancelled = shared.cancelled.load(Ordering::Relaxed);
+    let cancelled_during_post = shared.cancelled.load(Ordering::Relaxed);
 
     // Blind retry for segments that never got a `240` in the main loop
     // (connection drops, timeouts, etc — never confirmed by the server at
     // all). Recovered segments flow into the same streaming check queue as
     // everything else, so they get the same STAT confirmation before the
     // run reports them as posted.
-    if !failed_tasks.is_empty() && !cancelled {
+    if !failed_tasks.is_empty() && !cancelled_during_post {
         let n = failed_tasks.len();
         info!(count = n, "retrying segments that failed during upload");
         let recovered = repost_failed_tasks(
@@ -1289,8 +1295,21 @@ pub async fn post_files_inner(
             .map(|s| (s.file_name.clone(), s.part, s.total))
             .collect();
         for seg in recovered {
-            if let Some(tx) = &check_tx {
+            if let Some(tx) = shared.check_tx.lock().unwrap().as_ref() {
                 let _ = tx.send(seg.clone());
+            }
+            if let Some(resume) = &shared.resume {
+                resume.lock().unwrap().record_with(
+                    &seg.file_name,
+                    seg.part,
+                    SegmentRecord {
+                        message_id: seg.message_id.clone(),
+                        bytes: seg.bytes,
+                        confirmed: false,
+                        check_disabled: !shared.config.check,
+                        server_idx: seg.server_idx,
+                    },
+                );
             }
             shared.results.lock().unwrap().push(seg);
         }
@@ -1308,13 +1327,19 @@ pub async fn post_files_inner(
     // PAR2 file's bytes while it drains below. The caller is responsible for
     // removing `par2_temp_dir()` once it's truly done with the run (see
     // `run_single_upload` / `run_upload`).
-    drop(check_tx);
+    // Close the STAT feeder before drain. Shared outlives the coordinator;
+    // leaving this sender alive would hang `finish_and_drain` forever.
+    let _ = shared.check_tx.lock().unwrap().take();
     crate::memory::set_phase(crate::memory::Phase::Check);
     let mut still_missing = if let Some(coordinator) = check_coordinator {
         coordinator.finish_and_drain().await
     } else {
         Vec::new()
     };
+    // Re-read after drain: a cancel during the STAT wait must persist
+    // unconfirmed records rather than treating the dumped queue as
+    // MissingConfirmed (the watcher stays alive until after persist).
+    let cancelled = shared.cancelled.load(Ordering::Relaxed);
 
     // One more, bounded automatic recovery attempt for a small stubborn
     // tail. The common real-world case this targets: posting finished, the
@@ -1362,13 +1387,31 @@ pub async fn post_files_inner(
                 shared.events.as_ref(),
             )
             .await;
-            for seg in &recovered {
+            {
                 let mut results = shared.results.lock().unwrap();
-                if let Some(existing) = results
-                    .iter_mut()
-                    .find(|s| s.file_name == seg.file_name && s.part == seg.part)
-                {
-                    *existing = seg.clone();
+                for seg in &recovered {
+                    if let Some(existing) = results
+                        .iter_mut()
+                        .find(|s| s.file_name == seg.file_name && s.part == seg.part)
+                    {
+                        *existing = seg.clone();
+                    }
+                }
+            }
+            if let Some(resume) = &shared.resume {
+                let mut state = resume.lock().unwrap();
+                for seg in &recovered {
+                    state.record_with(
+                        &seg.file_name,
+                        seg.part,
+                        SegmentRecord {
+                            message_id: seg.message_id.clone(),
+                            bytes: seg.bytes,
+                            confirmed: true,
+                            check_disabled: false,
+                            server_idx: seg.server_idx,
+                        },
+                    );
                 }
             }
             let recovered_keys: std::collections::HashSet<(String, u32)> = recovered
@@ -1390,9 +1433,11 @@ pub async fn post_files_inner(
     // Message-ID must be forgotten now — otherwise a later `--resume` would
     // trust that known-bad ID and silently skip re-posting the segment,
     // producing an NZB that looks complete but references an article that
-    // was never actually confirmed present.
+    // was never actually confirmed present. Cancel is not a confirmed miss:
+    // keep those records as `confirmed: false` so `--resume --check` can
+    // re-STAT the same ids.
     if let Some(resume) = &shared.resume {
-        if !still_missing.is_empty() {
+        if !cancelled && !still_missing.is_empty() {
             let results = shared.results.lock().unwrap();
             let mut state = resume.lock().unwrap();
             for id in &still_missing {
@@ -1416,15 +1461,19 @@ pub async fn post_files_inner(
     // check simply didn't get to finish verifying everything, not a
     // confirmed gap), and `allow_incomplete_nzb` means the user has already
     // accepted the remaining gap and is relying on PAR2, not `--resume`, to
-    // fill it. Whenever the run is *not* complete by those terms, persist
-    // once so a later `--resume` has something to load; otherwise delete
-    // any state file (freshly written or left over from an earlier failed
-    // attempt at the same output path) — there is nothing left to resume.
+    // fill it. Cancel with any Posted/Confirmed records still persists so
+    // the operator does not lose 240s already accepted. Whenever the run is
+    // *not* complete by those terms, persist once so a later `--resume` has
+    // something to load; otherwise delete any state file (freshly written
+    // or left over from an earlier failed attempt at the same output path)
+    // — there is nothing left to resume.
     if let (Some(resume), Some(rp)) = (&shared.resume, &shared.resume_path) {
         let has_post_failures = !failed_tasks.is_empty();
         let has_confirmed_missing = !cancelled && !still_missing.is_empty();
-        let incomplete =
-            has_post_failures || (has_confirmed_missing && !config.allow_incomplete_nzb);
+        let has_progress = !resume.lock().unwrap().is_empty();
+        let incomplete = has_post_failures
+            || (has_confirmed_missing && !config.allow_incomplete_nzb)
+            || (cancelled && has_progress);
         if incomplete {
             let _ = resume.lock().unwrap().save(rp);
         } else {
@@ -1463,6 +1512,8 @@ pub async fn post_files_inner(
         .filter_map(|idx| all_servers.get(idx))
         .map(|s| s.host.clone())
         .collect();
+
+    cancel_handle.abort();
 
     Ok(PostOutcome {
         segments,
@@ -2823,7 +2874,8 @@ async fn encode_worker(
     }
 }
 
-/// Resume skip / spool / yEnc. `None` means the segment is already done.
+/// Resume skip / spool / yEnc. `None` means the segment is already done
+/// (skipped or re-queued for STAT of a stored id).
 async fn prepare_ready(shared: &Arc<Shared>, task: PostTask) -> Option<ReadyArticle> {
     if let Some(resume) = &shared.resume {
         let existing = resume
@@ -2831,32 +2883,42 @@ async fn prepare_ready(shared: &Arc<Shared>, task: PostTask) -> Option<ReadyArti
             .unwrap()
             .get(&task.meta.real_name, task.part)
             .cloned();
-        if let Some(existing) = existing {
-            shared.results.lock().unwrap().push(PostedSegment {
-                file_name: task.meta.real_name.clone(),
-                file_path: Arc::from(task.meta.path.as_path()),
-                subject_name: Arc::from(task.meta.real_name.as_str()),
-                wire_name: Arc::from(task.subject_name.as_str()),
-                file_size: task.meta.size,
-                part: task.part,
-                total: task.total,
-                message_id: existing.message_id,
-                bytes: existing.bytes,
-                from: Arc::from(task.from.as_str()),
-                date: task.date.clone(),
-                full_crc32: task.file_crc32.unwrap_or(0),
-                server_idx: 0,
-                file_index: task.meta.file_index,
-                total_files: shared.total_files,
-            });
-            let raw_bytes = task.data.len() as u64;
-            shared.release_buffer(task.data);
-            shared.emit(ProgressEvent::SegmentDone {
-                file: task.meta.real_name.clone(),
-                bytes: raw_bytes,
-                ok: true,
-            });
-            return None;
+        match resume_action(shared.config.check, existing.as_ref()) {
+            ResumeAction::Post => {}
+            action @ (ResumeAction::Skip | ResumeAction::ReStatStoredId) => {
+                let existing = existing.expect("skip/re-STAT arms require a record");
+                let seg = PostedSegment {
+                    file_name: task.meta.real_name.clone(),
+                    file_path: Arc::from(task.meta.path.as_path()),
+                    subject_name: Arc::from(task.meta.real_name.as_str()),
+                    wire_name: Arc::from(task.subject_name.as_str()),
+                    file_size: task.meta.size,
+                    part: task.part,
+                    total: task.total,
+                    message_id: existing.message_id,
+                    bytes: existing.bytes,
+                    from: Arc::from(task.from.as_str()),
+                    date: task.date.clone(),
+                    full_crc32: task.file_crc32.unwrap_or(0),
+                    server_idx: existing.server_idx,
+                    file_index: task.meta.file_index,
+                    total_files: shared.total_files,
+                };
+                if action == ResumeAction::ReStatStoredId {
+                    if let Some(tx) = shared.check_tx.lock().unwrap().as_ref() {
+                        let _ = tx.send(seg.clone());
+                    }
+                }
+                shared.results.lock().unwrap().push(seg);
+                let raw_bytes = task.data.len() as u64;
+                shared.release_buffer(task.data);
+                shared.emit(ProgressEvent::SegmentDone {
+                    file: task.meta.real_name.clone(),
+                    bytes: raw_bytes,
+                    ok: true,
+                });
+                return None;
+            }
         }
     }
 
@@ -2944,7 +3006,6 @@ async fn worker(
     mut rx: tokio::sync::mpsc::Receiver<ReadyArticle>,
     conn_id: usize,
     mut slot: ConnectionSlot,
-    check_tx: Option<tokio::sync::mpsc::UnboundedSender<PostedSegment>>,
     broker: Option<Arc<ConnectionBroker>>,
 ) {
     let mut rate_limiter = RateLimiter::new(
@@ -3182,7 +3243,6 @@ async fn worker(
             let wire = p.headers.len() + p.encoded.body.len();
             commit_result(
                 &shared,
-                check_tx.as_ref(),
                 p.task,
                 p.message_id,
                 wire,
@@ -3322,7 +3382,6 @@ async fn worker(
                 let wire = p.headers.len() + p.encoded.body.len();
                 commit_result(
                     &shared,
-                    check_tx.as_ref(),
                     p.task,
                     p.message_id,
                     wire,
@@ -3467,7 +3526,6 @@ fn resolve_date(mode: Option<&str>) -> (Option<String>, Option<u64>) {
 #[allow(clippy::too_many_arguments)]
 fn commit_result(
     shared: &Shared,
-    check_tx: Option<&tokio::sync::mpsc::UnboundedSender<PostedSegment>>,
     task: PostTask,
     message_id: String,
     wire_bytes: usize,
@@ -3489,11 +3547,19 @@ fn commit_result(
             // single persist decided by the final outcome (see the
             // still_missing handling and `run_single_upload`'s cleanup)
             // covers the same guarantee at a fraction of the cost.
-            resume.lock().unwrap().record(
+            //
+            // `confirmed` is false until STAT 223; `--no-check` never flips
+            // it (that run never STATed).
+            resume.lock().unwrap().record_with(
                 &task.meta.real_name,
                 task.part,
-                &message_id,
-                wire_bytes as u64,
+                SegmentRecord {
+                    message_id: message_id.clone(),
+                    bytes: wire_bytes as u64,
+                    confirmed: false,
+                    check_disabled: !shared.config.check,
+                    server_idx,
+                },
             );
         }
         // Confirmed posted — any spooled copy has served its purpose.
@@ -3518,7 +3584,7 @@ fn commit_result(
             file_index: task.meta.file_index,
             total_files: shared.total_files,
         };
-        if let Some(tx) = check_tx {
+        if let Some(tx) = shared.check_tx.lock().unwrap().as_ref() {
             let _ = tx.send(seg.clone());
         }
         shared.results.lock().unwrap().push(seg);
@@ -5070,6 +5136,7 @@ mod tests {
             release_from: None,
             run_id: 0,
             total_files: 0,
+            check_tx: Mutex::new(None),
         })
     }
 

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -281,11 +281,13 @@ pub struct PostOutcome {
     /// was unreachable all run) or, more commonly, every configured server
     /// that had a connection quota. Empty for `--par2-only`/`--dry-run`.
     pub servers: Vec<String>,
-    /// Message-IDs that were posted (`240`) but never confirmed retrievable
-    /// via the streaming STAT check, even after every repost attempt. Empty
-    /// when `config.check` is disabled. A non-empty list means the run
-    /// produced content that is not fully confirmed on the server.
+    /// Message-IDs that were posted (`240`) but STAT 430-exhausted every
+    /// retry/repost. Empty when `config.check` is disabled. Distinct from
+    /// [`Self::inconclusive`]: this is a confirmed gap.
     pub still_missing: Vec<String>,
+    /// Message-IDs whose STAT path failed without a 430 (transport, timeout,
+    /// 480/502, cancel drain). Never unblocked by `--allow-incomplete-nzb`.
+    pub inconclusive: Vec<String>,
     /// Set when the run stopped because `producer` returned an error (bad
     /// PAR2 geometry, a memory-budget check, file I/O, …) rather than because
     /// the user cancelled it. `cancelled` is `true` in both cases — callers
@@ -301,6 +303,29 @@ pub struct PostOutcome {
     /// `--season` entry (`--jobs > 1`) cleans up only its own directory
     /// instead of a path shared by every run in the process (issue #67).
     pub par2_temp_dir: PathBuf,
+}
+
+/// Whether the NZB (and NFO / post-hooks) should be written for this run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NzbWriteDecision {
+    Write,
+    Refuse,
+}
+
+/// Single NZB completeness gate used by the CLI and [`crate::upload::run_upload`].
+/// `--allow-incomplete-nzb` unblocks only MissingConfirmed, never POST
+/// failures or Inconclusive.
+pub fn nzb_write_decision(
+    post_failures: bool,
+    missing_confirmed: bool,
+    inconclusive: bool,
+    allow_incomplete_nzb: bool,
+) -> NzbWriteDecision {
+    if post_failures || inconclusive || (missing_confirmed && !allow_incomplete_nzb) {
+        NzbWriteDecision::Refuse
+    } else {
+        NzbWriteDecision::Write
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1374,14 +1399,19 @@ pub async fn post_files_inner(
     // leaving this sender alive would hang `finish_and_drain` forever.
     let _ = shared.check_tx.lock().unwrap().take();
     crate::memory::set_phase(crate::memory::Phase::Check);
-    let mut still_missing = Vec::new();
-    if let Some(mut coordinator) = check_coordinator {
+    let drain = if let Some(mut coordinator) = check_coordinator {
         // Ownership transfer: no checkin in between post-join and scale_up.
         coordinator.scale_up(std::mem::take(&mut post_slots));
-        let (missing, slots) = coordinator.finish_and_drain().await;
-        still_missing = missing;
-        post_slots = slots;
-    }
+        coordinator.finish_and_drain().await
+    } else {
+        check::CheckDrain {
+            slots: std::mem::take(&mut post_slots),
+            ..check::CheckDrain::default()
+        }
+    };
+    let mut still_missing = drain.still_missing;
+    let mut inconclusive = drain.inconclusive;
+    post_slots = drain.slots;
     // Re-read after drain: a cancel during the STAT wait must persist
     // unconfirmed records rather than treating the dumped queue as
     // MissingConfirmed (the watcher stays alive until after persist).
@@ -1426,7 +1456,7 @@ pub async fn post_files_inner(
                 .iter()
                 .map(|c| (c.message_id.clone(), (c.file_name.clone(), c.part)))
                 .collect();
-            let (recovered, slots) = check::recover_missing(
+            let recovered = check::recover_missing(
                 config,
                 &shared.post_group,
                 candidates,
@@ -1434,10 +1464,14 @@ pub async fn post_files_inner(
                 std::mem::take(&mut post_slots),
             )
             .await;
-            post_slots = slots;
+            post_slots = recovered.slots;
             {
                 let mut results = shared.results.lock().unwrap();
-                for seg in &recovered {
+                for seg in recovered
+                    .recovered
+                    .iter()
+                    .chain(recovered.inconclusive.iter())
+                {
                     if let Some(existing) = results
                         .iter_mut()
                         .find(|s| s.file_name == seg.file_name && s.part == seg.part)
@@ -1448,7 +1482,7 @@ pub async fn post_files_inner(
             }
             if let Some(resume) = &shared.resume {
                 let mut state = resume.lock().unwrap();
-                for seg in &recovered {
+                for seg in &recovered.recovered {
                     state.record_with(
                         &seg.file_name,
                         seg.part,
@@ -1461,9 +1495,24 @@ pub async fn post_files_inner(
                         },
                     );
                 }
+                for seg in &recovered.inconclusive {
+                    state.record_with(
+                        &seg.file_name,
+                        seg.part,
+                        SegmentRecord {
+                            message_id: seg.message_id.clone(),
+                            bytes: seg.bytes,
+                            confirmed: false,
+                            check_disabled: false,
+                            server_idx: seg.server_idx,
+                        },
+                    );
+                }
             }
             let recovered_keys: std::collections::HashSet<(String, u32)> = recovered
+                .recovered
                 .iter()
+                .chain(recovered.inconclusive.iter())
                 .map(|s| (s.file_name.clone(), s.part))
                 .collect();
             still_missing.retain(|id| {
@@ -1471,6 +1520,7 @@ pub async fn post_files_inner(
                     .get(id)
                     .is_some_and(|key| recovered_keys.contains(key))
             });
+            inconclusive.extend(recovered.inconclusive.into_iter().map(|s| s.message_id));
         }
     }
 
@@ -1507,24 +1557,19 @@ pub async fn post_files_inner(
     }
 
     // Single, final resume-state persistence decision, replacing the old
-    // per-segment write in `commit_result`. Mirrors the completeness check
-    // `run_single_upload` uses to decide whether the NZB itself gets
-    // written: a run cancellation makes `still_missing` meaningless (the
-    // check simply didn't get to finish verifying everything, not a
-    // confirmed gap), and `allow_incomplete_nzb` means the user has already
-    // accepted the remaining gap and is relying on PAR2, not `--resume`, to
-    // fill it. Cancel with any Posted/Confirmed records still persists so
-    // the operator does not lose 240s already accepted. Whenever the run is
-    // *not* complete by those terms, persist once so a later `--resume` has
-    // something to load; otherwise delete any state file (freshly written
-    // or left over from an earlier failed attempt at the same output path)
-    // — there is nothing left to resume.
+    // per-segment write in `commit_result`. Persist whenever anything is
+    // still unconfirmed: POST failures, MissingConfirmed (even with
+    // `--allow-incomplete-nzb` — the opt-in publishes the NZB but a later
+    // `--resume` can still fill the gap), Inconclusive, or a cancel that
+    // already has Posted records. Complete runs delete the state file.
     if let (Some(resume), Some(rp)) = (&shared.resume, &shared.resume_path) {
         let has_post_failures = !failed_tasks.is_empty();
         let has_confirmed_missing = !cancelled && !still_missing.is_empty();
+        let has_inconclusive = !inconclusive.is_empty();
         let has_progress = !resume.lock().unwrap().is_empty();
         let incomplete = has_post_failures
-            || (has_confirmed_missing && !config.allow_incomplete_nzb)
+            || has_confirmed_missing
+            || has_inconclusive
             || (cancelled && has_progress);
         if incomplete {
             let _ = resume.lock().unwrap().save(rp);
@@ -1550,6 +1595,7 @@ pub async fn post_files_inner(
         failed = failures.len(),
         retries = total_retries,
         still_missing = still_missing.len(),
+        inconclusive = inconclusive.len(),
         elapsed_ms = t_post_start.elapsed().as_millis(),
         phase = "post",
         "network summary"
@@ -1574,6 +1620,7 @@ pub async fn post_files_inner(
         cancelled,
         groups: shared.post_group.clone(),
         still_missing,
+        inconclusive,
         servers: servers_used,
         failure_reason,
         par2_temp_dir: par2_temp_dir(config.par2_temp_dir.as_deref(), shared.run_id),
@@ -4983,6 +5030,46 @@ mod tests {
         let (check, upload) = split_connections(&config, true).unwrap();
         assert_eq!(check, 1);
         assert_eq!(upload, 3);
+    }
+
+    #[test]
+    fn nzb_write_decision_writes_when_everything_confirmed() {
+        assert_eq!(
+            nzb_write_decision(false, false, false, false),
+            NzbWriteDecision::Write
+        );
+    }
+
+    #[test]
+    fn nzb_write_decision_refuses_post_failures_even_with_allow() {
+        assert_eq!(
+            nzb_write_decision(true, false, false, true),
+            NzbWriteDecision::Refuse
+        );
+    }
+
+    #[test]
+    fn nzb_write_decision_allow_incomplete_unblocks_missing_only() {
+        assert_eq!(
+            nzb_write_decision(false, true, false, true),
+            NzbWriteDecision::Write
+        );
+        assert_eq!(
+            nzb_write_decision(false, true, false, false),
+            NzbWriteDecision::Refuse
+        );
+    }
+
+    #[test]
+    fn nzb_write_decision_inconclusive_always_refuses() {
+        assert_eq!(
+            nzb_write_decision(false, false, true, true),
+            NzbWriteDecision::Refuse
+        );
+        assert_eq!(
+            nzb_write_decision(false, true, true, true),
+            NzbWriteDecision::Refuse
+        );
     }
 
     #[test]

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -92,28 +92,65 @@ fn par2_geometry_from_sizes(sizes: &[u64], config: &Config) -> (usize, usize, us
 }
 
 /// Split the configured total connection count between upload workers and
-/// the check queue. An auto-derived check pool (`check_connections == 0`)
-/// is carved out of the total so `-n 50` always means 50 connections to
+/// the check queue. Both auto (`check_connections == 0`) and explicit N
+/// are carved out of the total so `-n 50` always means 50 connections to
 /// the server, not 50 + a check pool on top — that total is frequently a
-/// hard provider-enforced cap. An *explicit* `--check-connections` is a
-/// deliberate, separate budget the user stated on purpose, so it's honored
-/// additively instead of eating into `--connections`. Returns
-/// `(check_conns, upload_conns)`.
-fn split_connections(config: &Config, check_enabled: bool) -> (usize, usize) {
+/// hard provider-enforced cap. Explicit N is clamped:
+/// `check = N.min(total.saturating_sub(1))`, so `-n 10 --check-connections 10`
+/// is 9+1, never 10+1.
+///
+/// `check_connections == 0` means auto, not off. Off is `config.check == false`.
+/// After the formula, `check == 0` with checking enabled is a start-up error
+/// (`-n 1 --check` and `-n 1 --check-connections 1`) rather than a silent skip.
+/// Returns `(check_conns, upload_conns)`.
+fn split_connections(config: &Config, check_enabled: bool) -> Result<(usize, usize)> {
     let total_conns = config.total_connections();
     if !check_enabled {
-        return (0, total_conns);
+        return Ok((0, total_conns));
     }
-    if config.check_connections == 0 {
-        // Reserve at least 1 connection for uploading; if the total is too
-        // small to spare any for checking (e.g. `-n 1`), checking is
-        // silently skipped for this run rather than exceeding the budget.
-        let check = config
+    let check = if config.check_connections == 0 {
+        config
             .effective_check_connections()
-            .min(total_conns.saturating_sub(1));
-        (check, total_conns.saturating_sub(check))
+            .min(total_conns.saturating_sub(1))
     } else {
-        (config.check_connections, total_conns)
+        config.check_connections.min(total_conns.saturating_sub(1))
+    };
+    if check == 0 {
+        bail!(
+            "checking is enabled but no connection remains for the STAT pool \
+             (need at least one upload connection and one check connection). \
+             Raise `-n`/`connections`, lower `--check-connections`, or pass `--no-check`"
+        );
+    }
+    Ok((check, total_conns.saturating_sub(check)))
+}
+
+/// Check out `n` slots from the broker, or build a fresh pool of `n` when
+/// this run has no broker. `n == 0` is a no-op.
+async fn take_slots(
+    broker: Option<&Arc<ConnectionBroker>>,
+    servers: Arc<Vec<crate::config::ServerEntry>>,
+    n: usize,
+) -> Vec<ConnectionSlot> {
+    if n == 0 {
+        return Vec::new();
+    }
+    match broker {
+        Some(broker) => broker.checkout(n).await,
+        None => ConnectionPool::build(servers, n).into_slots(),
+    }
+}
+
+/// One checkin of the whole set at episode end (broker), or QUIT when this
+/// run owns the sockets. Never called between post-join and `scale_up`.
+async fn release_slots(broker: Option<&ConnectionBroker>, slots: Vec<ConnectionSlot>) {
+    match broker {
+        Some(broker) => broker.checkin_all(slots).await,
+        None => {
+            for mut slot in slots {
+                slot.quit().await;
+            }
+        }
     }
 }
 
@@ -927,7 +964,7 @@ pub async fn post_files_inner(
     let total_conns = config.total_connections();
 
     let check_enabled = config.check && !config.dry_run && !config.par2_only;
-    let (check_conns, upload_conns) = split_connections(config, check_enabled);
+    let (check_conns, upload_conns) = split_connections(config, check_enabled)?;
 
     let worker_count = if config.par2_only {
         0
@@ -1139,17 +1176,35 @@ pub async fn post_files_inner(
         }
     }
 
+    // One checkout of the episode's full budget so `--jobs` cannot sneak a
+    // partial checkout in between check and upload (FIFO `acquire_many`
+    // deadlock). Check workers share these slots; they never open extra TCP.
+    let mut held_slots = if check_conns > 0 || worker_count > 0 {
+        take_slots(
+            broker.as_ref(),
+            shared.servers.clone(),
+            check_conns + upload_conns,
+        )
+        .await
+    } else {
+        Vec::new()
+    };
+    let check_slots: Vec<_> = held_slots
+        .drain(..check_conns.min(held_slots.len()))
+        .collect();
+    let mut post_slots = held_slots;
+
     // Streaming check: every segment that gets a clean `240` is queued here
     // and STAT-checked a few seconds later, concurrently with the rest of
     // the upload, instead of waiting for the whole run to finish.
-    let mut check_coordinator = if check_enabled && check_conns > 0 {
+    let check_coordinator = if !check_slots.is_empty() {
         Some(spawn_check_coordinator(
             config.clone(),
             shared.post_group.clone(),
             Arc::clone(&shared.results),
             shared.events.clone(),
             Some(Arc::clone(&shared.cancelled)),
-            check_conns,
+            check_slots,
             shared.resume.clone(),
         ))
     } else {
@@ -1163,29 +1218,21 @@ pub async fn post_files_inner(
     let t_post_start = std::time::Instant::now();
     let mut handles = Vec::with_capacity(worker_count);
     let mut encode_handles = Vec::new();
-    let tx_opt = if worker_count > 0 {
-        let ready_n = ready_queue_depth(worker_count);
-        let post_depth = (ready_n / worker_count).max(2);
-        let mut post_senders = Vec::with_capacity(worker_count);
-        let mut post_receivers = Vec::with_capacity(worker_count);
-        for _ in 0..worker_count {
+    let tx_opt = if worker_count > 0 && !post_slots.is_empty() {
+        let spawn_n = worker_count.min(post_slots.len());
+        let ready_n = ready_queue_depth(spawn_n);
+        let post_depth = (ready_n / spawn_n).max(2);
+        let mut post_senders = Vec::with_capacity(spawn_n);
+        let mut post_receivers = Vec::with_capacity(spawn_n);
+        for _ in 0..spawn_n {
             let (tx, rx) = tokio::sync::mpsc::channel(post_depth);
             post_senders.push(tx);
             post_receivers.push(rx);
         }
         let post_disp = Arc::new(TaskDispatcher::new(post_senders));
-        let slots = match &broker {
-            Some(broker) => broker.checkout(worker_count).await,
-            None => ConnectionPool::build(shared.servers.clone(), worker_count).into_slots(),
-        };
-        for (idx, (slot, rx)) in slots.into_iter().zip(post_receivers).enumerate() {
-            handles.push(tokio::spawn(worker(
-                shared.clone(),
-                rx,
-                idx,
-                slot,
-                broker.clone(),
-            )));
+        let spawned: Vec<_> = post_slots.drain(..spawn_n).collect();
+        for (idx, (slot, rx)) in spawned.into_iter().zip(post_receivers).enumerate() {
+            handles.push(tokio::spawn(worker(shared.clone(), rx, idx, slot)));
         }
 
         let n_enc = encode_concurrency(parmesan::performance_core_count(), worker_count);
@@ -1255,15 +1302,9 @@ pub async fn post_files_inner(
         let _ = handle.await;
     }
     for handle in handles {
-        let _ = handle.await;
-    }
-
-    // The upload's own connections are now idle — reuse that budget to
-    // drain any remaining check backlog faster instead of leaving it to a
-    // handful of dedicated connections that were sized for running
-    // *alongside* the upload, not for a burst catch-up at the end.
-    if let Some(coordinator) = check_coordinator.as_mut() {
-        coordinator.scale_up(upload_conns);
+        if let Ok(slot) = handle.await {
+            post_slots.push(slot);
+        }
     }
 
     let mut failures = std::mem::take(&mut *shared.failures.lock().unwrap());
@@ -1272,7 +1313,8 @@ pub async fn post_files_inner(
 
     // Blind retry for segments that never got a `240` in the main loop
     // (connection drops, timeouts, etc — never confirmed by the server at
-    // all). Recovered segments flow into the same streaming check queue as
+    // all). Runs on the post slots still held — never `ConnectionSlot::new`.
+    // Recovered segments flow into the same streaming check queue as
     // everything else, so they get the same STAT confirmation before the
     // run reports them as posted.
     if !failed_tasks.is_empty() && !cancelled_during_post {
@@ -1284,6 +1326,7 @@ pub async fn post_files_inner(
             &shared.post_group,
             shared.events.as_ref(),
             Some(&shared.cancelled),
+            &mut post_slots,
         )
         .await
         .unwrap_or_else(|e| {
@@ -1331,11 +1374,14 @@ pub async fn post_files_inner(
     // leaving this sender alive would hang `finish_and_drain` forever.
     let _ = shared.check_tx.lock().unwrap().take();
     crate::memory::set_phase(crate::memory::Phase::Check);
-    let mut still_missing = if let Some(coordinator) = check_coordinator {
-        coordinator.finish_and_drain().await
-    } else {
-        Vec::new()
-    };
+    let mut still_missing = Vec::new();
+    if let Some(mut coordinator) = check_coordinator {
+        // Ownership transfer: no checkin in between post-join and scale_up.
+        coordinator.scale_up(std::mem::take(&mut post_slots));
+        let (missing, slots) = coordinator.finish_and_drain().await;
+        still_missing = missing;
+        post_slots = slots;
+    }
     // Re-read after drain: a cancel during the STAT wait must persist
     // unconfirmed records rather than treating the dumped queue as
     // MissingConfirmed (the watcher stays alive until after persist).
@@ -1380,13 +1426,15 @@ pub async fn post_files_inner(
                 .iter()
                 .map(|c| (c.message_id.clone(), (c.file_name.clone(), c.part)))
                 .collect();
-            let recovered = check::recover_missing(
+            let (recovered, slots) = check::recover_missing(
                 config,
                 &shared.post_group,
                 candidates,
                 shared.events.as_ref(),
+                std::mem::take(&mut post_slots),
             )
             .await;
+            post_slots = slots;
             {
                 let mut results = shared.results.lock().unwrap();
                 for seg in &recovered {
@@ -1425,6 +1473,10 @@ pub async fn post_files_inner(
             });
         }
     }
+
+    // One checkin of the whole set so `--jobs` keeps the next episode
+    // blocked on the semaphore until this episode is fully done.
+    release_slots(broker.as_deref(), post_slots).await;
 
     // Whatever is left in `still_missing` at this point is confirmed bad:
     // the original POST got a `240`, but every STAT check and every repost
@@ -3006,8 +3058,7 @@ async fn worker(
     mut rx: tokio::sync::mpsc::Receiver<ReadyArticle>,
     conn_id: usize,
     mut slot: ConnectionSlot,
-    broker: Option<Arc<ConnectionBroker>>,
-) {
+) -> ConnectionSlot {
     let mut rate_limiter = RateLimiter::new(
         // Divide the global rate across all workers proportionally.
         if shared.config.upload_rate > 0 {
@@ -3396,10 +3447,7 @@ async fn worker(
     }
 
     shared.emit(ProgressEvent::ConnectionIdle { conn: conn_id });
-    match broker {
-        Some(broker) => broker.checkin(slot).await,
-        None => slot.quit().await,
-    }
+    slot
 }
 
 /// Build a `PostTask`, generating per-article subject and From when in
@@ -3696,16 +3744,17 @@ pub async fn repost_failed_tasks(
     groups: &[String],
     events: Option<&ProgressSender>,
     cancel: Option<&Arc<AtomicBool>>,
+    slots: &mut [ConnectionSlot],
 ) -> Result<Vec<PostedSegment>> {
     if failed.is_empty() {
         return Ok(Vec::new());
     }
 
-    let server = config
-        .all_servers()
-        .next()
-        .expect("at least one server is configured");
-    let mut slot = ConnectionSlot::new(Arc::new(vec![server]), 0);
+    // Never `ConnectionSlot::new` — extra TCP would exceed a budget already
+    // held by this episode. No slot means nothing to retry on.
+    let Some(slot) = slots.first_mut() else {
+        return Ok(Vec::new());
+    };
 
     let article_size = config.article_size as u64;
     let max_retries = config.retries.max(1);
@@ -3832,9 +3881,6 @@ pub async fn repost_failed_tasks(
                 total: task.total,
                 message_id,
                 bytes: wire_bytes,
-                // `slot` only ever targets the primary server (index 0 in
-                // `config.all_servers()` too — see its "primary first" order),
-                // since this blind end-of-run retry doesn't fail over.
                 server_idx: slot.server_idx(),
                 from: Arc::from(task.from.as_str()),
                 date: task.date.clone(),
@@ -4855,7 +4901,7 @@ mod tests {
         let mut config = dry_run_config();
         config.connections = 50;
         config.check_connections = 0; // auto
-        let (check, upload) = split_connections(&config, true);
+        let (check, upload) = split_connections(&config, true).unwrap();
         assert_eq!(check, 4);
         assert_eq!(upload, 46);
         assert_eq!(check + upload, 50);
@@ -4865,31 +4911,53 @@ mod tests {
     fn split_connections_disabled_uses_the_whole_total_for_upload() {
         let mut config = dry_run_config();
         config.connections = 50;
-        let (check, upload) = split_connections(&config, false);
+        let (check, upload) = split_connections(&config, false).unwrap();
         assert_eq!(check, 0);
         assert_eq!(upload, 50);
     }
 
     #[test]
-    fn split_connections_never_starves_upload_of_its_last_connection() {
+    fn split_connections_n1_check_auto_is_a_startup_error() {
+        // T22: `check_connections == 0` is auto, not off. Auto on `-n 1`
+        // would carve check down to 0 — fail loud instead of silently skipping.
         let mut config = dry_run_config();
         config.connections = 1;
         config.check_connections = 0; // auto
-        let (check, upload) = split_connections(&config, true);
-        assert_eq!(check, 0, "no connection left to spare for checking");
-        assert_eq!(upload, 1);
+        config.check = true;
+        let err = split_connections(&config, true).unwrap_err().to_string();
+        assert!(
+            err.contains("--no-check"),
+            "start-up error must mention --no-check: {err}"
+        );
+        assert!(
+            err.contains("-n") || err.contains("connections"),
+            "start-up error must mention raising -n: {err}"
+        );
     }
 
     #[test]
-    fn split_connections_explicit_check_connections_is_additive() {
+    fn split_connections_explicit_is_carved_out_not_additive() {
+        // T18: explicit N is no longer added on top of `-n`.
         let mut config = dry_run_config();
-        config.connections = 1;
-        config.check_connections = 1; // explicit, deliberate
-        let (check, upload) = split_connections(&config, true);
-        assert_eq!(check, 1);
+        config.connections = 10;
+        config.check_connections = 4;
+        let (check, upload) = split_connections(&config, true).unwrap();
+        assert_eq!((check, upload), (4, 6));
+
+        config.check_connections = 10;
+        let (check, upload) = split_connections(&config, true).unwrap();
         assert_eq!(
-            upload, 1,
-            "explicit --check-connections must not shrink upload"
+            (check, upload),
+            (9, 1),
+            "-n 10 --check-connections 10 must clamp to 9+1, never 10+1"
+        );
+
+        config.connections = 1;
+        config.check_connections = 1;
+        let err = split_connections(&config, true).unwrap_err().to_string();
+        assert!(
+            err.contains("--no-check"),
+            "-n 1 --check-connections 1 must error, not open 1+1: {err}"
         );
     }
 
@@ -4898,7 +4966,7 @@ mod tests {
         let mut config = dry_run_config();
         config.connections = 2;
         config.check_connections = 0; // auto
-        let (check, upload) = split_connections(&config, true);
+        let (check, upload) = split_connections(&config, true).unwrap();
         assert_eq!(check, 1);
         assert_eq!(upload, 1);
     }
@@ -4912,7 +4980,7 @@ mod tests {
         let mut config = dry_run_config();
         config.connections = 4;
         config.check_connections = 0; // auto
-        let (check, upload) = split_connections(&config, true);
+        let (check, upload) = split_connections(&config, true).unwrap();
         assert_eq!(check, 1);
         assert_eq!(upload, 3);
     }
@@ -4922,7 +4990,7 @@ mod tests {
         let mut config = dry_run_config();
         config.connections = 200;
         config.check_connections = 0; // auto
-        let (check, upload) = split_connections(&config, true);
+        let (check, upload) = split_connections(&config, true).unwrap();
         assert_eq!(check, 4);
         assert_eq!(upload, 196);
     }

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -328,6 +328,22 @@ pub fn nzb_write_decision(
     }
 }
 
+/// Whether a combined `--season` NZB should be written.
+///
+/// The pack is a distinct artefact from per-episode NZBs: write only when
+/// every episode is complete (Confirmed, or Posted under `--no-check`),
+/// the run was not cancelled, and there is at least one segment. One
+/// MissingConfirmed or Inconclusive episode blocks the pack even if
+/// `--allow-incomplete-nzb` wrote that episode's own NZB — the flag never
+/// unlocks the merge.
+pub fn should_write_season_nzb(
+    any_cancelled: bool,
+    any_episode_incomplete: bool,
+    all_segments_empty: bool,
+) -> bool {
+    !any_cancelled && !any_episode_incomplete && !all_segments_empty
+}
+
 #[derive(Debug, Clone)]
 struct FileMeta {
     path: PathBuf,
@@ -5070,6 +5086,32 @@ mod tests {
             nzb_write_decision(false, true, true, true),
             NzbWriteDecision::Refuse
         );
+    }
+
+    // T16: season pack is a distinct artefact; incomplete episodes never merge.
+    #[test]
+    fn should_write_season_nzb_requires_every_episode_complete() {
+        assert!(should_write_season_nzb(false, false, false));
+        assert!(!should_write_season_nzb(true, false, false));
+        assert!(!should_write_season_nzb(false, true, false));
+        assert!(!should_write_season_nzb(false, false, true));
+        assert!(!should_write_season_nzb(true, true, false));
+        assert!(!should_write_season_nzb(false, true, true));
+        assert!(!should_write_season_nzb(true, false, true));
+        assert!(!should_write_season_nzb(true, true, true));
+    }
+
+    // T16: MissingConfirmed on one episode blocks the pack even when that
+    // episode's NZB was written via --allow-incomplete-nzb. The flag is not
+    // a parameter of this predicate.
+    #[test]
+    fn should_write_season_nzb_allow_incomplete_does_not_unlock_pack() {
+        let any_episode_incomplete = true; // MissingConfirmed, regardless of flag
+        assert!(!should_write_season_nzb(
+            false,
+            any_episode_incomplete,
+            false
+        ));
     }
 
     #[test]

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -5101,17 +5101,29 @@ mod tests {
         assert!(!should_write_season_nzb(true, true, true));
     }
 
-    // T16: MissingConfirmed on one episode blocks the pack even when that
-    // episode's NZB was written via --allow-incomplete-nzb. The flag is not
-    // a parameter of this predicate.
+    // T16: pack input is had_failures (true completeness), not
+    // nzb_write_decision. MissingConfirmed + --allow-incomplete-nzb writes
+    // the episode NZB but CLI/UpaPasta still pass incomplete=true.
     #[test]
-    fn should_write_season_nzb_allow_incomplete_does_not_unlock_pack() {
-        let any_episode_incomplete = true; // MissingConfirmed, regardless of flag
-        assert!(!should_write_season_nzb(
-            false,
-            any_episode_incomplete,
-            false
-        ));
+    fn season_pack_uses_had_failures_not_nzb_write_decision() {
+        let post_failures = false;
+        let missing_confirmed = true;
+        let inconclusive = false;
+        let allow_incomplete_nzb = true;
+        assert_eq!(
+            nzb_write_decision(
+                post_failures,
+                missing_confirmed,
+                inconclusive,
+                allow_incomplete_nzb
+            ),
+            NzbWriteDecision::Write
+        );
+        // CLI UploadResult.had_failures / UploadOutcome.had_failures —
+        // independent of the flag.
+        let had_failures = post_failures || missing_confirmed || inconclusive;
+        assert!(had_failures);
+        assert!(!should_write_season_nzb(false, had_failures, false));
     }
 
     #[test]

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -1295,9 +1295,6 @@ pub async fn post_files_inner(
             .map(|s| (s.file_name.clone(), s.part, s.total))
             .collect();
         for seg in recovered {
-            if let Some(tx) = shared.check_tx.lock().unwrap().as_ref() {
-                let _ = tx.send(seg.clone());
-            }
             if let Some(resume) = &shared.resume {
                 resume.lock().unwrap().record_with(
                     &seg.file_name,
@@ -1311,7 +1308,10 @@ pub async fn post_files_inner(
                     },
                 );
             }
-            shared.results.lock().unwrap().push(seg);
+            shared.results.lock().unwrap().push(seg.clone());
+            if let Some(tx) = shared.check_tx.lock().unwrap().as_ref() {
+                let _ = tx.send(seg);
+            }
         }
         failed_tasks.retain(|t| !recovered_keys.contains(&(t.file_name.clone(), t.part, t.total)));
         failures.retain(|f| {
@@ -2904,12 +2904,12 @@ async fn prepare_ready(shared: &Arc<Shared>, task: PostTask) -> Option<ReadyArti
                     file_index: task.meta.file_index,
                     total_files: shared.total_files,
                 };
+                shared.results.lock().unwrap().push(seg.clone());
                 if action == ResumeAction::ReStatStoredId {
                     if let Some(tx) = shared.check_tx.lock().unwrap().as_ref() {
-                        let _ = tx.send(seg.clone());
+                        let _ = tx.send(seg);
                     }
                 }
-                shared.results.lock().unwrap().push(seg);
                 let raw_bytes = task.data.len() as u64;
                 shared.release_buffer(task.data);
                 shared.emit(ProgressEvent::SegmentDone {
@@ -3584,10 +3584,10 @@ fn commit_result(
             file_index: task.meta.file_index,
             total_files: shared.total_files,
         };
+        shared.results.lock().unwrap().push(seg.clone());
         if let Some(tx) = shared.check_tx.lock().unwrap().as_ref() {
-            let _ = tx.send(seg.clone());
+            let _ = tx.send(seg);
         }
-        shared.results.lock().unwrap().push(seg);
     } else {
         record_failure(shared, &task.meta, &task, message_id, last_err);
     }

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -169,7 +169,23 @@ pub enum ProgressEvent {
     /// (verified, or given up on after every repost attempt); `ok` is true
     /// if this particular article was confirmed. Fires continuously,
     /// concurrently with the upload — there is no separate "check phase".
+    /// Shape is load-bearing: embedding matchers (UpaPasta) bind
+    /// `{ checked, ok }` without `..`.
     CheckProgress { checked: u64, ok: bool },
+    /// STAT itself failed (timeout, transport, 480/502, unexpected code)
+    /// until `check_retries` ran out, without ever seeing a 430. `count` is
+    /// how many articles have taken this path so far this run; `reason`
+    /// matches [`Self::CheckRetrying`] (`"connection error"` today).
+    /// Distinct from a confirmed gap — do not conflate with
+    /// [`Self::CheckProgress`] `{ ok: false }`.
+    CheckInconclusive { count: u64, reason: &'static str },
+    /// An isolated first-copy 430 skipped the remaining patient STAT
+    /// retries and went straight to repost. `first_checks` / `first_misses`
+    /// are the running totals that satisfied the fast-repost heuristic.
+    CheckFastRepost {
+        first_checks: u64,
+        first_misses: u64,
+    },
     /// The streaming check queue has fully drained (all articles resolved).
     /// `failed` is the number of articles that were never confirmed even
     /// after every repost attempt.
@@ -435,6 +451,22 @@ async fn json_emit_loop(mut rx: ProgressReceiver) {
                         let _ = writeln!(
                             out,
                             r#"{{"type":"check_progress","checked":{checked},"ok":{ok_str}}}"#
+                        );
+                    }
+                    ProgressEvent::CheckInconclusive { count, reason } => {
+                        let reason_esc = reason.replace('\\', "\\\\").replace('"', "\\\"");
+                        let _ = writeln!(
+                            out,
+                            r#"{{"type":"check_inconclusive","count":{count},"reason":"{reason_esc}"}}"#
+                        );
+                    }
+                    ProgressEvent::CheckFastRepost {
+                        first_checks,
+                        first_misses,
+                    } => {
+                        let _ = writeln!(
+                            out,
+                            r#"{{"type":"check_fast_repost","first_checks":{first_checks},"first_misses":{first_misses}}}"#
                         );
                     }
                     ProgressEvent::CheckDone { failed } => {

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -185,9 +185,10 @@ pub enum ProgressEvent {
         first_misses: u64,
     },
     /// The streaming check queue has fully drained (all articles resolved).
-    /// `failed` is the number of articles that were never confirmed even
-    /// after every repost attempt.
-    CheckDone { failed: u64 },
+    /// `failed` is MissingConfirmed (STAT 430 exhausted). `inconclusive` is
+    /// a failed check path (transport/timeout/480/502/cancel) — not a
+    /// confirmed gap, and never "all articles confirmed".
+    CheckDone { failed: u64, inconclusive: u64 },
     /// A STAT attempt failed on try `attempt`; retrying after `delay_secs`.
     /// `reason` distinguishes an article genuinely missing ("article not
     /// found") from the STAT call itself failing ("connection error") —
@@ -467,8 +468,14 @@ async fn json_emit_loop(mut rx: ProgressReceiver) {
                             r#"{{"type":"check_fast_repost","first_checks":{first_checks},"first_misses":{first_misses}}}"#
                         );
                     }
-                    ProgressEvent::CheckDone { failed } => {
-                        let _ = writeln!(out, r#"{{"type":"check_done","failed":{failed}}}"#);
+                    ProgressEvent::CheckDone {
+                        failed,
+                        inconclusive,
+                    } => {
+                        let _ = writeln!(
+                            out,
+                            r#"{{"type":"check_done","failed":{failed},"inconclusive":{inconclusive}}}"#
+                        );
                     }
                     ProgressEvent::CheckRetrying {
                         attempt,

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -52,8 +52,10 @@ pub enum ProgressEvent {
         /// (0 for `--par2-only`) — does not include `check_connections`.
         connections: usize,
         /// Number of NNTP connections dedicated to the streaming STAT check
-        /// (`poster::check`), carved out of `connections` — see
-        /// `split_connections`. 0 when checking is disabled.
+        /// (`poster::check`), carved out of `total_connections()` / `-n`
+        /// (not additive, and not a carve-out of this event's `connections`
+        /// field — that is `worker_count`, which can be smaller than upload
+        /// when the release has few segments). 0 when checking is disabled.
         check_connections: usize,
         /// `host:port` of the NNTP server, or `None` when not posting.
         target: Option<String>,

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -169,15 +169,11 @@ pub enum ProgressEvent {
     /// (verified, or given up on after every repost attempt); `ok` is true
     /// if this particular article was confirmed. Fires continuously,
     /// concurrently with the upload — there is no separate "check phase".
-    /// Shape is load-bearing: embedding matchers (UpaPasta) bind
-    /// `{ checked, ok }` without `..`.
     CheckProgress { checked: u64, ok: bool },
     /// STAT itself failed (timeout, transport, 480/502, unexpected code)
     /// until `check_retries` ran out, without ever seeing a 430. `count` is
     /// how many articles have taken this path so far this run; `reason`
-    /// matches [`Self::CheckRetrying`] (`"connection error"` today).
-    /// Distinct from a confirmed gap — do not conflate with
-    /// [`Self::CheckProgress`] `{ ok: false }`.
+    /// matches [`Self::CheckRetrying`] (`"connection error"`).
     CheckInconclusive { count: u64, reason: &'static str },
     /// An isolated first-copy 430 skipped the remaining patient STAT
     /// retries and went straight to repost. `first_checks` / `first_misses`

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -52,8 +52,8 @@ pub enum ProgressEvent {
         /// (0 for `--par2-only`) — does not include `check_connections`.
         connections: usize,
         /// Number of NNTP connections dedicated to the streaming STAT check
-        /// (`poster::check`), carved out of (or additive to) `connections` —
-        /// see `split_connections`. 0 when checking is disabled.
+        /// (`poster::check`), carved out of `connections` — see
+        /// `split_connections`. 0 when checking is disabled.
         check_connections: usize,
         /// `host:port` of the NNTP server, or `None` when not posting.
         target: Option<String>,

--- a/crates/pesto/src/resume.rs
+++ b/crates/pesto/src/resume.rs
@@ -99,8 +99,9 @@ pub struct FileFingerprint {
 
 /// In-memory confirmation state for a posted article. Not serialized —
 /// disk uses [`SegmentRecord`]'s two bools + `server_idx`.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfirmState {
+pub(crate) enum ConfirmState {
     Posted,
     CheckPending,
     CheckInFlight,

--- a/crates/pesto/src/resume.rs
+++ b/crates/pesto/src/resume.rs
@@ -4,9 +4,9 @@
 //! State is stored as a JSON file (`.pesto-state`) beside the `.nzb` output.
 //! Each record maps a `(relative_file_name, part_number)` pair to the
 //! `Message-ID` (and wire size) issued when the segment was originally
-//! posted. On resume, workers skip segments present in the state and inject
-//! the stored `Message-ID`/`bytes` directly into the results, so the final
-//! `.nzb` is correct.
+//! posted, plus whether STAT 223 confirmed it. On resume, `prepare_ready`
+//! either skips the segment, re-STATs the stored id without a second POST,
+//! or POSTs a fresh article — see [`resume_action`].
 //!
 //! Trusting a state file blindly is unsafe (see GitHub issue #18): the same
 //! output name can be reused for an unrelated or edited file, or with
@@ -97,18 +97,79 @@ pub struct FileFingerprint {
     pub mtime: Option<u64>,
 }
 
+/// In-memory confirmation state for a posted article. Not serialized —
+/// disk uses [`SegmentRecord`]'s two bools + `server_idx`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmState {
+    Posted,
+    CheckPending,
+    CheckInFlight,
+    Confirmed,
+    RetryWait,
+    Reposting,
+    Recovering,
+    MissingConfirmed,
+    Inconclusive,
+}
+
+/// What `--resume` should do with a stored [`SegmentRecord`] (or the lack of
+/// one) on this run. Evaluated in this order: no record → POST; check off
+/// or already confirmed → skip; otherwise re-STAT the stored Message-ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumeAction {
+    /// Inject the stored `PostedSegment`; no POST; no STAT.
+    Skip,
+    /// Inject the stored Message-ID into results and enqueue a STAT of that
+    /// same id. Do not encode or POST.
+    ReStatStoredId,
+    /// Encode and POST a fresh Message-ID (MissingConfirmed stripped, or
+    /// never posted).
+    Post,
+}
+
+/// Decide the `--resume` arm for this segment. Pre-schema JSON (no
+/// `confirmed`/`check_disabled` fields) deserializes both bools as `false`,
+/// which is the re-STAT path under `--check` and the skip path under
+/// `--no-check`. `check_disabled` is not inferred from old files.
+pub fn resume_action(check: bool, rec: Option<&SegmentRecord>) -> ResumeAction {
+    match rec {
+        None => ResumeAction::Post,
+        Some(_) if !check => ResumeAction::Skip,
+        Some(r) if r.confirmed => ResumeAction::Skip,
+        Some(_) => ResumeAction::ReStatStoredId,
+    }
+}
+
 /// One recorded segment: the `Message-ID` a prior run's `POST` was
 /// acknowledged under, and the wire size actually sent (headers + encoded
 /// body) — needed so a resumed segment can report its real size in the NZB
 /// instead of `0`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `confirmed` is set **only** after STAT 223. A `--no-check` run never
+/// writes `confirmed: true` (that run never STATed). New fields use
+/// `#[serde(default)]` so a pre-schema `{message_id, bytes}` record still
+/// loads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct SegmentRecord {
     pub message_id: String,
     pub bytes: u64,
+    /// STAT 223 observed in the run that wrote this record.
+    #[serde(default)]
+    pub confirmed: bool,
+    /// The writing run had `--no-check`. Informational; skip-when-check-off
+    /// does not require this field (any existing record is skipped when
+    /// check is off).
+    #[serde(default)]
+    pub check_disabled: bool,
+    /// Server that accepted the 240. Arm 2 copies this into `PostedSegment`
+    /// so STAT retargets the right host. Pre-schema JSON → 0.
+    #[serde(default)]
+    pub server_idx: usize,
 }
 
 /// Persistent state for a single upload session.
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ResumeState {
     /// Posting parameters this state was recorded under. `None` for a fresh
     /// state (nothing recorded yet) or a state file written before this
@@ -273,15 +334,35 @@ impl ResumeState {
         self.segments.get(&Self::key(file_name, part))
     }
 
-    /// Record a successfully posted segment.
+    /// Record a successfully posted segment. `confirmed`/`check_disabled`/
+    /// `server_idx` default to `(false, false, 0)` — the POST-240 path
+    /// should call [`Self::record_with`] so those flags match the run.
     pub fn record(&mut self, file_name: &str, part: u32, message_id: &str, bytes: u64) {
-        self.segments.insert(
-            Self::key(file_name, part),
+        self.record_with(
+            file_name,
+            part,
             SegmentRecord {
                 message_id: message_id.to_string(),
                 bytes,
+                confirmed: false,
+                check_disabled: false,
+                server_idx: 0,
             },
         );
+    }
+
+    /// Insert or overwrite the record for `(file_name, part)`.
+    pub fn record_with(&mut self, file_name: &str, part: u32, rec: SegmentRecord) {
+        self.segments.insert(Self::key(file_name, part), rec);
+    }
+
+    /// Flip `confirmed` after STAT 223. No-op if the segment is not recorded.
+    /// Never called on a `--no-check` run (that path never STATs).
+    pub fn mark_confirmed(&mut self, file_name: &str, part: u32) {
+        if let Some(rec) = self.segments.get_mut(&Self::key(file_name, part)) {
+            rec.confirmed = true;
+            rec.check_disabled = false;
+        }
     }
 
     /// Forget a segment — used when a POST that once succeeded is later
@@ -558,5 +639,92 @@ mod tests {
         let mut ll = base.clone();
         ll.line_length = 256;
         assert_ne!(base, ll);
+    }
+
+    #[test]
+    fn pre_schema_json_defaults_new_fields() {
+        let json = r#"{"files":{},"segments":{"a.bin\u00001":{"message_id":"id1@x","bytes":100}}}"#;
+        let loaded: ResumeState = serde_json::from_str(json).unwrap();
+        let rec = loaded.get("a.bin", 1).unwrap();
+        assert_eq!(rec.message_id, "id1@x");
+        assert_eq!(rec.bytes, 100);
+        assert!(!rec.confirmed);
+        assert!(!rec.check_disabled);
+        assert_eq!(rec.server_idx, 0);
+    }
+
+    #[test]
+    fn mark_confirmed_flips_only_that_record() {
+        let mut s = ResumeState::default();
+        s.record_with(
+            "a.bin",
+            1,
+            SegmentRecord {
+                message_id: "id1@x".into(),
+                bytes: 100,
+                confirmed: false,
+                check_disabled: true,
+                server_idx: 2,
+            },
+        );
+        s.record("a.bin", 2, "id2@x", 50);
+        s.mark_confirmed("a.bin", 1);
+        let rec = s.get("a.bin", 1).unwrap();
+        assert!(rec.confirmed);
+        assert!(!rec.check_disabled);
+        assert_eq!(rec.server_idx, 2);
+        assert!(!s.get("a.bin", 2).unwrap().confirmed);
+    }
+
+    #[test]
+    fn resume_action_three_arms() {
+        let confirmed = SegmentRecord {
+            message_id: "id@x".into(),
+            bytes: 1,
+            confirmed: true,
+            check_disabled: false,
+            server_idx: 0,
+        };
+        let unconfirmed = SegmentRecord {
+            confirmed: false,
+            ..confirmed.clone()
+        };
+        let check_off = SegmentRecord {
+            confirmed: false,
+            check_disabled: true,
+            ..confirmed.clone()
+        };
+        assert_eq!(resume_action(true, None), ResumeAction::Post);
+        assert_eq!(resume_action(false, None), ResumeAction::Post);
+        assert_eq!(resume_action(false, Some(&unconfirmed)), ResumeAction::Skip);
+        assert_eq!(resume_action(false, Some(&check_off)), ResumeAction::Skip);
+        assert_eq!(resume_action(false, Some(&confirmed)), ResumeAction::Skip);
+        assert_eq!(resume_action(true, Some(&confirmed)), ResumeAction::Skip);
+        assert_eq!(
+            resume_action(true, Some(&unconfirmed)),
+            ResumeAction::ReStatStoredId
+        );
+        assert_eq!(
+            resume_action(true, Some(&check_off)),
+            ResumeAction::ReStatStoredId
+        );
+    }
+
+    #[test]
+    fn no_check_record_never_sets_confirmed() {
+        let mut s = ResumeState::default();
+        s.record_with(
+            "a.bin",
+            1,
+            SegmentRecord {
+                message_id: "id@x".into(),
+                bytes: 10,
+                confirmed: false,
+                check_disabled: true,
+                server_idx: 0,
+            },
+        );
+        let rec = s.get("a.bin", 1).unwrap();
+        assert!(!rec.confirmed && rec.check_disabled);
     }
 }

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -294,8 +294,13 @@ struct RenderState {
     check_active: bool,
     check_checked: u64,
     check_failed: u64,
+    /// Articles whose STAT path failed (transport/timeout/unexpected code)
+    /// rather than a confirmed 430. Distinct from `check_failed`.
+    check_inconclusive: u64,
     check_reposted: u64,
     check_start: Instant,
+    /// Latest fast-repost heuristic snapshot, shown until the run ends.
+    check_fast_repost: Option<(u64, u64)>,
     /// Most recent retry backoff still in its window: (label without the
     /// countdown, e.g. "connection error — retry 1/3", deadline). Cleared
     /// once the deadline passes (`expire_check_retry`) rather than on every
@@ -378,9 +383,11 @@ impl RenderState {
             check_active: false,
             check_checked: 0,
             check_failed: 0,
+            check_inconclusive: 0,
             check_reposted: 0,
             check_start: Instant::now(),
             check_retry: None,
+            check_fast_repost: None,
             recover_active: false,
             recover_done: 0,
             recover_total: 0,
@@ -670,6 +677,25 @@ impl RenderState {
                 if !ok {
                     self.check_failed += 1;
                 }
+            }
+            ProgressEvent::CheckInconclusive { count, .. } => {
+                if !self.check_active {
+                    self.started = true;
+                    self.check_active = true;
+                    self.check_start = Instant::now();
+                }
+                self.check_inconclusive = count;
+            }
+            ProgressEvent::CheckFastRepost {
+                first_checks,
+                first_misses,
+            } => {
+                if !self.check_active {
+                    self.started = true;
+                    self.check_active = true;
+                    self.check_start = Instant::now();
+                }
+                self.check_fast_repost = Some((first_checks, first_misses));
             }
             ProgressEvent::CheckRetrying {
                 attempt,
@@ -1008,8 +1034,13 @@ impl RenderState {
                 String::new()
             };
             if self.failures + self.check_failed > 0 {
+                let inconclusive_note = if self.check_inconclusive > 0 {
+                    format!(" · {}", inconclusive_label(self.check_inconclusive))
+                } else {
+                    String::new()
+                };
                 format!(
-                    "upload incomplete · {} unresolved",
+                    "upload incomplete · {} unresolved{inconclusive_note}",
                     self.failures + self.check_failed
                 )
             } else if self.mode == RunMode::Post && self.checks_enabled {
@@ -1325,6 +1356,12 @@ impl RenderState {
             }
         }
 
+        if self.check_inconclusive > 0 {
+            lines.push(format!(
+                "  {}",
+                ansi(&inconclusive_label(self.check_inconclusive), "33")
+            ));
+        }
         if let Some(desc) = &self.failed_description {
             lines.push(format!("  {}", ansi(&format!("⚠ {desc}"), "33")));
         }
@@ -1602,6 +1639,15 @@ impl RenderState {
                 lines.push(box_top("availability", body_w));
                 lines.push(box_line(&line1, body_w));
                 lines.push(box_line(&line2, body_w));
+                if self.check_inconclusive > 0 {
+                    lines.push(box_line(
+                        &ansi(&inconclusive_label(self.check_inconclusive), "33"),
+                        body_w,
+                    ));
+                }
+                if let Some((n, m)) = self.check_fast_repost {
+                    lines.push(box_line(&fast_repost_label(n, m), body_w));
+                }
                 lines.push(box_bottom(body_w));
             }
 
@@ -2009,6 +2055,15 @@ impl RenderState {
                 let remaining = deadline.saturating_duration_since(Instant::now()).as_secs();
                 suffix.push_str(&format!(" · {label} in {remaining}s"));
             }
+            if self.check_inconclusive > 0 {
+                suffix.push_str(&format!(
+                    " · {}",
+                    inconclusive_label(self.check_inconclusive)
+                ));
+            }
+            if let Some((n, m)) = self.check_fast_repost {
+                suffix.push_str(&format!(" · {}", fast_repost_label(n, m)));
+            }
             suffix
         } else {
             String::new()
@@ -2178,6 +2233,17 @@ fn render_dual_bar(checked_frac: f64, total_frac: f64, width: usize) -> String {
         s.push('░');
     }
     s
+}
+
+/// Inconclusive STAT-path failures: not a confirmed 430 gap.
+fn inconclusive_label(count: u64) -> String {
+    format!("{count} inconclusive (check path failed — not a confirmed gap)")
+}
+
+/// Fast-repost heuristic snapshot for the availability box / plain suffix.
+fn fast_repost_label(first_checks: u64, first_misses: u64) -> String {
+    let pct = (first_misses as f64 / first_checks.max(1) as f64 * 100.0).round() as u64;
+    format!("fast-repost: isolated miss (miss rate {pct}% of {first_checks} first checks)")
 }
 
 /// Human-readable byte size with binary (IEC) units.
@@ -2906,6 +2972,59 @@ mod tests {
         assert!(summary.contains("accepted by the server"));
         assert!(summary.contains("Not independently verified"));
         assert!(!summary.contains("articles confirmed"));
+    }
+
+    #[test]
+    fn inconclusive_is_shown_distinctly_from_missing() {
+        let mut state = upload_done_check_running();
+        state.apply(ProgressEvent::CheckInconclusive {
+            count: 2,
+            reason: "connection error",
+        });
+        state.apply(ProgressEvent::CheckProgress {
+            checked: state.total_segments,
+            ok: false,
+        });
+        state.apply(ProgressEvent::CheckDone { failed: 1 });
+
+        let panel = state.panel_lines(true, 160).join("\n");
+        assert!(
+            panel.contains("2 inconclusive (check path failed — not a confirmed gap)"),
+            "availability box should name inconclusive distinctly:\n{panel}"
+        );
+        assert!(
+            panel.contains("1 missing"),
+            "confirmed-missing tally must still appear alongside inconclusive:\n{panel}"
+        );
+        assert!(
+            !panel.contains("2 missing"),
+            "inconclusive count must not be labelled as missing:\n{panel}"
+        );
+
+        let summary = state.summary_lines(160).join("\n");
+        assert!(
+            summary.contains("2 inconclusive (check path failed — not a confirmed gap)"),
+            "final summary should name inconclusive:\n{summary}"
+        );
+        assert!(
+            summary.contains("unresolved failure"),
+            "NZB-policy missing count stays in the summary:\n{summary}"
+        );
+        assert!(summary.contains('✗'));
+    }
+
+    #[test]
+    fn fast_repost_is_shown_when_it_fires() {
+        let mut state = upload_done_check_running();
+        state.apply(ProgressEvent::CheckFastRepost {
+            first_checks: 20,
+            first_misses: 1,
+        });
+        let panel = state.panel_lines(false, 160).join("\n");
+        assert!(
+            panel.contains("fast-repost: isolated miss (miss rate 5% of 20 first checks)"),
+            "availability box should report the fast-repost heuristic:\n{panel}"
+        );
     }
 
     #[test]

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -2240,7 +2240,6 @@ fn inconclusive_label(count: u64) -> String {
     format!("{count} inconclusive (check path failed — not a confirmed gap)")
 }
 
-/// Fast-repost heuristic snapshot for the availability box / plain suffix.
 fn fast_repost_label(first_checks: u64, first_misses: u64) -> String {
     let pct = (first_misses as f64 / first_checks.max(1) as f64 * 100.0).round() as u64;
     format!("fast-repost: isolated miss (miss rate {pct}% of {first_checks} first checks)")

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -684,6 +684,11 @@ impl RenderState {
                     self.check_active = true;
                     self.check_start = Instant::now();
                 }
+                if count > self.check_inconclusive {
+                    self.check_checked = self
+                        .check_checked
+                        .saturating_add(count - self.check_inconclusive);
+                }
                 self.check_inconclusive = count;
             }
             ProgressEvent::CheckFastRepost {
@@ -714,9 +719,18 @@ impl RenderState {
             ProgressEvent::CheckRetryRecovered => {
                 self.recovered_check_retries += 1;
             }
-            ProgressEvent::CheckDone { failed } => {
+            ProgressEvent::CheckDone {
+                failed,
+                inconclusive,
+            } => {
                 self.check_active = false;
                 self.check_failed = failed;
+                if inconclusive > self.check_inconclusive {
+                    self.check_checked = self
+                        .check_checked
+                        .saturating_add(inconclusive - self.check_inconclusive);
+                }
+                self.check_inconclusive = inconclusive;
                 self.check_retry = None;
             }
             ProgressEvent::CheckRecoverStarted { total } => {
@@ -921,7 +935,9 @@ impl RenderState {
     }
 
     fn confirmed_articles(&self) -> u64 {
-        self.check_checked.saturating_sub(self.check_failed)
+        self.check_checked
+            .saturating_sub(self.check_failed)
+            .saturating_sub(self.check_inconclusive)
     }
 
     fn accepted_articles(&self) -> u64 {
@@ -1008,7 +1024,7 @@ impl RenderState {
             // Reserve the red-style cross for unresolved upload/availability
             // failures. Cancellation remains a warning rather than looking
             // like a server rejected data.
-            if self.failures > 0 || self.check_failed > 0 {
+            if self.failures > 0 || self.check_failed > 0 || self.check_inconclusive > 0 {
                 '✗'
             } else if self.interrupted || self.failed_description.is_some() {
                 '⚠'
@@ -1243,7 +1259,7 @@ impl RenderState {
     /// nzb`/`wrote nfo` paths, so this covers only what the renderer itself
     /// knows — outcome, throughput and verification.
     fn summary_lines(&self, width: usize) -> Vec<String> {
-        let unresolved = self.failures + self.check_failed;
+        let unresolved = self.failures + self.check_failed + self.check_inconclusive;
         let ok = unresolved == 0 && !self.interrupted && self.failed_description.is_none();
         let glyph = if self.interrupted || self.failed_description.is_some() {
             ansi("⚠", "33")
@@ -1582,7 +1598,10 @@ impl RenderState {
             // This box carries the numbers that band can't — the running
             // verified / pending / missing / reposted tally.
             if self.check_active || (final_draw && self.check_checked > 0) {
-                let verified = self.check_checked.saturating_sub(self.check_failed);
+                let verified = self
+                    .check_checked
+                    .saturating_sub(self.check_failed)
+                    .saturating_sub(self.check_inconclusive);
                 let pending = self.done_segments.saturating_sub(self.check_checked);
                 // Colour-match the upload bar's two bands: "verified" in the
                 // checked band's colour, "pending" in the upload band's —
@@ -1594,11 +1613,21 @@ impl RenderState {
                     &format!("{pending} pending confirmation"),
                     UPLOAD_BAND_COLOR,
                 );
-                let mut line1 = if self.check_failed > 0 {
-                    format!(
-                        "{verified_str} · {pending_str} · {}",
-                        ansi(&format!("{} missing", self.check_failed), "31")
-                    )
+                let mut line1 = if self.check_failed > 0 || self.check_inconclusive > 0 {
+                    let mut extra = String::new();
+                    if self.check_failed > 0 {
+                        extra.push_str(&format!(
+                            " · {}",
+                            ansi(&format!("{} missing", self.check_failed), "31")
+                        ));
+                    }
+                    if self.check_inconclusive > 0 {
+                        extra.push_str(&format!(
+                            " · {}",
+                            ansi(&format!("{} inconclusive", self.check_inconclusive), "33")
+                        ));
+                    }
+                    format!("{verified_str} · {pending_str}{extra}")
                 } else if !self.check_active {
                     format!("{verified_str} · all confirmed available")
                 } else {
@@ -2034,11 +2063,14 @@ impl RenderState {
         // extra suffix on the normal progress line rather than a phase that
         // suppresses it.
         let check_suffix = if self.check_active || (final_draw && self.check_checked > 0) {
-            let verified = self.check_checked.saturating_sub(self.check_failed);
+            let verified = self
+                .check_checked
+                .saturating_sub(self.check_failed)
+                .saturating_sub(self.check_inconclusive);
             let pending = self.done_segments.saturating_sub(self.check_checked);
             let mut suffix = format!(
-                " · availability: {verified} confirmed/{} missing/{pending} pending",
-                self.check_failed
+                " · availability: {verified} confirmed/{} missing/{} inconclusive/{pending} pending",
+                self.check_failed, self.check_inconclusive
             );
             let retries_awaiting_confirmation = self
                 .check_reposted
@@ -2690,7 +2722,10 @@ mod tests {
     /// `check::recover_missing` (and its `CheckRecoverStarted`) ever runs.
     fn recovery_pass_running() -> RenderState {
         let mut state = upload_done_check_running();
-        state.apply(ProgressEvent::CheckDone { failed: 2 });
+        state.apply(ProgressEvent::CheckDone {
+            failed: 2,
+            inconclusive: 0,
+        });
         state.apply(ProgressEvent::CheckRecoverStarted { total: 2 });
         state
     }
@@ -2824,7 +2859,10 @@ mod tests {
             checked: state.total_segments,
             ok: true,
         });
-        state.apply(ProgressEvent::CheckDone { failed: 0 });
+        state.apply(ProgressEvent::CheckDone {
+            failed: 0,
+            inconclusive: 0,
+        });
         for width in [60, 80, 100] {
             let summary = state.summary_lines(width);
             assert_eq!(summary.len(), 2, "clean summary stays at two lines");
@@ -2892,7 +2930,10 @@ mod tests {
             checked: state.total_segments,
             ok: true,
         });
-        state.apply(ProgressEvent::CheckDone { failed: 0 });
+        state.apply(ProgressEvent::CheckDone {
+            failed: 0,
+            inconclusive: 0,
+        });
 
         for width in [60, 80] {
             let lines = state.summary_lines(width);
@@ -2924,7 +2965,10 @@ mod tests {
             checked: state.total_segments,
             ok: true,
         });
-        state.apply(ProgressEvent::CheckDone { failed: 0 });
+        state.apply(ProgressEvent::CheckDone {
+            failed: 0,
+            inconclusive: 0,
+        });
 
         let summary = state.summary_lines(80).join("\n");
         assert!(summary.contains("Upload complete"));
@@ -2940,7 +2984,10 @@ mod tests {
             checked: state.total_segments,
             ok: false,
         });
-        state.apply(ProgressEvent::CheckDone { failed: 1 });
+        state.apply(ProgressEvent::CheckDone {
+            failed: 1,
+            inconclusive: 0,
+        });
 
         let summary = state.summary_lines(160).join("\n");
         assert!(summary.contains("Upload incomplete"));
@@ -2984,7 +3031,10 @@ mod tests {
             checked: state.total_segments,
             ok: false,
         });
-        state.apply(ProgressEvent::CheckDone { failed: 1 });
+        state.apply(ProgressEvent::CheckDone {
+            failed: 1,
+            inconclusive: 2,
+        });
 
         let panel = state.panel_lines(true, 160).join("\n");
         assert!(
@@ -3024,6 +3074,28 @@ mod tests {
             panel.contains("fast-repost: isolated miss (miss rate 5% of 20 first checks)"),
             "availability box should report the fast-repost heuristic:\n{panel}"
         );
+    }
+
+    #[test]
+    fn inconclusive_check_never_claims_articles_were_confirmed() {
+        let mut state = upload_done_check_running();
+        state.apply(ProgressEvent::CheckInconclusive {
+            count: 1,
+            reason: "connection error",
+        });
+        state.apply(ProgressEvent::CheckDone {
+            failed: 0,
+            inconclusive: 1,
+        });
+
+        let summary = state.summary_lines(160).join("\n");
+        assert!(summary.contains("Upload incomplete"));
+        assert!(summary.contains("unresolved"));
+        assert!(
+            !summary.contains("articles confirmed"),
+            "Inconclusive must not be reported as confirmed: {summary}"
+        );
+        assert!(!summary.contains("Upload complete"));
     }
 
     #[test]

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -22,6 +22,8 @@ pub struct UploadOutcome {
     pub groups: Vec<String>,
     pub cancelled: bool,
     pub had_failures: bool,
+    /// STAT path failed without a 430. Never unblocked by `allow_incomplete_nzb`.
+    pub inconclusive: Vec<String>,
     pub nzb_path: Option<PathBuf>,
     pub total_bytes: u64,
     /// See [`crate::poster::PostOutcome::failure_reason`]: set when
@@ -241,8 +243,9 @@ pub async fn run_upload(
     // Set when the streaming check still can't confirm some articles after
     // every repost attempt. Kept separate from `has_post_failures` because
     // `--allow-incomplete-nzb` only opts back into publishing past *this*
-    // kind of gap, not a genuine POST failure.
+    // kind of gap, not a genuine POST failure, and never past Inconclusive.
     let has_confirmed_missing = !outcome.still_missing.is_empty();
+    let has_inconclusive = !outcome.inconclusive.is_empty();
     let cancelled = outcome.cancelled || cancel.as_ref().is_some_and(|f| f.load(Ordering::Relaxed));
 
     if has_confirmed_missing {
@@ -255,14 +258,25 @@ pub async fn run_upload(
             "check: articles still missing after every repost attempt"
         );
     }
+    if has_inconclusive {
+        for id in &outcome.inconclusive {
+            emit_status(&progress_tx, format!("  inconclusive: {id}"));
+        }
+        tracing::error!(
+            count = outcome.inconclusive.len(),
+            ids = ?outcome.inconclusive,
+            "check: articles inconclusive (check path failed — not a confirmed gap)"
+        );
+    }
 
-    // If some articles are still confirmed missing after every repost round,
-    // refuse to write the NZB (and skip NFO/hooks below) unless the caller
-    // explicitly opted into publishing anyway via `allow_incomplete_nzb`
-    // (e.g. relying on PAR2 recovery). A genuine POST failure always blocks,
-    // regardless of the flag.
-    let write_blocked =
-        has_post_failures || (has_confirmed_missing && !config.allow_incomplete_nzb);
+    // POST failures and Inconclusive always refuse the NZB.
+    // `--allow-incomplete-nzb` unblocks only MissingConfirmed.
+    let write_blocked = crate::poster::nzb_write_decision(
+        has_post_failures,
+        has_confirmed_missing,
+        has_inconclusive,
+        config.allow_incomplete_nzb,
+    ) == crate::poster::NzbWriteDecision::Refuse;
 
     // ── Write NZB ────────────────────────────────────────────────────────────
     let nzb_path: Option<PathBuf> = if (cancelled && !config.resume)
@@ -369,7 +383,7 @@ pub async fn run_upload(
             // Reflects true completeness, independent of `allow_incomplete_nzb`
             // — the notification should say "not fully ok" even when the
             // caller chose to publish anyway.
-            ok: !(has_post_failures || has_confirmed_missing),
+            ok: !(has_post_failures || has_confirmed_missing || has_inconclusive),
         })
         .await;
     }
@@ -456,6 +470,7 @@ pub async fn run_upload(
                 .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             wire_subject: crate::nzb::wire_subject(&outcome.segments).unwrap_or_default(),
+            incomplete: has_confirmed_missing,
         };
         let hook_cfg = config.clone();
         let log_lines =
@@ -487,7 +502,8 @@ pub async fn run_upload(
         // True completeness, independent of `allow_incomplete_nzb` — the
         // caller (e.g. upapasta's catalog) should still be able to tell an
         // upload with confirmed-missing articles apart from a clean one.
-        had_failures: has_post_failures || has_confirmed_missing,
+        had_failures: has_post_failures || has_confirmed_missing || has_inconclusive,
+        inconclusive: outcome.inconclusive,
         nzb_path,
         total_bytes,
         failure_reason: outcome.failure_reason,

--- a/crates/pesto/tests/check_fast_reposts_isolated_miss.rs
+++ b/crates/pesto/tests/check_fast_reposts_isolated_miss.rs
@@ -170,7 +170,7 @@ async fn check_fast_reposts_an_isolated_miss_instead_of_waiting_out_patient_retr
         host: addr.ip().to_string(),
         port: addr.port(),
         ssl: false,
-        connections: 1,
+        connections: 2,
         username: None,
         password: None,
         from: "tester <t@pesto.test>".to_string(),

--- a/crates/pesto/tests/check_inconclusive.rs
+++ b/crates/pesto/tests/check_inconclusive.rs
@@ -2,7 +2,7 @@
 //!
 //! Mock NNTP only — never a real provider.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -140,6 +140,105 @@ async fn spawn_mock(stat: StatBehaviour, post_already_exists: bool) -> (u16, Moc
         });
     }
     (addr.port(), counts)
+}
+
+/// POST 240, STAT 430, then AUTH 481 on the reconnect that `repost_one` does
+/// after `handle_confirmed_miss`. AUTH 48x must be Inconclusive, not a 4xx
+/// article refusal.
+async fn spawn_430_then_auth_481() -> (u16, MockStats) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let counts = MockStats::default();
+    let seen_stat = Arc::new(AtomicBool::new(false));
+    {
+        let counts = counts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                let counts = counts.clone();
+                let seen_stat = seen_stat.clone();
+                tokio::spawn(async move {
+                    handle_430_then_auth_481(stream, counts, seen_stat).await;
+                });
+            }
+        });
+    }
+    (addr.port(), counts)
+}
+
+async fn handle_430_then_auth_481(
+    stream: TcpStream,
+    counts: MockStats,
+    seen_stat: Arc<AtomicBool>,
+) {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    write_half
+        .write_all(b"200 pesto mock ready\r\n")
+        .await
+        .unwrap();
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await.unwrap() == 0 {
+            return;
+        }
+        let command = line.trim_end();
+
+        if command.starts_with("AUTHINFO USER") {
+            write_half
+                .write_all(b"381 password required\r\n")
+                .await
+                .unwrap();
+        } else if command.starts_with("AUTHINFO PASS") {
+            if seen_stat.load(Ordering::Relaxed) {
+                write_half
+                    .write_all(b"481 Authentication failed\r\n")
+                    .await
+                    .unwrap();
+            } else {
+                write_half
+                    .write_all(b"281 authenticated\r\n")
+                    .await
+                    .unwrap();
+            }
+        } else if command == "POST" {
+            write_half.write_all(b"340 send article\r\n").await.unwrap();
+            let mut body = Vec::new();
+            loop {
+                body.clear();
+                if reader.read_until(b'\n', &mut body).await.unwrap() == 0 {
+                    return;
+                }
+                if body == b".\r\n" {
+                    break;
+                }
+            }
+            counts.posts.fetch_add(1, Ordering::Relaxed);
+            write_half
+                .write_all(b"240 article received\r\n")
+                .await
+                .unwrap();
+        } else if command.starts_with("STAT ") {
+            counts.stats.fetch_add(1, Ordering::Relaxed);
+            seen_stat.store(true, Ordering::Relaxed);
+            write_half
+                .write_all(b"430 No such article\r\n")
+                .await
+                .unwrap();
+        } else if command.starts_with("MODE READER") {
+            write_half.write_all(b"200 reader mode\r\n").await.unwrap();
+        } else if command == "QUIT" {
+            write_half.write_all(b"205 bye\r\n").await.unwrap();
+            return;
+        } else {
+            write_half
+                .write_all(b"500 unknown command\r\n")
+                .await
+                .unwrap();
+        }
+    }
 }
 
 fn test_config(port: u16) -> Config {
@@ -441,4 +540,43 @@ async fn t21_run_upload_refuses_nzb_on_inconclusive() {
     assert!(!nzb.exists());
     let state_path = nzb.with_extension("pesto-state");
     assert!(state_path.exists());
+}
+
+/// AUTH 481 on the reconnect after a STAT 430 must be Inconclusive, not a
+/// 4xx article refusal. `handle_confirmed_miss` invalidates the slot and
+/// `repost_one` re-AUTHs; 48x is the AUTH class, not MissingConfirmed.
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_481_on_repost_after_430_is_inconclusive() {
+    let (port, _) = spawn_430_then_auth_481().await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 80);
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let mut config = test_config(port);
+    config.check_post_retries = 1;
+
+    let outcome = post_files_with_progress(
+        &config,
+        std::slice::from_ref(&file),
+        None,
+        Some(&state_path),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        outcome.still_missing.is_empty(),
+        "AUTH 481 on repost must not become MissingConfirmed: {:?}",
+        outcome.still_missing
+    );
+    assert!(
+        !outcome.inconclusive.is_empty(),
+        "AUTH 481 on repost must be Inconclusive"
+    );
+    assert!(state_path.exists());
+    let state = ResumeState::load(&state_path).unwrap();
+    assert!(
+        state.get("movie.bin", 1).is_some(),
+        "Inconclusive must not strip the stored id"
+    );
 }

--- a/crates/pesto/tests/check_inconclusive.rs
+++ b/crates/pesto/tests/check_inconclusive.rs
@@ -1,0 +1,444 @@
+//! Inconclusive ≠ MissingConfirmed (design T5 / T5b / T6 / T11 / T21).
+//!
+//! Mock NNTP only — never a real provider.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+use pesto::config::{Config, ObfuscateMode};
+use pesto::poster::post_files_with_progress;
+use pesto::resume::ResumeState;
+use pesto::upload::run_upload;
+
+#[derive(Clone, Default)]
+struct MockStats {
+    posts: Arc<AtomicUsize>,
+    stats: Arc<AtomicUsize>,
+}
+
+#[derive(Clone, Copy)]
+enum StatBehaviour {
+    /// Drop the connection without a STAT response (T5).
+    Drop,
+    /// Reply with this 3-digit code (T6: 480/502).
+    Code(&'static str),
+    /// Always 430 (T11 MissingConfirmed).
+    Missing,
+    /// Always 223 (resume re-STAT).
+    Present,
+}
+
+async fn handle_connection(
+    stream: TcpStream,
+    counts: MockStats,
+    stat: StatBehaviour,
+    post_already_exists: bool,
+) {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    write_half
+        .write_all(b"200 pesto mock ready\r\n")
+        .await
+        .unwrap();
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await.unwrap() == 0 {
+            return;
+        }
+        let command = line.trim_end();
+
+        if command.starts_with("AUTHINFO USER") {
+            write_half
+                .write_all(b"381 password required\r\n")
+                .await
+                .unwrap();
+        } else if command.starts_with("AUTHINFO PASS") {
+            write_half
+                .write_all(b"281 authenticated\r\n")
+                .await
+                .unwrap();
+        } else if command == "POST" {
+            write_half.write_all(b"340 send article\r\n").await.unwrap();
+            let mut body = Vec::new();
+            loop {
+                body.clear();
+                if reader.read_until(b'\n', &mut body).await.unwrap() == 0 {
+                    return;
+                }
+                if body == b".\r\n" {
+                    break;
+                }
+            }
+            counts.posts.fetch_add(1, Ordering::Relaxed);
+            if post_already_exists {
+                write_half
+                    .write_all(b"441 435 Already exists in history\r\n")
+                    .await
+                    .unwrap();
+            } else {
+                write_half
+                    .write_all(b"240 article received\r\n")
+                    .await
+                    .unwrap();
+            }
+        } else if command.starts_with("STAT ") {
+            counts.stats.fetch_add(1, Ordering::Relaxed);
+            match stat {
+                StatBehaviour::Drop => return,
+                StatBehaviour::Code(code) => {
+                    let resp = format!("{code} STAT failed\r\n");
+                    write_half.write_all(resp.as_bytes()).await.unwrap();
+                }
+                StatBehaviour::Missing => {
+                    write_half
+                        .write_all(b"430 No such article\r\n")
+                        .await
+                        .unwrap();
+                }
+                StatBehaviour::Present => {
+                    write_half
+                        .write_all(b"223 0 article exists\r\n")
+                        .await
+                        .unwrap();
+                }
+            }
+        } else if command.starts_with("MODE READER") {
+            write_half.write_all(b"200 reader mode\r\n").await.unwrap();
+        } else if command == "QUIT" {
+            write_half.write_all(b"205 bye\r\n").await.unwrap();
+            return;
+        } else {
+            write_half
+                .write_all(b"500 unknown command\r\n")
+                .await
+                .unwrap();
+        }
+    }
+}
+
+async fn spawn_mock(stat: StatBehaviour, post_already_exists: bool) -> (u16, MockStats) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let counts = MockStats::default();
+    {
+        let counts = counts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection(
+                    stream,
+                    counts.clone(),
+                    stat,
+                    post_already_exists,
+                ));
+            }
+        });
+    }
+    (addr.port(), counts)
+}
+
+fn test_config(port: u16) -> Config {
+    Config {
+        host: "127.0.0.1".to_string(),
+        port,
+        ssl: false,
+        connections: 2,
+        username: Some("user".to_string()),
+        password: Some("pass".to_string()),
+        from: "tester <t@pesto.test>".to_string(),
+        groups: vec!["alt.binaries.test".to_string()],
+        article_size: 100,
+        line_length: 128,
+        retries: 1,
+        retry_delay: 0,
+        timeout: pesto::config::DEFAULT_TIMEOUT_SECS,
+        proxy: None,
+        proxy_check_ip: false,
+        obfuscate: ObfuscateMode::None,
+        dry_run: false,
+        par2: 0,
+        par2_memory_limit: Some(1_000_000_000),
+        memory_limit: None,
+        par2_temp_dir: None,
+        compress_temp_dir: None,
+        par2_slice_size: None,
+        par2_slice_count: None,
+        par2_recovery_count: None,
+        par2_only: false,
+        par2_before_upload: false,
+        threads: 0,
+        simd: parmesan::SimdPath::Auto,
+        extra_servers: vec![],
+        resume: false,
+        upload_rate: 0,
+        compress_format: None,
+        compress_password: None,
+        compress_volume_size: None,
+        nzb_title: None,
+        nzb_password: None,
+        nzb_category: None,
+        nzb_tags: vec![],
+        tmdb_id: None,
+        tmdb_kind: None,
+        imdb_id: None,
+        tvdb_id: None,
+        tvdb_kind: None,
+        mal_id: None,
+        indexer_url: None,
+        indexer_api_key: None,
+        notify_webhook: None,
+        notify_ntfy: None,
+        notify: None,
+        history: false,
+        history_dir: None,
+        nzb_dir: None,
+        date: None,
+        no_archive: false,
+        file_counter: false,
+        message_id_domain: None,
+        pre_hooks: vec![],
+        post_hooks: vec![],
+        no_hooks: true,
+        nfo: false,
+        nzb_conflict: pesto::config::NzbConflict::Overwrite,
+        quiet: false,
+        bell: false,
+        check: true,
+        check_delay_secs: 0,
+        check_retries: 1,
+        check_connections: 1,
+        check_post_retries: 0,
+        allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
+        pipeline_depth: 1,
+        keepalive_interval: 0,
+    }
+}
+
+fn input(dir: &std::path::Path, name: &str, bytes: usize) -> pesto::walk::InputFile {
+    let path = dir.join(name);
+    std::fs::write(&path, vec![0xABu8; bytes]).unwrap();
+    pesto::walk::InputFile {
+        path,
+        name: name.to_string(),
+    }
+}
+
+/// T5: connection drop on STAT is Inconclusive, not MissingConfirmed; NZB
+/// refused; `--resume` re-STATs the same ID with no extra POST.
+#[tokio::test(flavor = "multi_thread")]
+async fn t5_stat_drop_is_inconclusive_not_missing() {
+    let (port, counts) = spawn_mock(StatBehaviour::Drop, false).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 80);
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let config = test_config(port);
+
+    let outcome = post_files_with_progress(
+        &config,
+        std::slice::from_ref(&file),
+        None,
+        Some(&state_path),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        outcome.still_missing.is_empty(),
+        "STAT drop must not become MissingConfirmed: {:?}",
+        outcome.still_missing
+    );
+    assert!(
+        !outcome.inconclusive.is_empty(),
+        "STAT drop must be Inconclusive"
+    );
+    assert_eq!(
+        counts.posts.load(Ordering::Relaxed),
+        1,
+        "a STAT drop must not trigger a repost"
+    );
+    assert!(
+        state_path.exists(),
+        "Inconclusive must persist .pesto-state"
+    );
+    let state = ResumeState::load(&state_path).unwrap();
+    let rec = state.get("movie.bin", 1).expect("id must not be stripped");
+    assert!(!rec.confirmed);
+    let stored_id = rec.message_id.clone();
+
+    let (port2, counts2) = spawn_mock(StatBehaviour::Present, false).await;
+    let mut config2 = test_config(port2);
+    config2.resume = true;
+    let outcome2 = post_files_with_progress(&config2, &[file], None, Some(&state_path), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        counts2.posts.load(Ordering::Relaxed),
+        0,
+        "resume after Inconclusive must re-STAT the stored id, not POST"
+    );
+    assert!(counts2.stats.load(Ordering::Relaxed) >= 1);
+    assert_eq!(outcome2.segments[0].message_id, stored_id);
+    assert!(outcome2.still_missing.is_empty());
+    assert!(outcome2.inconclusive.is_empty());
+}
+
+/// T5b: `--allow-incomplete-nzb` does not unblock Inconclusive.
+#[tokio::test(flavor = "multi_thread")]
+async fn t5b_allow_incomplete_does_not_write_nzb_for_inconclusive() {
+    let (port, _) = spawn_mock(StatBehaviour::Drop, false).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 80);
+    let nzb = dir.path().join("out.nzb");
+    let mut config = test_config(port);
+    config.allow_incomplete_nzb = true;
+
+    let outcome = run_upload(
+        &config,
+        std::slice::from_ref(&file.path),
+        "movie.bin",
+        None,
+        None,
+        Some(nzb.clone()),
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(outcome.had_failures);
+    assert!(!outcome.inconclusive.is_empty());
+    assert!(
+        outcome.nzb_path.is_none() && !nzb.exists(),
+        "T5b: --allow-incomplete-nzb must not publish an Inconclusive NZB"
+    );
+}
+
+/// T6: STAT 480/502 is the same class as T5.
+#[tokio::test(flavor = "multi_thread")]
+async fn t6_stat_502_is_inconclusive() {
+    let (port, counts) = spawn_mock(StatBehaviour::Code("502"), false).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 80);
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let config = test_config(port);
+
+    let outcome = post_files_with_progress(&config, &[file], None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(
+        outcome.still_missing.is_empty(),
+        "502 must not become MissingConfirmed: {:?}",
+        outcome.still_missing
+    );
+    assert!(!outcome.inconclusive.is_empty());
+    assert_eq!(counts.posts.load(Ordering::Relaxed), 1);
+    assert!(state_path.exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t6_stat_480_is_inconclusive() {
+    let (port, _) = spawn_mock(StatBehaviour::Code("480"), false).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 80);
+    let config = test_config(port);
+    let outcome = post_files_with_progress(&config, &[file], None, None, None)
+        .await
+        .unwrap();
+    assert!(outcome.still_missing.is_empty());
+    assert!(!outcome.inconclusive.is_empty());
+}
+
+/// T21 + T11 library path: `run_upload` writes the NZB on MissingConfirmed
+/// + `--allow-incomplete-nzb`, keeps state, strips the missing id, and sets
+/// `PESTO_INCOMPLETE=1`.
+#[tokio::test(flavor = "multi_thread")]
+async fn t11_t21_run_upload_allow_incomplete_keeps_state_and_sets_hook_env() {
+    let (port, _) = spawn_mock(StatBehaviour::Missing, true).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 80);
+    let nzb = dir.path().join("out.nzb");
+    let captured = dir.path().join("incomplete.env");
+    let mut config = test_config(port);
+    config.allow_incomplete_nzb = true;
+    config.no_hooks = true;
+    config.post_hooks = vec![format!(
+        "printf %s \"$PESTO_INCOMPLETE\" > {}",
+        captured.display()
+    )];
+
+    let outcome = run_upload(
+        &config,
+        std::slice::from_ref(&file.path),
+        "movie.bin",
+        None,
+        None,
+        Some(nzb.clone()),
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(outcome.had_failures);
+    assert!(outcome.inconclusive.is_empty());
+    assert!(
+        outcome.nzb_path.is_some() && nzb.exists(),
+        "T11: MissingConfirmed + --allow-incomplete-nzb must write the NZB"
+    );
+    let state_path = nzb.with_extension("pesto-state");
+    assert!(
+        state_path.exists(),
+        "T11: --allow-incomplete-nzb must keep .pesto-state"
+    );
+    let state = ResumeState::load(&state_path).unwrap();
+    assert!(
+        state.get("movie.bin", 1).is_none(),
+        "T11: MissingConfirmed ids must be stripped from resume"
+    );
+    let env = std::fs::read_to_string(&captured)
+        .unwrap_or_else(|e| panic!("run_upload hook never wrote {}: {e}", captured.display()));
+    assert_eq!(
+        env.trim(),
+        "1",
+        "T11: PESTO_INCOMPLETE=1 on the library hook path"
+    );
+}
+
+/// T21: `run_upload` refuses the NZB on Inconclusive the same way the CLI does.
+#[tokio::test(flavor = "multi_thread")]
+async fn t21_run_upload_refuses_nzb_on_inconclusive() {
+    let (port, _) = spawn_mock(StatBehaviour::Drop, false).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 80);
+    let nzb = dir.path().join("out.nzb");
+    let config = test_config(port);
+
+    let outcome = run_upload(
+        &config,
+        std::slice::from_ref(&file.path),
+        "movie.bin",
+        None,
+        None,
+        Some(nzb.clone()),
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(outcome.had_failures);
+    assert!(!outcome.inconclusive.is_empty());
+    assert!(outcome.nzb_path.is_none());
+    assert!(!nzb.exists());
+    let state_path = nzb.with_extension("pesto-state");
+    assert!(state_path.exists());
+}

--- a/crates/pesto/tests/check_inconclusive.rs
+++ b/crates/pesto/tests/check_inconclusive.rs
@@ -142,9 +142,9 @@ async fn spawn_mock(stat: StatBehaviour, post_already_exists: bool) -> (u16, Moc
     (addr.port(), counts)
 }
 
-/// POST 240, STAT 430, then AUTH 481 on the reconnect that `repost_one` does
-/// after `handle_confirmed_miss`. AUTH 48x must be Inconclusive, not a 4xx
-/// article refusal.
+/// POST 240, STAT 430 followed by a dropped connection, then AUTH 481 on
+/// `repost_one`'s retry connection. AUTH 48x must be Inconclusive, not a
+/// 4xx article refusal.
 async fn spawn_430_then_auth_481() -> (u16, MockStats) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -227,6 +227,10 @@ async fn handle_430_then_auth_481(
                 .write_all(b"430 No such article\r\n")
                 .await
                 .unwrap();
+            // A 430 keeps a healthy connection reusable in production. Drop
+            // this mock connection so the repost's transport retry must open
+            // a new one and exercise the AUTH 481 classification below.
+            return;
         } else if command.starts_with("MODE READER") {
             write_half.write_all(b"200 reader mode\r\n").await.unwrap();
         } else if command == "QUIT" {
@@ -552,6 +556,7 @@ async fn auth_481_on_repost_after_430_is_inconclusive() {
     let file = input(dir.path(), "movie.bin", 80);
     let state_path = dir.path().join("movie.bin.pesto-state");
     let mut config = test_config(port);
+    config.retries = 2;
     config.check_post_retries = 1;
 
     let outcome = post_files_with_progress(

--- a/crates/pesto/tests/check_post_retries.rs
+++ b/crates/pesto/tests/check_post_retries.rs
@@ -238,7 +238,7 @@ fn run_pesto_with_args(
         .args(["-s", "127.0.0.1"])
         .args(["-P", &port.to_string()])
         .args(["-g", "alt.binaries.test"])
-        .args(["-n", "1"])
+        .args(["-n", "2"])
         .args(["--par2", "0"])
         .arg("--check")
         .args(["--check-delay", "0"])

--- a/crates/pesto/tests/check_post_retries.rs
+++ b/crates/pesto/tests/check_post_retries.rs
@@ -366,7 +366,15 @@ fn allow_incomplete_nzb_publishes_despite_confirmed_missing_articles() {
     std::fs::write(&input, vec![0xABu8; 64]).unwrap();
     let out = dir.path().join("out.nzb");
 
-    let output = run_pesto_with_args(addr.port(), 1, &input, &out, &["--allow-incomplete-nzb"]);
+    let captured = dir.path().join("incomplete.env");
+    let hook = format!("printf %s \"$PESTO_INCOMPLETE\" > {}", captured.display());
+    let output = run_pesto_with_args(
+        addr.port(),
+        1,
+        &input,
+        &out,
+        &["--allow-incomplete-nzb", "--post-hook", &hook],
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     // Still reported as a failure (exit code), since the article really is
@@ -382,5 +390,26 @@ fn allow_incomplete_nzb_publishes_despite_confirmed_missing_articles() {
     assert!(
         out.exists(),
         "expected the NZB to be written when --allow-incomplete-nzb is set"
+    );
+    let state_path = out.with_extension("pesto-state");
+    assert!(
+        state_path.exists(),
+        "T11: --allow-incomplete-nzb must keep .pesto-state so --resume can fill the gap"
+    );
+    let state = pesto::resume::ResumeState::load(&state_path).unwrap();
+    assert!(
+        state.get("movie.bin", 1).is_none(),
+        "T11: MissingConfirmed ids must be stripped from resume"
+    );
+    let env = std::fs::read_to_string(&captured).unwrap_or_else(|e| {
+        panic!(
+            "CLI hook never wrote {} (PESTO_INCOMPLETE)\nstderr:\n{stderr}\n{e}",
+            captured.display()
+        )
+    });
+    assert_eq!(
+        env.trim(),
+        "1",
+        "T11: PESTO_INCOMPLETE=1 on the CLI hook path"
     );
 }

--- a/crates/pesto/tests/check_recover_pass.rs
+++ b/crates/pesto/tests/check_recover_pass.rs
@@ -120,7 +120,7 @@ fn test_config(addr: SocketAddr) -> Config {
         host: addr.ip().to_string(),
         port: addr.port(),
         ssl: false,
-        connections: 1,
+        connections: 2,
         username: None,
         password: None,
         from: "tester <t@pesto.test>".to_string(),
@@ -413,6 +413,7 @@ async fn auto_recovery_pass_resolves_several_concurrent_stubborn_misses() {
         .collect();
 
     let mut config = test_config(addr);
+    config.connections = 4;
     config.check_connections = 3;
     config.check_recover_percent = 100;
     config.check_recover_max = N;

--- a/crates/pesto/tests/check_repost_preserves_obfuscation.rs
+++ b/crates/pesto/tests/check_repost_preserves_obfuscation.rs
@@ -116,7 +116,7 @@ fn config(addr: SocketAddr) -> Config {
         host: addr.ip().to_string(),
         port: addr.port(),
         ssl: false,
-        connections: 1,
+        connections: 2,
         username: None,
         password: None,
         from: "tester <t@pesto.test>".to_string(),

--- a/crates/pesto/tests/check_targets_posting_server.rs
+++ b/crates/pesto/tests/check_targets_posting_server.rs
@@ -180,7 +180,7 @@ async fn check_stats_the_server_the_article_was_actually_posted_to() {
             host: real_addr.ip().to_string(),
             port: real_addr.port(),
             ssl: false,
-            connections: 1,
+            connections: 2,
             username: None,
             password: None,
             retry_delay: 0,

--- a/crates/pesto/tests/compress_hook_input_paths.rs
+++ b/crates/pesto/tests/compress_hook_input_paths.rs
@@ -118,6 +118,7 @@ fn compress_preserves_original_filenames_in_hook_input_paths() {
         .args(["-g", "alt.binaries.test"])
         .args(["-n", "1"])
         .args(["--par2", "0"])
+        .arg("--no-check")
         .arg("--compress")
         .args(["-o", out.to_str().unwrap()])
         .arg(&input)

--- a/crates/pesto/tests/each_reuses_connections_across_episodes.rs
+++ b/crates/pesto/tests/each_reuses_connections_across_episodes.rs
@@ -15,8 +15,16 @@ use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 fn spawn_counting_server(accepted: Arc<AtomicUsize>) -> SocketAddr {
+    spawn_counting_server_with_post_delay(accepted, Duration::ZERO)
+}
+
+fn spawn_counting_server_with_post_delay(
+    accepted: Arc<AtomicUsize>,
+    post_delay: Duration,
+) -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -24,14 +32,14 @@ fn spawn_counting_server(accepted: Arc<AtomicUsize>) -> SocketAddr {
         for stream in listener.incoming() {
             let Ok(stream) = stream else { continue };
             accepted.fetch_add(1, Ordering::SeqCst);
-            std::thread::spawn(move || handle_connection(stream));
+            std::thread::spawn(move || handle_connection(stream, post_delay));
         }
     });
 
     addr
 }
 
-fn handle_connection(stream: TcpStream) {
+fn handle_connection(stream: TcpStream, post_delay: Duration) {
     let mut writer = match stream.try_clone() {
         Ok(w) => w,
         Err(_) => return,
@@ -65,7 +73,14 @@ fn handle_connection(stream: TcpStream) {
                     break;
                 }
             }
+            if !post_delay.is_zero() {
+                std::thread::sleep(post_delay);
+            }
             if writer.write_all(b"240 article received\r\n").is_err() {
+                return;
+            }
+        } else if command.starts_with("STAT ") {
+            if writer.write_all(b"223 0 article exists\r\n").is_err() {
                 return;
             }
         } else if command.starts_with("MODE READER") {
@@ -133,5 +148,98 @@ fn each_batch_reuses_connections_instead_of_one_pool_per_episode() {
         "expected connections to be reused across the {EPISODES} episodes \
          (≈{CONNECTIONS} total), but the mock server accepted {total} \
          connections — looks like each episode is opening its own pool again"
+    );
+}
+
+/// T17: `--each --jobs 2 --check` with overlapping start must not open a
+/// second peak of sockets for check workers / `scale_up` / `recover_missing`.
+/// Episode B blocks on the broker until A has drained+recovered and
+/// checkined the whole set.
+#[test]
+fn each_jobs_check_overlapping_start_honors_connection_budget() {
+    const CONNECTIONS: usize = 4;
+    const EPISODES: usize = 2;
+
+    let accepted = Arc::new(AtomicUsize::new(0));
+    // Slow POSTs so episode B is already waiting on checkout while A still
+    // holds the full budget (check + upload + drain), not two sequential
+    // `--each` runs that would never overlap.
+    let addr = spawn_counting_server_with_post_delay(accepted.clone(), Duration::from_millis(200));
+
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..EPISODES {
+        let entry_dir = dir.path().join(format!("episode_{i:02}"));
+        std::fs::create_dir_all(&entry_dir).unwrap();
+        std::fs::write(entry_dir.join("movie.bin"), vec![0xABu8; 4096]).unwrap();
+    }
+    let out = dir.path().join("out.nzb");
+    let xdg_home = tempfile::tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pesto"))
+        .env("XDG_CONFIG_HOME", xdg_home.path())
+        .arg("--no-ssl")
+        .args(["-s", "127.0.0.1"])
+        .args(["-P", &addr.port().to_string()])
+        .args(["-g", "alt.binaries.test"])
+        .args(["-n", &CONNECTIONS.to_string()])
+        .args(["--article-size", "4096"])
+        .args(["--par2", "0"])
+        .arg("--no-hooks")
+        .arg("--check")
+        .args(["--check-delay", "0"])
+        .arg("--each")
+        .args(["--jobs", "2"])
+        .args(["-o", out.to_str().unwrap()])
+        .arg(dir.path())
+        .output()
+        .expect("failed to run pesto");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "expected the overlapping --each --jobs 2 --check batch to succeed\nstderr:\n{stderr}"
+    );
+
+    let total = accepted.load(Ordering::SeqCst);
+    assert!(
+        total <= CONNECTIONS + 1,
+        "expected accept() ≤ {CONNECTIONS} (not 2×) with overlapping --jobs 2 --check, \
+         but the mock server accepted {total} connections — check workers or \
+         scale_up/recover_missing opened sockets outside the broker budget"
+    );
+}
+
+/// T22: `-n 1 --check` (auto) is a start-up error, not a silent skip.
+#[test]
+fn n1_check_auto_is_a_startup_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("movie.bin");
+    std::fs::write(&input, vec![0xABu8; 64]).unwrap();
+    let out = dir.path().join("out.nzb");
+    let xdg_home = tempfile::tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pesto"))
+        .env("XDG_CONFIG_HOME", xdg_home.path())
+        .arg("--no-ssl")
+        .args(["-s", "127.0.0.1"])
+        .args(["-P", "9"])
+        .args(["-g", "alt.binaries.test"])
+        .args(["-n", "1"])
+        .arg("--check")
+        .args(["--par2", "0"])
+        .arg("--no-hooks")
+        .args(["-o", out.to_str().unwrap()])
+        .arg(&input)
+        .output()
+        .expect("failed to run pesto");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected `-n 1 --check` to fail at start-up, not silently skip checking\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--no-check") || stderr.contains("STAT pool"),
+        "start-up error must be actionable (raise -n, lower --check-connections, or --no-check):\n{stderr}"
     );
 }

--- a/crates/pesto/tests/each_reuses_connections_across_episodes.rs
+++ b/crates/pesto/tests/each_reuses_connections_across_episodes.rs
@@ -10,36 +10,53 @@
 //! near the connection budget (2) instead of scaling with the episode count
 //! (which would show up as ~10).
 
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-fn spawn_counting_server(accepted: Arc<AtomicUsize>) -> SocketAddr {
-    spawn_counting_server_with_post_delay(accepted, Duration::ZERO)
+/// First STAT per article Subject reports missing; later STATs (the
+/// `recover_missing` pass's own Message-ID) succeed. Shared across every
+/// accepted TCP so overlapping `--jobs` episodes still count per-article.
+struct FirstStatMiss {
+    subject_by_id: Mutex<HashMap<String, String>>,
+    attempts_by_subject: Mutex<HashMap<String, u32>>,
 }
 
-fn spawn_counting_server_with_post_delay(
+fn spawn_counting_server(accepted: Arc<AtomicUsize>) -> SocketAddr {
+    spawn_counting_server_with_options(accepted, Duration::ZERO, false)
+}
+
+fn spawn_counting_server_with_options(
     accepted: Arc<AtomicUsize>,
     post_delay: Duration,
+    first_stat_miss: bool,
 ) -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
+    let miss = first_stat_miss.then(|| {
+        Arc::new(FirstStatMiss {
+            subject_by_id: Mutex::new(HashMap::new()),
+            attempts_by_subject: Mutex::new(HashMap::new()),
+        })
+    });
 
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(stream) = stream else { continue };
             accepted.fetch_add(1, Ordering::SeqCst);
-            std::thread::spawn(move || handle_connection(stream, post_delay));
+            let miss = miss.clone();
+            std::thread::spawn(move || handle_connection(stream, post_delay, miss));
         }
     });
 
     addr
 }
 
-fn handle_connection(stream: TcpStream, post_delay: Duration) {
+fn handle_connection(stream: TcpStream, post_delay: Duration, miss: Option<Arc<FirstStatMiss>>) {
     let mut writer = match stream.try_clone() {
         Ok(w) => w,
         Err(_) => return,
@@ -62,6 +79,8 @@ fn handle_connection(stream: TcpStream, post_delay: Duration) {
             if writer.write_all(b"340 send article\r\n").is_err() {
                 return;
             }
+            let mut message_id = String::new();
+            let mut subject = String::new();
             let mut raw = Vec::new();
             loop {
                 raw.clear();
@@ -72,6 +91,23 @@ fn handle_connection(stream: TcpStream, post_delay: Duration) {
                 if raw == b".\r\n" {
                     break;
                 }
+                if miss.is_some() {
+                    if let Ok(text) = std::str::from_utf8(&raw) {
+                        if let Some(v) = text.strip_prefix("Message-ID: ") {
+                            message_id = v.trim_end().to_string();
+                        } else if let Some(v) = text.strip_prefix("Subject: ") {
+                            subject = v.trim_end().to_string();
+                        }
+                    }
+                }
+            }
+            if let Some(miss) = &miss {
+                if !message_id.is_empty() && !subject.is_empty() {
+                    miss.subject_by_id
+                        .lock()
+                        .unwrap()
+                        .insert(message_id, subject);
+                }
             }
             if !post_delay.is_zero() {
                 std::thread::sleep(post_delay);
@@ -79,8 +115,25 @@ fn handle_connection(stream: TcpStream, post_delay: Duration) {
             if writer.write_all(b"240 article received\r\n").is_err() {
                 return;
             }
-        } else if command.starts_with("STAT ") {
-            if writer.write_all(b"223 0 article exists\r\n").is_err() {
+        } else if let Some(id) = command.strip_prefix("STAT ") {
+            let found = if let Some(miss) = &miss {
+                let subject = miss.subject_by_id.lock().unwrap().get(id).cloned();
+                let attempt = subject.map(|s| {
+                    let mut attempts = miss.attempts_by_subject.lock().unwrap();
+                    let n = attempts.entry(s).or_insert(0);
+                    *n += 1;
+                    *n
+                });
+                attempt.is_some_and(|n| n > 1)
+            } else {
+                true
+            };
+            let resp: &[u8] = if found {
+                b"223 0 article exists\r\n"
+            } else {
+                b"430 no such article found\r\n"
+            };
+            if writer.write_all(resp).is_err() {
                 return;
             }
         } else if command.starts_with("MODE READER") {
@@ -155,22 +208,34 @@ fn each_batch_reuses_connections_instead_of_one_pool_per_episode() {
 /// second peak of sockets for check workers / `scale_up` / `recover_missing`.
 /// Episode B blocks on the broker until A has drained+recovered and
 /// checkined the whole set.
+///
+/// Geometry: auto `-n 4` is 1 check + 3 upload. Three segments per episode
+/// so `worker_count == upload_conns` and every budgeted post slot connects.
+/// First STAT per article misses and `--check-post-retries 0` skips the
+/// streaming repost, so `recover_missing` runs on the drained slots.
 #[test]
 fn each_jobs_check_overlapping_start_honors_connection_budget() {
     const CONNECTIONS: usize = 4;
     const EPISODES: usize = 2;
+    const ARTICLE_SIZE: usize = 4096;
+    const SEGMENTS: usize = 3;
 
     let accepted = Arc::new(AtomicUsize::new(0));
     // Slow POSTs so episode B is already waiting on checkout while A still
-    // holds the full budget (check + upload + drain), not two sequential
-    // `--each` runs that would never overlap.
-    let addr = spawn_counting_server_with_post_delay(accepted.clone(), Duration::from_millis(200));
+    // holds the full budget (check + upload + drain + recover), not two
+    // sequential `--each` runs that would never overlap.
+    let addr =
+        spawn_counting_server_with_options(accepted.clone(), Duration::from_millis(200), true);
 
     let dir = tempfile::tempdir().unwrap();
     for i in 0..EPISODES {
         let entry_dir = dir.path().join(format!("episode_{i:02}"));
         std::fs::create_dir_all(&entry_dir).unwrap();
-        std::fs::write(entry_dir.join("movie.bin"), vec![0xABu8; 4096]).unwrap();
+        std::fs::write(
+            entry_dir.join("movie.bin"),
+            vec![0xABu8; ARTICLE_SIZE * SEGMENTS],
+        )
+        .unwrap();
     }
     let out = dir.path().join("out.nzb");
     let xdg_home = tempfile::tempdir().unwrap();
@@ -182,11 +247,14 @@ fn each_jobs_check_overlapping_start_honors_connection_budget() {
         .args(["-P", &addr.port().to_string()])
         .args(["-g", "alt.binaries.test"])
         .args(["-n", &CONNECTIONS.to_string()])
-        .args(["--article-size", "4096"])
+        .args(["--article-size", &ARTICLE_SIZE.to_string()])
         .args(["--par2", "0"])
         .arg("--no-hooks")
         .arg("--check")
         .args(["--check-delay", "0"])
+        .args(["--check-retries", "1"])
+        .args(["--check-post-retries", "0"])
+        .args(["--check-recover-percent", "100"])
         .arg("--each")
         .args(["--jobs", "2"])
         .args(["-o", out.to_str().unwrap()])
@@ -202,10 +270,11 @@ fn each_jobs_check_overlapping_start_honors_connection_budget() {
 
     let total = accepted.load(Ordering::SeqCst);
     assert!(
-        total <= CONNECTIONS + 1,
-        "expected accept() ≤ {CONNECTIONS} (not 2×) with overlapping --jobs 2 --check, \
-         but the mock server accepted {total} connections — check workers or \
-         scale_up/recover_missing opened sockets outside the broker budget"
+        total <= CONNECTIONS,
+        "expected accept() ≤ {CONNECTIONS} (not 2×, and not N+1 extra-socket slack) \
+         with overlapping --jobs 2 --check, but the mock server accepted {total} \
+         connections — check workers, scale_up, or recover_missing opened sockets \
+         outside the broker budget"
     );
 }
 

--- a/crates/pesto/tests/independent_obfuscation_tokens.rs
+++ b/crates/pesto/tests/independent_obfuscation_tokens.rs
@@ -147,6 +147,7 @@ fn run_pesto(
         .args(["-g", "alt.binaries.test"])
         .args(["-n", "1"])
         .args(["--par2", "0"])
+        .arg("--no-check")
         .arg("--no-hooks")
         .arg(obfuscate_flag)
         .args(["-o", out.to_str().unwrap()])

--- a/crates/pesto/tests/resume_confirm.rs
+++ b/crates/pesto/tests/resume_confirm.rs
@@ -1,0 +1,639 @@
+//! Resume confirmation flags, the three `prepare_ready` arms, and cancel
+//! persistence (design T12 / T13 / T13a / T13b / T13c / T15 / T23).
+//!
+//! Mock NNTP only — never a real provider.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+use pesto::config::{Config, ObfuscateMode};
+use pesto::poster::{post_files_with_progress, post_files_with_progress_and_cancel};
+use pesto::progress::ProgressEvent;
+use pesto::resume::{ResumeState, RunFingerprint};
+
+#[derive(Clone, Default)]
+struct MockStats {
+    posts: Arc<AtomicUsize>,
+    stats: Arc<AtomicUsize>,
+}
+
+/// Accepts POST/STAT with optional: fail POSTs after `fail_after` successes,
+/// reject POSTs whose Subject contains `reject_subject`, and answer STAT 430
+/// for the first `cursed` distinct Message-IDs (in first-seen order).
+async fn handle_connection(
+    stream: TcpStream,
+    counts: MockStats,
+    fail_after: Option<usize>,
+    reject_subject: Option<&'static str>,
+    cursed: usize,
+    seen: Arc<std::sync::Mutex<Vec<String>>>,
+) {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    write_half
+        .write_all(b"200 pesto mock ready\r\n")
+        .await
+        .unwrap();
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await.unwrap() == 0 {
+            return;
+        }
+        let command = line.trim_end();
+
+        if command.starts_with("AUTHINFO USER") {
+            write_half
+                .write_all(b"381 password required\r\n")
+                .await
+                .unwrap();
+        } else if command.starts_with("AUTHINFO PASS") {
+            write_half
+                .write_all(b"281 authenticated\r\n")
+                .await
+                .unwrap();
+        } else if command == "POST" {
+            write_half.write_all(b"340 send article\r\n").await.unwrap();
+            let mut article = Vec::new();
+            let mut body = Vec::new();
+            loop {
+                body.clear();
+                if reader.read_until(b'\n', &mut body).await.unwrap() == 0 {
+                    return;
+                }
+                if body == b".\r\n" {
+                    break;
+                }
+                article.extend_from_slice(&body);
+            }
+            let text = String::from_utf8_lossy(&article);
+            let subject = text
+                .lines()
+                .find_map(|l| l.strip_prefix("Subject: "))
+                .unwrap_or("");
+            let id = text
+                .lines()
+                .find_map(|l| l.strip_prefix("Message-ID: "))
+                .map(str::trim)
+                .map(str::to_string);
+            if let Some(needle) = reject_subject {
+                if subject.contains(needle) {
+                    write_half
+                        .write_all(b"441 posting failed\r\n")
+                        .await
+                        .unwrap();
+                    continue;
+                }
+            }
+            let n = counts.posts.fetch_add(1, Ordering::Relaxed);
+            if fail_after.is_some_and(|after| n >= after) {
+                write_half
+                    .write_all(b"441 posting failed\r\n")
+                    .await
+                    .unwrap();
+                continue;
+            }
+            if let Some(id) = id {
+                let mut seen = seen.lock().unwrap();
+                if !seen.contains(&id) {
+                    seen.push(id);
+                }
+            }
+            write_half
+                .write_all(b"240 article received\r\n")
+                .await
+                .unwrap();
+        } else if let Some(id) = command.strip_prefix("STAT ") {
+            counts.stats.fetch_add(1, Ordering::Relaxed);
+            let found = {
+                let seen = seen.lock().unwrap();
+                match seen.iter().position(|x| x == id) {
+                    Some(ord) => ord >= cursed,
+                    // Stored resume ids were never POSTed this run — treat as
+                    // present so arm 2 can confirm without a second POST.
+                    None => cursed == 0,
+                }
+            };
+            let resp = if found {
+                format!("223 0 {id} article exists\r\n")
+            } else {
+                "430 No such article\r\n".to_string()
+            };
+            write_half.write_all(resp.as_bytes()).await.unwrap();
+        } else if command.starts_with("MODE READER") {
+            write_half.write_all(b"200 reader mode\r\n").await.unwrap();
+        } else if command == "QUIT" {
+            write_half.write_all(b"205 bye\r\n").await.unwrap();
+            return;
+        } else {
+            write_half
+                .write_all(b"500 unknown command\r\n")
+                .await
+                .unwrap();
+        }
+    }
+}
+
+async fn spawn_mock(
+    fail_after: Option<usize>,
+    reject_subject: Option<&'static str>,
+    cursed: usize,
+) -> (u16, MockStats) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let counts = MockStats::default();
+    let seen: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    {
+        let counts = counts.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(handle_connection(
+                    stream,
+                    counts.clone(),
+                    fail_after,
+                    reject_subject,
+                    cursed,
+                    seen.clone(),
+                ));
+            }
+        });
+    }
+    (addr.port(), counts)
+}
+
+fn test_config(port: u16, check: bool) -> Config {
+    Config {
+        host: "127.0.0.1".to_string(),
+        port,
+        ssl: false,
+        connections: 2,
+        username: Some("user".to_string()),
+        password: Some("pass".to_string()),
+        from: "tester <t@pesto.test>".to_string(),
+        groups: vec!["alt.binaries.test".to_string()],
+        article_size: 100,
+        line_length: 128,
+        retries: 1,
+        retry_delay: 0,
+        timeout: pesto::config::DEFAULT_TIMEOUT_SECS,
+        proxy: None,
+        proxy_check_ip: false,
+        obfuscate: ObfuscateMode::None,
+        dry_run: false,
+        par2: 0,
+        par2_memory_limit: Some(1_000_000_000),
+        memory_limit: None,
+        par2_temp_dir: None,
+        compress_temp_dir: None,
+        par2_slice_size: None,
+        par2_slice_count: None,
+        par2_recovery_count: None,
+        par2_only: false,
+        par2_before_upload: false,
+        threads: 0,
+        simd: parmesan::SimdPath::Auto,
+        extra_servers: vec![],
+        resume: false,
+        upload_rate: 0,
+        compress_format: None,
+        compress_password: None,
+        compress_volume_size: None,
+        nzb_title: None,
+        nzb_password: None,
+        nzb_category: None,
+        nzb_tags: vec![],
+        tmdb_id: None,
+        tmdb_kind: None,
+        imdb_id: None,
+        tvdb_id: None,
+        tvdb_kind: None,
+        mal_id: None,
+        indexer_url: None,
+        indexer_api_key: None,
+        notify_webhook: None,
+        notify_ntfy: None,
+        notify: None,
+        history: false,
+        history_dir: None,
+        nzb_dir: None,
+        date: None,
+        no_archive: false,
+        file_counter: false,
+        message_id_domain: None,
+        pre_hooks: vec![],
+        post_hooks: vec![],
+        no_hooks: false,
+        nfo: false,
+        nzb_conflict: pesto::config::NzbConflict::Overwrite,
+        quiet: false,
+        bell: false,
+        check,
+        check_delay_secs: 0,
+        check_retries: 1,
+        check_connections: 1,
+        check_post_retries: 1,
+        allow_incomplete_nzb: false,
+        check_recover_percent: 15,
+        check_recover_max: 0,
+        pipeline_depth: 1,
+        keepalive_interval: 0,
+    }
+}
+
+fn input(dir: &std::path::Path, name: &str, bytes: usize) -> pesto::walk::InputFile {
+    let path = dir.join(name);
+    std::fs::write(&path, vec![0xABu8; bytes]).unwrap();
+    pesto::walk::InputFile {
+        path,
+        name: name.to_string(),
+    }
+}
+
+/// Write a `.pesto-state` whose segment objects are `{message_id, bytes}`
+/// only — the on-disk shape before `confirmed`/`check_disabled`/`server_idx`.
+fn write_pre_schema_state(
+    path: &std::path::Path,
+    config: &Config,
+    file_name: &str,
+    segs: &[(&str, u64)],
+) {
+    let mut state = ResumeState::default();
+    state.validate_run(&RunFingerprint::from_config(config));
+    for (i, (id, bytes)) in segs.iter().enumerate() {
+        state.record(file_name, (i as u32) + 1, id, *bytes);
+    }
+    state.save(path).unwrap();
+    let text = std::fs::read_to_string(path).unwrap();
+    let mut v: serde_json::Value = serde_json::from_str(&text).unwrap();
+    if let Some(segments) = v.get_mut("segments").and_then(|s| s.as_object_mut()) {
+        for rec in segments.values_mut() {
+            if let Some(obj) = rec.as_object_mut() {
+                obj.remove("confirmed");
+                obj.remove("check_disabled");
+                obj.remove("server_idx");
+            }
+        }
+    }
+    std::fs::write(path, serde_json::to_string(&v).unwrap()).unwrap();
+}
+
+/// T12: `--no-check` incomplete (POST fail) persists `(confirmed=false,
+/// check_disabled=true)` and never `confirmed=true`.
+#[tokio::test(flavor = "multi_thread")]
+async fn t12_no_check_incomplete_persists_check_disabled() {
+    let (port, counts) = spawn_mock(Some(1), None, 0).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "partial.bin", 150); // 2 segments
+    let state_path = dir.path().join("partial.bin.pesto-state");
+    let mut config = test_config(port, false);
+    config.connections = 1;
+
+    let outcome = post_files_with_progress(&config, &[file], None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(
+        !outcome.failed_tasks.is_empty(),
+        "second segment should fail POST"
+    );
+    assert!(
+        state_path.exists(),
+        "incomplete --no-check must persist state"
+    );
+    let state = ResumeState::load(&state_path).unwrap();
+    assert!(
+        !state.is_empty(),
+        "at least one 240 must be recorded on an incomplete --no-check run"
+    );
+    for part in [1u32, 2] {
+        if let Some(rec) = state.get("partial.bin", part) {
+            assert!(!rec.confirmed, "--no-check must never write confirmed=true");
+            assert!(rec.check_disabled);
+        }
+    }
+    assert!(counts.posts.load(Ordering::Relaxed) >= 1);
+}
+
+/// T13: new-schema fixture + `--resume --check` skips `confirmed`, re-STATs
+/// unconfirmed (0 extra POSTs if 223), POSTs missing.
+#[tokio::test(flavor = "multi_thread")]
+async fn t13_new_schema_three_arms() {
+    let (port, counts) = spawn_mock(None, None, 0).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 250); // 3 segments
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let mut config = test_config(port, true);
+    config.resume = true;
+
+    let mut prior = ResumeState::default();
+    prior.validate_run(&RunFingerprint::from_config(&config));
+    prior.record_with(
+        "movie.bin",
+        1,
+        pesto::resume::SegmentRecord {
+            message_id: "conf@pre.example".into(),
+            bytes: 100,
+            confirmed: true,
+            check_disabled: false,
+            server_idx: 0,
+        },
+    );
+    prior.record_with(
+        "movie.bin",
+        2,
+        pesto::resume::SegmentRecord {
+            message_id: "open@pre.example".into(),
+            bytes: 100,
+            confirmed: false,
+            check_disabled: false,
+            server_idx: 0,
+        },
+    );
+    prior.save(&state_path).unwrap();
+
+    let outcome = post_files_with_progress(&config, &[file], None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    let ids: Vec<&str> = outcome
+        .segments
+        .iter()
+        .map(|s| s.message_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"conf@pre.example"),
+        "arm 1 reuses confirmed id"
+    );
+    assert!(
+        ids.contains(&"open@pre.example"),
+        "arm 2 reuses unconfirmed id"
+    );
+    assert_eq!(
+        counts.posts.load(Ordering::Relaxed),
+        1,
+        "only the missing part should POST"
+    );
+    assert!(
+        counts.stats.load(Ordering::Relaxed) >= 1,
+        "arm 2 must STAT the stored unconfirmed id"
+    );
+}
+
+/// T13a: pre-schema `{message_id, bytes}` + `--resume --no-check` → skip, 0 POSTs.
+#[tokio::test(flavor = "multi_thread")]
+async fn t13a_pre_schema_no_check_skips() {
+    let (port, counts) = spawn_mock(None, None, 0).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 250);
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let mut config = test_config(port, false);
+    config.resume = true;
+    write_pre_schema_state(
+        &state_path,
+        &config,
+        "movie.bin",
+        &[
+            ("seg1@pre.example", 100),
+            ("seg2@pre.example", 100),
+            ("seg3@pre.example", 50),
+        ],
+    );
+
+    let outcome = post_files_with_progress(&config, &[file], None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.segments.len(), 3);
+    assert_eq!(counts.posts.load(Ordering::Relaxed), 0);
+    let ids: Vec<&str> = outcome
+        .segments
+        .iter()
+        .map(|s| s.message_id.as_str())
+        .collect();
+    assert!(ids.contains(&"seg1@pre.example"));
+    assert!(ids.contains(&"seg2@pre.example"));
+    assert!(ids.contains(&"seg3@pre.example"));
+}
+
+/// T13b: same pre-schema fixture + `--resume --check` → re-STAT stored ids,
+/// 0 extra POSTs if STAT 223.
+#[tokio::test(flavor = "multi_thread")]
+async fn t13b_pre_schema_check_restats_without_post() {
+    let (port, counts) = spawn_mock(None, None, 0).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 250);
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let mut config = test_config(port, true);
+    config.resume = true;
+    write_pre_schema_state(
+        &state_path,
+        &config,
+        "movie.bin",
+        &[
+            ("seg1@pre.example", 100),
+            ("seg2@pre.example", 100),
+            ("seg3@pre.example", 50),
+        ],
+    );
+
+    let outcome = post_files_with_progress(&config, &[file], None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.segments.len(), 3);
+    assert_eq!(
+        counts.posts.load(Ordering::Relaxed),
+        0,
+        "arm 2 must not POST stored ids"
+    );
+    assert!(
+        counts.stats.load(Ordering::Relaxed) >= 3,
+        "arm 2 must STAT each stored id"
+    );
+    let ids: Vec<&str> = outcome
+        .segments
+        .iter()
+        .map(|s| s.message_id.as_str())
+        .collect();
+    assert!(ids.contains(&"seg1@pre.example"));
+}
+
+/// T13c: T13b wrapped in a timeout — the run must return (no hang in
+/// `finish_and_drain` from a leftover `check_tx` sender on Shared).
+#[tokio::test(flavor = "multi_thread")]
+async fn t13c_restat_run_returns_without_hanging() {
+    let (port, _counts) = spawn_mock(None, None, 0).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 250);
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let mut config = test_config(port, true);
+    config.resume = true;
+    write_pre_schema_state(
+        &state_path,
+        &config,
+        "movie.bin",
+        &[
+            ("seg1@pre.example", 100),
+            ("seg2@pre.example", 100),
+            ("seg3@pre.example", 50),
+        ],
+    );
+
+    let files = [file];
+    let run = post_files_with_progress(&config, &files, None, Some(&state_path), None);
+    tokio::time::timeout(Duration::from_secs(20), run)
+        .await
+        .expect("resume --check arm 2 hung in finish_and_drain (check_tx not taken)")
+        .unwrap();
+}
+
+/// T15: a successful check-repost overwrites resume (and the NZB) with the
+/// new Message-ID, not the cursed original.
+#[tokio::test(flavor = "multi_thread")]
+async fn t15_repost_persists_new_message_id() {
+    let (port, _counts) = spawn_mock(None, Some("fail.bin"), 1).await;
+    let dir = tempfile::tempdir().unwrap();
+    let ok = input(dir.path(), "ok.bin", 80);
+    let fail = input(dir.path(), "fail.bin", 80);
+    let state_path = dir.path().join("release.pesto-state");
+    let mut config = test_config(port, true);
+    config.connections = 2;
+    config.check_connections = 1;
+    config.check_retries = 1;
+    config.check_post_retries = 1;
+    config.check_recover_max = 0;
+
+    let outcome = post_files_with_progress(&config, &[ok, fail], None, Some(&state_path), None)
+        .await
+        .unwrap();
+
+    assert!(
+        !outcome.failed_tasks.is_empty(),
+        "fail.bin must keep the run incomplete so state is saved"
+    );
+    let ok_seg = outcome
+        .segments
+        .iter()
+        .find(|s| s.file_name == "ok.bin")
+        .expect("ok.bin must appear in results");
+    assert!(
+        state_path.exists(),
+        "incomplete run must persist resume state"
+    );
+    let state = ResumeState::load(&state_path).unwrap();
+    let rec = state
+        .get("ok.bin", 1)
+        .expect("reposted segment must be recorded");
+    assert_eq!(
+        rec.message_id, ok_seg.message_id,
+        "resume must store the new (not cursed) Message-ID"
+    );
+
+    // `--resume --check` must reuse that new id, not POST a third copy of ok.bin.
+    let (port2, counts2) = spawn_mock(None, Some("fail.bin"), 0).await;
+    let mut config2 = test_config(port2, true);
+    config2.resume = true;
+    config2.check_recover_max = 0;
+    let ok2 = pesto::walk::InputFile {
+        path: dir.path().join("ok.bin"),
+        name: "ok.bin".into(),
+    };
+    let fail2 = pesto::walk::InputFile {
+        path: dir.path().join("fail.bin"),
+        name: "fail.bin".into(),
+    };
+    let outcome2 = post_files_with_progress(&config2, &[ok2, fail2], None, Some(&state_path), None)
+        .await
+        .unwrap();
+    let ok_seg2 = outcome2
+        .segments
+        .iter()
+        .find(|s| s.file_name == "ok.bin")
+        .unwrap();
+    assert_eq!(ok_seg2.message_id, rec.message_id);
+    assert_eq!(
+        counts2.posts.load(Ordering::Relaxed),
+        0,
+        "ok.bin must not be POSTed again; rejected fail.bin POSTs are not counted"
+    );
+}
+
+/// T23: cancel during check drain persists state and does not strip ids.
+#[tokio::test(flavor = "multi_thread")]
+async fn t23_cancel_during_check_drain_persists_unconfirmed() {
+    let (port, _counts) = spawn_mock(None, None, 0).await;
+    let dir = tempfile::tempdir().unwrap();
+    let file = input(dir.path(), "movie.bin", 150); // 2 segments
+    let state_path = dir.path().join("movie.bin.pesto-state");
+    let mut config = test_config(port, true);
+    config.check_delay_secs = 30;
+    config.check_recover_max = 0;
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let run = {
+        let cancel = cancel.clone();
+        let file = file.clone();
+        let state_path = state_path.clone();
+        tokio::spawn(async move {
+            post_files_with_progress_and_cancel(
+                &config,
+                &[file],
+                Some(tx),
+                Some(&state_path),
+                Some(cancel),
+                None,
+            )
+            .await
+        })
+    };
+
+    let mut done = 0usize;
+    while let Some(ev) = rx.recv().await {
+        if let ProgressEvent::SegmentDone { ok: true, .. } = ev {
+            done += 1;
+            if done >= 2 {
+                cancel.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+    let outcome = run.await.unwrap().unwrap();
+    assert!(outcome.cancelled, "cancel flag must abort the run");
+    assert!(
+        state_path.exists(),
+        "cancel with Posted records must persist .pesto-state"
+    );
+    let state = ResumeState::load(&state_path).unwrap();
+    assert!(
+        state.get("movie.bin", 1).is_some() && state.get("movie.bin", 2).is_some(),
+        "cancel must not strip still_missing ids"
+    );
+    for part in [1u32, 2] {
+        let rec = state.get("movie.bin", part).unwrap();
+        assert!(
+            !rec.confirmed,
+            "cancel during drain must persist confirmed=false (STAT never finished)"
+        );
+    }
+
+    // `--resume --check` re-STATs those ids, 0 extra POSTs.
+    let (port2, counts2) = spawn_mock(None, None, 0).await;
+    let mut config2 = test_config(port2, true);
+    config2.resume = true;
+    let file2 = pesto::walk::InputFile {
+        path: dir.path().join("movie.bin"),
+        name: "movie.bin".into(),
+    };
+    let outcome2 = post_files_with_progress(&config2, &[file2], None, Some(&state_path), None)
+        .await
+        .unwrap();
+    assert_eq!(outcome2.segments.len(), 2);
+    assert_eq!(counts2.posts.load(Ordering::Relaxed), 0);
+    assert!(counts2.stats.load(Ordering::Relaxed) >= 2);
+}

--- a/crates/pesto/tests/season_par2_matches_compressed_archive.rs
+++ b/crates/pesto/tests/season_par2_matches_compressed_archive.rs
@@ -157,6 +157,7 @@ fn season_par2_describes_the_posted_archive_not_the_original_episode() {
         .args(["-P", &addr.port().to_string()])
         .args(["-g", "alt.binaries.test"])
         .args(["-n", "1"])
+        .arg("--no-check")
         .args(["--jobs", "1"])
         .args(["--par2", "40"])
         // A small article size (rather than a manual --slice-size, which has

--- a/crates/pesto/tests/server_substituted_message_id.rs
+++ b/crates/pesto/tests/server_substituted_message_id.rs
@@ -113,7 +113,7 @@ fn pesto_adopts_the_server_returned_message_id() {
         .args(["-s", "127.0.0.1"])
         .args(["-P", &addr.port().to_string()])
         .args(["-g", "alt.binaries.test"])
-        .args(["-n", "1"])
+        .args(["-n", "2"])
         .args(["--par2", "0"])
         .arg("--check")
         .args(["--check-delay", "0"])

--- a/crates/pesto/tests/streaming_check_overlaps_upload.rs
+++ b/crates/pesto/tests/streaming_check_overlaps_upload.rs
@@ -115,7 +115,7 @@ fn check_completes_an_early_segment_before_the_last_segment_finishes_posting() {
         .args(["-s", "127.0.0.1"])
         .args(["-P", &addr.port().to_string()])
         .args(["-g", "alt.binaries.test"])
-        .args(["-n", "1"])
+        .args(["-n", "2"])
         .args(["--article-size", "100"])
         .args(["--par2", "0"])
         .arg("--check")

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1440,6 +1440,34 @@ fn trigger_prowlarr_download(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>)
     });
 }
 
+/// Combined season NZB is a distinct artefact from per-episode NZBs.
+/// `--allow-incomplete-nzb` never unlocks the pack: `folder_ok` is already
+/// false on `had_failures` (including MissingConfirmed with the flag).
+fn should_write_season_pack(
+    any_cancelled: bool,
+    folder_ok: bool,
+    all_segments_empty: bool,
+) -> bool {
+    pesto::poster::should_write_season_nzb(any_cancelled, !folder_ok, all_segments_empty)
+}
+
+/// Same skip reasons as pesto CLI `run_batch`. `None` means write the pack.
+fn season_pack_skip_message(
+    any_cancelled: bool,
+    folder_ok: bool,
+    all_segments_empty: bool,
+) -> Option<&'static str> {
+    if should_write_season_pack(any_cancelled, folder_ok, all_segments_empty) {
+        None
+    } else if any_cancelled {
+        Some("interrupted — skipping season nzb output")
+    } else if !folder_ok {
+        Some("season pack was not created due to earlier upload failures")
+    } else {
+        Some("season pack was not created (no valid segments were uploaded)")
+    }
+}
+
 /// Called when the user presses 'u' on the Dashboard.
 /// Delegates the full upload pipeline to `pesto::upload::run_upload`, which
 /// handles compression, posting, NZB writing, history, indexer, and hooks.
@@ -1704,74 +1732,82 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
             // The pack is a distinct artefact: --allow-incomplete-nzb never
             // unlocks it. Per-episode NZBs already followed nzb_write_decision.
             let mut season_nzb = None;
-            if folder_mode == app::FolderMode::Season
-                && pesto::poster::should_write_season_nzb(
-                    any_cancelled,
-                    !folder_ok,
-                    all_segments.is_empty(),
-                )
-            {
-                if let Some(ref dir) = nzb_out_dir {
-                    let out = dir.join(format!("{label}.nzb"));
-                    let meta = pesto::nzb::NzbMeta {
-                        name: Some(label.clone()),
-                        password: config
-                            .nzb_password
-                            .clone()
-                            .or_else(|| config.compress_password.clone()),
-                        category: config.nzb_category.clone(),
-                        tmdb_id: config.tmdb_id.clone(),
-                        imdb_id: config.imdb_id.clone(),
-                        tvdb_id: config.tvdb_id.as_deref().map(|id| {
-                            format!(
-                                "{}/{id}",
-                                config
-                                    .tvdb_kind
-                                    .unwrap_or(pesto::nzb::TvdbKind::Series)
-                                    .as_str()
-                            )
-                        }),
-                        mal_id: config.mal_id.clone(),
-                        tags: config.nzb_tags.clone(),
-                    };
-                    let xml = pesto::nzb::generate(
-                        &config.groups,
-                        &all_segments,
-                        &meta,
-                        config.obfuscate,
-                    );
-                    match std::fs::write(&out, xml) {
-                        Ok(()) => {
-                            let _ = tx.send(AppEvent::Progress(format!(
-                                "wrote season nzb: {}",
-                                out.display()
-                            )));
-                            let _ = tx.send(AppEvent::CatalogRecord {
-                                original_name: label.clone(),
-                                size_bytes: total_size,
-                                nzb_path: Some(out.clone()),
-                                duration_s: item_start.elapsed().as_secs_f64(),
-                            });
+            if folder_mode == app::FolderMode::Season {
+                match season_pack_skip_message(any_cancelled, folder_ok, all_segments.is_empty()) {
+                    None => {
+                        if let Some(ref dir) = nzb_out_dir {
+                            let out = dir.join(format!("{label}.nzb"));
+                            let meta = pesto::nzb::NzbMeta {
+                                name: Some(label.clone()),
+                                password: config
+                                    .nzb_password
+                                    .clone()
+                                    .or_else(|| config.compress_password.clone()),
+                                category: config.nzb_category.clone(),
+                                tmdb_id: config.tmdb_id.clone(),
+                                imdb_id: config.imdb_id.clone(),
+                                tvdb_id: config.tvdb_id.as_deref().map(|id| {
+                                    format!(
+                                        "{}/{id}",
+                                        config
+                                            .tvdb_kind
+                                            .unwrap_or(pesto::nzb::TvdbKind::Series)
+                                            .as_str()
+                                    )
+                                }),
+                                mal_id: config.mal_id.clone(),
+                                tags: config.nzb_tags.clone(),
+                            };
+                            let xml = pesto::nzb::generate(
+                                &config.groups,
+                                &all_segments,
+                                &meta,
+                                config.obfuscate,
+                            );
+                            match std::fs::write(&out, xml) {
+                                Ok(()) => {
+                                    let _ = tx.send(AppEvent::Progress(format!(
+                                        "wrote season nzb: {}",
+                                        out.display()
+                                    )));
+                                    let _ = tx.send(AppEvent::CatalogRecord {
+                                        original_name: label.clone(),
+                                        size_bytes: total_size,
+                                        nzb_path: Some(out.clone()),
+                                        duration_s: item_start.elapsed().as_secs_f64(),
+                                    });
 
-                            // Run post-upload hooks on the combined season pack so
-                            // it reaches the indexer just like each episode does.
-                            // Per-episode hooks run inside `run_upload`; this NZB is
-                            // written here, outside that pipeline, so without this
-                            // the season pack is posted but never sent on. Skip when
-                            // an episode failed — an incomplete pack must not be
-                            // forwarded to the indexer (matches run_upload, which
-                            // only runs hooks when there were no failures).
-                            if folder_ok {
-                                run_season_hooks(&config, path, &label, &out, total_size, &tx)
-                                    .await;
+                                    // Run post-upload hooks on the combined season pack so
+                                    // it reaches the indexer just like each episode does.
+                                    // Per-episode hooks run inside `run_upload`; this NZB is
+                                    // written here, outside that pipeline, so without this
+                                    // the season pack is posted but never sent on. Skip when
+                                    // an episode failed — an incomplete pack must not be
+                                    // forwarded to the indexer (matches run_upload, which
+                                    // only runs hooks when there were no failures).
+                                    if folder_ok {
+                                        run_season_hooks(
+                                            &config, path, &label, &out, total_size, &tx,
+                                        )
+                                        .await;
+                                    }
+
+                                    season_nzb = Some(out);
+                                }
+                                Err(e) => {
+                                    let _ = tx.send(AppEvent::UploadError(format!(
+                                        "season nzb write: {e}"
+                                    )));
+                                    folder_ok = false;
+                                }
                             }
-
-                            season_nzb = Some(out);
                         }
-                        Err(e) => {
-                            let _ =
-                                tx.send(AppEvent::UploadError(format!("season nzb write: {e}")));
-                            folder_ok = false;
+                    }
+                    Some(msg) => {
+                        if any_cancelled {
+                            let _ = tx.send(AppEvent::Progress(msg.to_string()));
+                        } else {
+                            let _ = tx.send(AppEvent::UploadError(msg.to_string()));
                         }
                     }
                 }
@@ -2690,32 +2726,42 @@ fn extract_progress_update(
 
 #[cfg(test)]
 mod season_nzb_gate_tests {
-    /// T16b: UpaPasta `folder_mode == Season` gates `fs::write` on the same
-    /// library predicate as pesto CLI `run_batch`. `folder_ok == false`
-    /// (any episode `had_failures`, including MissingConfirmed with
-    /// `--allow-incomplete-nzb`) maps to `any_episode_incomplete`.
-    fn gate(any_cancelled: bool, folder_ok: bool, all_segments_empty: bool) -> bool {
-        pesto::poster::should_write_season_nzb(any_cancelled, !folder_ok, all_segments_empty)
+    use super::{season_pack_skip_message, should_write_season_pack};
+
+    /// T16b: production `should_write_season_pack` is what the Season
+    /// `fs::write` calls. `folder_ok == false` (had_failures, including
+    /// MissingConfirmed with `--allow-incomplete-nzb`) is incomplete.
+    #[test]
+    fn t16b_folder_ok_writes_pack() {
+        assert!(should_write_season_pack(false, true, false));
+        assert_eq!(season_pack_skip_message(false, true, false), None);
     }
 
     #[test]
-    fn t16b_all_episodes_ok_writes_pack() {
-        assert!(gate(false, true, false));
-    }
-
-    #[test]
-    fn t16b_incomplete_episode_does_not_write_pack() {
-        assert!(!gate(false, false, false));
+    fn t16b_folder_ok_false_does_not_write_pack() {
+        assert!(!should_write_season_pack(false, false, false));
+        assert_eq!(
+            season_pack_skip_message(false, false, false),
+            Some("season pack was not created due to earlier upload failures")
+        );
     }
 
     #[test]
     fn t16b_cancelled_does_not_write_pack() {
-        assert!(!gate(true, true, false));
+        assert!(!should_write_season_pack(true, true, false));
+        assert_eq!(
+            season_pack_skip_message(true, true, false),
+            Some("interrupted — skipping season nzb output")
+        );
     }
 
     #[test]
     fn t16b_empty_segments_does_not_write_pack() {
-        assert!(!gate(false, true, true));
+        assert!(!should_write_season_pack(false, true, true));
+        assert_eq!(
+            season_pack_skip_message(false, true, true),
+            Some("season pack was not created (no valid segments were uploaded)")
+        );
     }
 }
 

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1701,8 +1701,16 @@ fn handle_upload_trigger(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
             }
 
             // Season: consolidate every posted segment into one combined NZB.
+            // The pack is a distinct artefact: --allow-incomplete-nzb never
+            // unlocks it. Per-episode NZBs already followed nzb_write_decision.
             let mut season_nzb = None;
-            if folder_mode == app::FolderMode::Season && !all_segments.is_empty() {
+            if folder_mode == app::FolderMode::Season
+                && pesto::poster::should_write_season_nzb(
+                    any_cancelled,
+                    !folder_ok,
+                    all_segments.is_empty(),
+                )
+            {
                 if let Some(ref dir) = nzb_out_dir {
                     let out = dir.join(format!("{label}.nzb"));
                     let meta = pesto::nzb::NzbMeta {
@@ -2677,6 +2685,37 @@ fn extract_progress_update(
             par2_complete: false,
         }),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod season_nzb_gate_tests {
+    /// T16b: UpaPasta `folder_mode == Season` gates `fs::write` on the same
+    /// library predicate as pesto CLI `run_batch`. `folder_ok == false`
+    /// (any episode `had_failures`, including MissingConfirmed with
+    /// `--allow-incomplete-nzb`) maps to `any_episode_incomplete`.
+    fn gate(any_cancelled: bool, folder_ok: bool, all_segments_empty: bool) -> bool {
+        pesto::poster::should_write_season_nzb(any_cancelled, !folder_ok, all_segments_empty)
+    }
+
+    #[test]
+    fn t16b_all_episodes_ok_writes_pack() {
+        assert!(gate(false, true, false));
+    }
+
+    #[test]
+    fn t16b_incomplete_episode_does_not_write_pack() {
+        assert!(!gate(false, false, false));
+    }
+
+    #[test]
+    fn t16b_cancelled_does_not_write_pack() {
+        assert!(!gate(true, true, false));
+    }
+
+    #[test]
+    fn t16b_empty_segments_does_not_write_pack() {
+        assert!(!gate(false, true, true));
     }
 }
 

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -1133,6 +1133,7 @@ fn run_selected_hook(app: &mut App, tx: mpsc::UnboundedSender<AppEvent>) {
             // the real filename (see `nzb::generate`'s doc comment), never
             // the wire identity, so there is nothing to recover it from.
             wire_subject: String::new(),
+            incomplete: false,
         };
 
         let (ok, mut log) = pesto::hooks::run_one_hook(&hook, &ctx);
@@ -1962,6 +1963,7 @@ async fn run_season_hooks(
         // either — same reasoning as `server`/`servers` above — so there is
         // no wire identity left to report.
         wire_subject: String::new(),
+        incomplete: false,
     };
 
     let hook_cfg = config.clone();

--- a/crates/upapasta/src/main.rs
+++ b/crates/upapasta/src/main.rs
@@ -2382,9 +2382,26 @@ fn format_progress_event(ev: &pesto::progress::ProgressEvent) -> String {
         E::Interrupted => "Interrupted by user".into(),
         E::Paused => "=== Upload paused ===".into(),
         E::Resumed => "=== Upload resumed ===".into(),
-        E::CheckDone { failed } if *failed == 0 => "✓ Check: all articles verified".into(),
-        E::CheckDone { failed } => {
-            format!("✗ Check: {failed} article(s) still missing after every repost attempt")
+        E::CheckDone {
+            failed,
+            inconclusive,
+        } if *failed == 0 && *inconclusive == 0 => "✓ Check: all articles verified".into(),
+        E::CheckDone {
+            failed,
+            inconclusive,
+        } => {
+            let mut parts = Vec::new();
+            if *failed > 0 {
+                parts.push(format!(
+                    "{failed} article(s) still missing after every repost attempt"
+                ));
+            }
+            if *inconclusive > 0 {
+                parts.push(format!(
+                    "{inconclusive} inconclusive (check path failed — not a confirmed gap)"
+                ));
+            }
+            format!("✗ Check: {}", parts.join("; "))
         }
         E::CheckRetrying {
             attempt,
@@ -2593,7 +2610,10 @@ fn extract_progress_update(
                 par2_complete: false,
             })
         }
-        E::CheckDone { failed } => Some(ProgressUpdate {
+        E::CheckDone {
+            failed,
+            inconclusive,
+        } => Some(ProgressUpdate {
             done_segments: previous.done_segments,
             total_segments: previous.total_segments,
             done_bytes: previous.done_bytes,
@@ -2605,7 +2625,7 @@ fn extract_progress_update(
             par2_slices: None,
             check_progress: Some((
                 previous.check_progress.map(|(c, _)| c).unwrap_or(0),
-                *failed,
+                *failed + *inconclusive,
             )),
             queue_extended: None,
             par2_hint_bytes: 0,


### PR DESCRIPTION
## Summary

- distinguish inconclusive STAT failures from confirmed missing articles
- persist confirmation state for safe resume and keep all check/recovery work inside the configured connection budget
- refuse partial combined season NZBs and document the release behavior
- bump pesto-poster to 0.9.1 and update penne's path dependency requirement

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo doc --no-deps -p pesto-poster