### PR TITLE
Add fail-fast penne checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "penne"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/penne/Cargo.toml
+++ b/crates/penne/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penne"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast NZB downloader: fetches articles over NNTP, reassembles files, verifies and repairs with PAR2."

--- a/crates/penne/README.md
+++ b/crates/penne/README.md
@@ -385,6 +385,7 @@ connection pool, so no per-file reconnect cost), **structured JSON output**,
 penne check path/to/release.nzb
 penne check release1.nzb release2.nzb --method head
 penne check release.nzb --json --quiet > result.jsonl
+penne check *.nzb --fail-fast --quiet
 ```
 
 Flags:
@@ -394,6 +395,7 @@ Flags:
 | `--method <stat\|head\|body>` | `stat` | Which NNTP command to check with — see the method descriptions under `--stat` above; same trade-offs apply here. |
 | `--sample <N>` | off (check every segment) | Check only `N` segment(s) per file, spread evenly — same semantics as `download --stat`'s `--sample`. |
 | `--pipeline-depth <N>` | `128` | How many `STAT` commands are pipelined per connection per round trip. Only affects `--method stat`; ignored for `head`/`body`, which don't pipeline (see `--stat` above for why). |
+| `--fail-fast` | off | Stop scheduling work after the first article confirmed missing on every applicable server. Requests already pipelined are completed cleanly, and remaining articles are reported as skipped; use this when only a pass/fail verdict matters. |
 | `--json` | off | Emit one JSON object per line (NDJSON) instead of the human-readable summary — see schema below. |
 | `-q`, `--quiet` | off | Suppress the live progress bar and per-segment `missing`/`unreachable` lines; only the final summary (or, with `--json`, the JSON lines themselves) is printed. |
 | `--server <NAME>` | every configured server | Use only the named `[[servers]]` entry (repeatable) — same as `download`'s `--server`. |
@@ -468,10 +470,12 @@ given:
 | `server` | The single hostname this line's result came from. Only present with `--independent-servers`, in place of `servers`. |
 | `complete` | `true` only if every segment was confirmed present — `false` for both confirmed-missing and merely-unreachable segments. |
 | `conclusive` | `true` if every segment got a definitive present/absent answer from some server. **Check this before trusting `missing`/`missing_pct` as a final verdict** — if `false`, at least one segment's fate is unknown, and `missing` alone isn't enough to declare the release dead. |
-| `total_articles` | Total segments checked. |
+| `stopped_early` | `true` when `--fail-fast` stopped after a confirmed missing article. A result with this field set is intentionally partial. |
+| `total_articles` | Total segments listed in the `.nzb`, including any reported as `skipped` by a fail-fast run. |
 | `present` | Segments confirmed present on at least one server. |
 | `missing` / `missing_pct` | Segments at least one server definitively denied (`430`/`423`/`420`) and none confirmed present — the only case that should be treated as confirmed data loss. |
 | `unreachable` / `unreachable_pct` | Segments no tried server ever gave a real answer for (connection failure, exhausted retries) — deliberately kept separate from `missing` so a transient network hiccup is never read as confirmed absence. |
+| `skipped` | Segments not checked because `--fail-fast` had already found a confirmed missing article. They are neither missing nor unreachable. |
 | `files` | Per-file breakdown, `.nzb` order: `name`, `total_segments`, `present_segments`. |
 | `missing_articles` | `{ file_name, part, message_id }` for each confirmed-missing segment. |
 | `unreachable_articles` | Same shape, for unreachable segments. |

--- a/crates/penne/ROADMAP.md
+++ b/crates/penne/ROADMAP.md
@@ -57,6 +57,7 @@ testable state.
 | 16 | `sabnzbd`-inspired hardening — categorized, actionable NNTP connect/auth error messages; PAR2 quick-check deriving a file's expected CRC-32 from IFSC data alone (new `pesto::yenc::crc32_combine`), skipping a full re-hash on the common all-intact path; per-segment streaming writes, closing the memory-scaling gap Phase 14 left for single-large-file releases. |
 | 17 | Processing modes — `--mode {download,repair,unpack,delete}` gates PAR2 verify/repair, extraction, and a new post-extraction cleanup step behind `sabnzbd`-style cumulative processing levels; new `penne::cleanup::purge_archives_and_par2` deletes archive volumes and PAR2 recovery data once extraction succeeds. |
 | 18 | `HEAD`/`BODY` availability checks + `--sample` — `pesto::nntp::Connection::head` (RFC 3977 §6.2.2) and `penne::check::CheckMethod` let `--stat` pick `stat`/`head`/`body` instead of only ever trusting `STAT`'s index; `--sample <N>` bounds a `body` check to the first `N` segment(s) per file. Prompted by, and verified against, a real provider whose `STAT` (and, it turned out, `HEAD` too) reported a release fully present while every real download attempt — and a `body` check — failed. |
+| 19 | Fail-fast availability checks — `penne check --fail-fast` stops scheduling after a confirmed missing article while preserving server failover and draining already-pipelined NNTP requests cleanly; partial results explicitly report skipped segments. |
 
 ---
 
@@ -1389,6 +1390,25 @@ provider, the two had drifted apart.
       `body_method_catches_an_article_stat_lies_about` can reproduce the
       exact "index lies" bug this phase exists for; `penne::queue` gains
       unit tests for `sample`.
+
+---
+
+## Phase 19 — Fail-fast availability checks ✅
+
+- [x] **`penne check --fail-fast`** stops scheduling work after an article
+      is conclusively missing. A definitive `430` from a primary alone does
+      not stop the run: configured backup tiers still get their chance to
+      confirm the article, preserving the normal failover guarantee.
+- [x] **Protocol-safe early stop for every check method.** `STAT` finishes
+      requests already in a pipeline before workers stop taking new batches;
+      `HEAD` and `BODY` finish an article already in flight. No NNTP response
+      is abandoned mid-stream, regardless of `--method`.
+- [x] **Explicit partial results.** Human output and NDJSON expose
+      `stopped_early` and `skipped`, so unchecked articles are never
+      misreported as either confirmed missing or unreachable. README and
+      `penne check --help` describe the option and its trade-offs.
+- [x] Tests cover early termination and primary-to-backup failover, in
+      addition to the existing `STAT`/`HEAD`/`BODY` availability tests.
 
 ---
 

--- a/crates/penne/src/bin/penne.rs
+++ b/crates/penne/src/bin/penne.rs
@@ -179,6 +179,11 @@ enum Command {
         /// STAT commands pipelined per connection (default: 128).
         #[arg(long, default_value = "128")]
         pipeline_depth: usize,
+        /// Stop after the first article confirmed missing on every applicable
+        /// server. Already-pipelined requests finish cleanly; the remaining
+        /// articles are reported as skipped rather than missing.
+        #[arg(long)]
+        fail_fast: bool,
         /// Machine-readable JSON output.
         #[arg(long)]
         json: bool,
@@ -261,6 +266,7 @@ async fn main() -> Result<()> {
             method,
             sample,
             pipeline_depth,
+            fail_fast,
             json,
             quiet,
             server,
@@ -271,6 +277,7 @@ async fn main() -> Result<()> {
                 method,
                 sample,
                 pipeline_depth,
+                fail_fast,
                 json,
                 quiet,
                 cli.config.flatten(),
@@ -732,6 +739,7 @@ async fn check(
     method: CheckMethod,
     sample: Option<usize>,
     pipeline_depth: usize,
+    fail_fast: bool,
     json: bool,
     quiet: bool,
     config_path: Option<PathBuf>,
@@ -766,6 +774,7 @@ async fn check(
         method,
         pipeline_depth,
         retries: config.retries,
+        fail_fast,
     };
 
     let flat_servers: Vec<penne::config::ServerTier> = config
@@ -878,6 +887,7 @@ async fn check(
                     // this field split exists to prevent.
                     "complete": outcome.is_complete(),
                     "conclusive": outcome.is_conclusive(),
+                    "stopped_early": outcome.stopped_early,
                     "total_articles": outcome.total_checked,
                     "present": outcome.total_present,
                     "missing": outcome.missing_count(),
@@ -887,6 +897,7 @@ async fn check(
                         0.0
                     },
                     "unreachable": outcome.unreachable_count(),
+                    "skipped": outcome.skipped,
                     "unreachable_pct": if outcome.total_checked > 0 {
                         outcome.unreachable_count() as f64 / outcome.total_checked as f64 * 100.0
                     } else {
@@ -1031,6 +1042,12 @@ async fn check(
                          not counted as missing, but this check is inconclusive",
                         outcome.unreachable.len(),
                         unreachable_pct
+                    );
+                }
+                if outcome.stopped_early {
+                    println!(
+                        "  stopped early:    {} segment(s) skipped after confirmed missing article",
+                        outcome.skipped
                     );
                 }
                 println!(

--- a/crates/penne/src/check.rs
+++ b/crates/penne/src/check.rs
@@ -33,6 +33,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -108,6 +109,10 @@ pub struct CheckConfig {
     pub pipeline_depth: usize,
     /// Retry attempts per server before failing over to the next tier.
     pub retries: u32,
+    /// Stop scheduling work after the first article is conclusively missing.
+    /// A server failover pass still completes first, so a miss on a primary
+    /// alone never produces a false failure.
+    pub fail_fast: bool,
 }
 
 impl Default for CheckConfig {
@@ -116,6 +121,7 @@ impl Default for CheckConfig {
             method: CheckMethod::default(),
             pipeline_depth: DEFAULT_STAT_PIPELINE_DEPTH,
             retries: 3,
+            fail_fast: false,
         }
     }
 }
@@ -221,10 +227,18 @@ pub struct CheckOutcome {
     /// the last response being read, not including NZB parsing or queue
     /// construction).
     pub elapsed: Duration,
-    /// Total number of articles checked (segments in the queue).
+    /// Total number of articles requested (segments in the queue), including
+    /// any that a fail-fast run deliberately skipped.
     pub total_checked: u32,
     /// Articles confirmed present on at least one configured server.
     pub total_present: u32,
+    /// `true` when `CheckConfig::fail_fast` stopped the run after a
+    /// confirmed absence. Counts and per-file results then cover only the
+    /// work completed before stopping.
+    pub stopped_early: bool,
+    /// Segments deliberately not checked because `fail_fast` stopped the
+    /// scheduler. They are neither missing nor unreachable.
+    pub skipped: u32,
 }
 
 impl CheckOutcome {
@@ -232,7 +246,7 @@ impl CheckOutcome {
     /// `false` for both confirmed-missing segments and merely-unreachable
     /// ones, since neither case means the release is safely grabbable.
     pub fn is_complete(&self) -> bool {
-        self.missing.is_empty() && self.unreachable.is_empty()
+        !self.stopped_early && self.missing.is_empty() && self.unreachable.is_empty()
     }
 
     /// True when every segment got a definitive answer (present or
@@ -240,15 +254,16 @@ impl CheckOutcome {
     /// segment's fate is still unknown, so `missing` — even if empty —
     /// cannot yet be read as "this release is fully present".
     pub fn is_conclusive(&self) -> bool {
-        self.unreachable.is_empty()
+        !self.stopped_early && self.unreachable.is_empty()
     }
 
-    /// Articles checked per second, based on wall-clock elapsed time.
+    /// Articles actually checked per second, based on wall-clock elapsed
+    /// time. Deliberately skipped fail-fast items are not counted.
     /// Returns `0.0` when elapsed is zero (instantaneous or empty queue).
     pub fn articles_per_second(&self) -> f64 {
         let secs = self.elapsed.as_secs_f64();
         if secs > 0.0 {
-            self.total_checked as f64 / secs
+            (self.total_checked - self.skipped) as f64 / secs
         } else {
             0.0
         }
@@ -280,6 +295,8 @@ impl Default for CheckOutcome {
             elapsed: Duration::ZERO,
             total_checked: 0,
             total_present: 0,
+            stopped_early: false,
+            skipped: 0,
         }
     }
 }
@@ -365,6 +382,7 @@ pub async fn check_nzbs(
         .iter()
         .map(|q| q.files.iter().map(|f| f.segments.len() as u32).sum())
         .collect();
+    let stop = Arc::new(AtomicBool::new(false));
 
     let (item_tx, mut item_rx) = tokio::sync::mpsc::unbounded_channel::<ItemResolution>();
     let item_tx_opt = if outcome_tx.is_some() {
@@ -378,12 +396,14 @@ pub async fn check_nzbs(
         let totals_clone = totals.clone();
         let total_items_per_q_clone = total_items_per_q.clone();
         let start_time = start;
+        let tracker_stop = stop.clone();
 
         Some(tokio::spawn(async move {
             let mut resolved = vec![0u32; qs.len()];
             let mut present = vec![HashMap::<String, u32>::new(); qs.len()];
             let mut missing = vec![Vec::<MissingSegment>::new(); qs.len()];
             let mut unreachable = vec![Vec::<UnreachableSegment>::new(); qs.len()];
+            let mut sent = vec![false; qs.len()];
 
             while let Some(res) = item_rx.recv().await {
                 let q_idx = match &res {
@@ -416,8 +436,7 @@ pub async fn check_nzbs(
 
                 if resolved[q_idx] == total_items_per_q_clone[q_idx] {
                     let total_items = total_items_per_q_clone[q_idx];
-                    let total_present =
-                        total_items - missing[q_idx].len() as u32 - unreachable[q_idx].len() as u32;
+                    let total_present = present[q_idx].values().sum();
 
                     let files = qs[q_idx]
                         .files
@@ -437,9 +456,47 @@ pub async fn check_nzbs(
                         elapsed: start_time.elapsed(),
                         total_checked: total_items,
                         total_present,
+                        stopped_early: false,
+                        skipped: 0,
                     };
 
                     let _ = out_tx.send((q_idx, outcome));
+                    sent[q_idx] = true;
+                }
+            }
+
+            // With fail-fast, deliberately skipped items do not emit a
+            // resolution event. Send the partial per-NZB result once the
+            // workers have stopped so JSON callers still get one line.
+            if tracker_stop.load(Ordering::Relaxed) {
+                for q_idx in 0..qs.len() {
+                    if sent[q_idx] {
+                        continue;
+                    }
+                    let total_items = total_items_per_q_clone[q_idx];
+                    let files = qs[q_idx]
+                        .files
+                        .iter()
+                        .map(|f| FileCheck {
+                            name: f.name.clone(),
+                            total_segments: *totals_clone[q_idx].get(&f.name).unwrap_or(&0),
+                            present_segments: *present[q_idx].get(&f.name).unwrap_or(&0),
+                        })
+                        .collect();
+                    let _ = out_tx.send((
+                        q_idx,
+                        CheckOutcome {
+                            files,
+                            missing: std::mem::take(&mut missing[q_idx]),
+                            unreachable: std::mem::take(&mut unreachable[q_idx]),
+                            bytes_used: 0,
+                            elapsed: start_time.elapsed(),
+                            total_checked: total_items,
+                            total_present: present[q_idx].values().sum(),
+                            stopped_early: true,
+                            skipped: total_items - resolved[q_idx],
+                        },
+                    ));
                 }
             }
         }))
@@ -462,6 +519,7 @@ pub async fn check_nzbs(
             config,
             &progress,
             is_last_tier,
+            stop.clone(),
             item_tx_opt.clone(),
         )
         .await;
@@ -474,6 +532,8 @@ pub async fn check_nzbs(
 
     let mut missing_per_q: Vec<Vec<MissingSegment>> = vec![Vec::new(); queues.len()];
     let mut unreachable_per_q: Vec<Vec<UnreachableSegment>> = vec![Vec::new(); queues.len()];
+    let stopped_early = stop.load(Ordering::Relaxed);
+    let mut skipped_per_q = vec![0u32; queues.len()];
     for item in pending {
         // `confirmed_missing` was set the instant any tried tier returned a
         // definitive 430/423/420 for this item (see `WorkItem`'s doc
@@ -486,6 +546,8 @@ pub async fn check_nzbs(
                 part: item.part,
                 message_id: item.message_id,
             });
+        } else if stopped_early {
+            skipped_per_q[item.queue_idx] += 1;
         } else {
             unreachable_per_q[item.queue_idx].push(UnreachableSegment {
                 file_name: item.file_name,
@@ -508,8 +570,7 @@ pub async fn check_nzbs(
 
     for (q_idx, queue) in queues.iter().enumerate() {
         let total_items = total_items_per_q[q_idx];
-        let total_present =
-            total_items - missing_per_q[q_idx].len() as u32 - unreachable_per_q[q_idx].len() as u32;
+        let total_present = present[q_idx].values().sum();
 
         let files = queue
             .files
@@ -529,6 +590,8 @@ pub async fn check_nzbs(
             elapsed: start.elapsed(),
             total_checked: total_items,
             total_present,
+            stopped_early: stopped_early && skipped_per_q[q_idx] > 0,
+            skipped: skipped_per_q[q_idx],
         });
     }
 
@@ -574,6 +637,7 @@ async fn drain_one_tier(
     config: &CheckConfig,
     progress: &Option<CheckProgressSender>,
     is_last_tier: bool,
+    stop: Arc<AtomicBool>,
     item_tx: Option<tokio::sync::mpsc::UnboundedSender<ItemResolution>>,
 ) -> (Vec<WorkItem>, Vec<WorkItem>, u64) {
     let queue = Arc::new(Mutex::new(VecDeque::from(pending)));
@@ -602,6 +666,8 @@ async fn drain_one_tier(
                 pipeline_depth,
                 progress.clone(),
                 is_last_tier,
+                config.fail_fast,
+                stop.clone(),
                 worker_count,
                 breaker.clone(),
                 item_tx.clone(),
@@ -626,6 +692,10 @@ async fn drain_one_tier(
     // confirmed them missing (`WorkItem::confirmed_missing`).
     let mut q = queue.lock().unwrap();
     while let Some(item) = q.pop_front() {
+        if stop.load(Ordering::Relaxed) {
+            leftover.push(item);
+            continue;
+        }
         if is_last_tier {
             emit(progress, false);
             if let Some(tx) = &item_tx {
@@ -675,6 +745,8 @@ async fn worker_loop(
     pipeline_depth: usize,
     progress: Option<CheckProgressSender>,
     is_last_server: bool,
+    fail_fast: bool,
+    stop: Arc<AtomicBool>,
     worker_count: usize,
     breaker: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     item_tx: Option<tokio::sync::mpsc::UnboundedSender<ItemResolution>>,
@@ -688,6 +760,8 @@ async fn worker_loop(
                 pipeline_depth,
                 progress,
                 is_last_server,
+                fail_fast,
+                stop,
                 worker_count,
                 breaker,
                 item_tx,
@@ -702,6 +776,8 @@ async fn worker_loop(
                 retries,
                 progress,
                 is_last_server,
+                fail_fast,
+                stop,
                 breaker,
                 item_tx,
             )
@@ -718,6 +794,8 @@ async fn stat_worker_loop(
     pipeline_depth: usize,
     progress: Option<CheckProgressSender>,
     is_last_server: bool,
+    fail_fast: bool,
+    stop: Arc<AtomicBool>,
     worker_count: usize,
     breaker: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     item_tx: Option<tokio::sync::mpsc::UnboundedSender<ItemResolution>>,
@@ -728,6 +806,9 @@ async fn stat_worker_loop(
     let mut bytes_used = 0u64;
 
     loop {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
         if breaker.load(std::sync::atomic::Ordering::Relaxed) >= 5 {
             break;
         }
@@ -760,6 +841,9 @@ async fn stat_worker_loop(
                             emit(&progress, false);
                             if let Some(tx) = &item_tx {
                                 let _ = tx.send(ItemResolution::Missing(item.clone()));
+                            }
+                            if fail_fast {
+                                stop.store(true, Ordering::Relaxed);
                             }
                         }
                         leftover.push(item);
@@ -814,6 +898,8 @@ async fn single_item_worker_loop(
     retries: u32,
     progress: Option<CheckProgressSender>,
     is_last_server: bool,
+    fail_fast: bool,
+    stop: Arc<AtomicBool>,
     breaker: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     item_tx: Option<tokio::sync::mpsc::UnboundedSender<ItemResolution>>,
 ) -> (Vec<WorkItem>, Vec<WorkItem>, u64) {
@@ -823,6 +909,9 @@ async fn single_item_worker_loop(
     let mut bytes_used = 0u64;
 
     loop {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
         if breaker.load(std::sync::atomic::Ordering::Relaxed) >= 5 {
             break;
         }
@@ -860,6 +949,9 @@ async fn single_item_worker_loop(
                     emit(&progress, false);
                     if let Some(tx) = &item_tx {
                         let _ = tx.send(ItemResolution::Missing(item.clone()));
+                    }
+                    if fail_fast {
+                        stop.store(true, Ordering::Relaxed);
                     }
                 }
                 leftover.push(item);

--- a/crates/penne/src/lib.rs
+++ b/crates/penne/src/lib.rs
@@ -12,8 +12,8 @@
 //! eventually, a web UI (à la SABnzbd) built on top of it. The web UI is out
 //! of scope until the CLI reaches feature parity with the roadmap.
 
-/// Shown by `--version`. `dev` on this branch (main is frozen at 0.5.0).
-pub const DISPLAY_VERSION: &str = "dev";
+/// Shown by `--version`.
+pub const DISPLAY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod assemble;
 pub mod cache;

--- a/crates/penne/tests/check.rs
+++ b/crates/penne/tests/check.rs
@@ -272,6 +272,60 @@ async fn missing_segments_are_reported_per_file_and_overall() {
 }
 
 #[tokio::test]
+async fn fail_fast_stops_after_a_confirmed_missing_article() {
+    let addr = spawn_fake_server(HashSet::new());
+    let queue = queue_with(&[("movie.bin", &["gone@x", "later1@x", "later2@x"])]);
+    let config = CheckConfig {
+        pipeline_depth: 1,
+        fail_fast: true,
+        ..CheckConfig::new(CheckMethod::Stat, 0)
+    };
+
+    let outcome = check_queue(
+        &queue,
+        &[ServerTier::solo(server_entry(addr))],
+        &config,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(outcome.stopped_early);
+    assert_eq!(outcome.missing.len(), 1);
+    assert_eq!(outcome.missing[0].message_id, "gone@x");
+    assert_eq!(outcome.skipped, 2);
+    assert!(!outcome.is_complete());
+    assert!(!outcome.is_conclusive());
+}
+
+#[tokio::test]
+async fn fail_fast_still_uses_a_backup_server() {
+    let primary = spawn_fake_server(HashSet::new());
+    let backup = spawn_fake_server(["a1@x", "a2@x"].into_iter().collect());
+    let queue = queue_with(&[("movie.bin", &["a1@x", "a2@x"])]);
+    let config = CheckConfig {
+        fail_fast: true,
+        ..CheckConfig::new(CheckMethod::Stat, 0)
+    };
+
+    let outcome = check_queue(
+        &queue,
+        &[
+            ServerTier::solo(server_entry(primary)),
+            ServerTier::solo(server_entry(backup)),
+        ],
+        &config,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(outcome.is_complete());
+    assert!(!outcome.stopped_early);
+    assert!(outcome.missing.is_empty());
+}
+
+#[tokio::test]
 async fn falls_back_to_backup_server_for_segments_the_primary_lacks() {
     let primary = spawn_fake_server(HashSet::new()); // knows nothing
     let backup_known: HashSet<&str> = ["a1@x"].into_iter().collect();


### PR DESCRIPTION
## Summary
- Add penne check --fail-fast for a fast pass/fail availability verdict.
- Preserve server failover and safely drain in-flight STAT, HEAD, and BODY requests.
- Report partial results explicitly and bump penne to 0.5.1.

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test