### PR TITLE
Improve penne help and check output

### DIFF
--- a/crates/penne/README.md
+++ b/crates/penne/README.md
@@ -39,9 +39,16 @@ cargo run --bin penne -- check path/to/release.nzb
 
 # You can also check multiple releases at once (they will share the connection pool)
 cargo run --bin penne -- check path/to/release1.nzb path/to/release2.nzb
+
+# Only need a pass/fail answer? Stop after the first confirmed missing article.
+cargo run --bin penne -- check path/to/release.nzb --fail-fast --quiet
 ```
 
 `penne check` verifies if every article is still present on the configured servers without downloading the bodies or writing anything to disk. It's a high-performance availability check that can pipeline hundreds of STAT commands at once, emitting JSON if asked (`--json`) and exiting with meaningful codes (0 = all present, 1 = confirmed missing, 2 = fatal error, 3 = inconclusive). It natively supports checking multiple `.nzb` files sequentially while reusing the same active connection pool, avoiding reconnection overhead. See [`check`: dedicated availability-check subcommand](#check-dedicated-availability-check-subcommand) below for every flag and the full `--json` schema.
+
+Run `penne --help` to see the configuration, availability-check, and download
+workflows together. `penne check --help` and `penne help check` are equivalent
+ways to see availability-check-specific options and examples.
 
 A confirmed-missing article (a server returned a definitive `430`/`423`/`420`) is reported separately from an unreachable one (every tried server failed to connect or timed out before ever answering) — `missing` vs `unreachable` in the JSON output, `conclusive: false` when any segment falls in the latter bucket. This distinction matters for callers that act on a check's result (e.g. deciding whether to declare a release dead): a transient network hiccup must never be read as confirmed data loss.
 
@@ -388,6 +395,36 @@ penne check release.nzb --json --quiet > result.jsonl
 penne check *.nzb --fail-fast --quiet
 ```
 
+#### `--fail-fast`: stop once a release is known to be incomplete
+
+By default, `penne check` completes every requested segment so its summary
+can give an exact availability percentage and a complete missing-article
+list. Add `--fail-fast` when the only useful answer is “is at least one
+article definitely gone?”:
+
+```bash
+# Exit 0 when every checked NZB is complete; exit 1 as soon as an NZB is
+# conclusively known to be incomplete.
+penne check *.nzb --fail-fast --quiet
+
+# Same policy, but verify actual article delivery rather than a provider's
+# STAT index. This consumes article bandwidth for requests already started.
+penne check release.nzb --method body --fail-fast
+```
+
+It applies equally to `stat`, `head`, and `body`. It never treats a `430`
+from a primary as final while a configured failover server could still have
+the article: every applicable server is tried first. Once an article is
+confirmed absent everywhere, no new work is scheduled. `STAT` requests
+already pipelined are read to completion; an in-flight `HEAD` or `BODY` is
+also completed normally, so no NNTP response is abandoned mid-stream.
+
+The result is intentionally **partial**: `stopped_early: true` and a
+non-zero `skipped` count mean the unchecked articles are neither “missing”
+nor “unreachable”, and `complete`/`conclusive` are both `false`. Use the
+default mode when you need a percentage, a complete missing list, or a
+provider comparison with `--independent-servers`.
+
 Flags:
 
 | Flag | Default | Meaning |
@@ -443,12 +480,14 @@ given:
   "servers": ["news.example.com", "backup.example.com"],
   "complete": true,
   "conclusive": true,
+  "stopped_early": false,
   "total_articles": 6968,
   "present": 6968,
   "missing": 0,
   "missing_pct": 0.0,
   "unreachable": 0,
   "unreachable_pct": 0.0,
+  "skipped": 0,
   "files": [
     { "name": "movie.mkv", "total_segments": 200, "present_segments": 200 }
   ],

--- a/crates/penne/src/bin/penne.rs
+++ b/crates/penne/src/bin/penne.rs
@@ -37,7 +37,9 @@ Server credentials are read from a TOML config file. If --config is not \
 given, penne loads it from the OS-standard location: $XDG_CONFIG_HOME/penne/config.toml \
 (or, failing that, ~/.config/penne/config.toml) on Linux/macOS, or \
 %APPDATA%\\penne\\config.toml on Windows. Create that file interactively \
-with `penne --config`, or point at a specific file with `--config <FILE>`."
+with `penne --config`, or point at a specific file with `--config <FILE>`.",
+after_help = "QUICK START:\n  penne --config                         Configure a news server\n  penne check RELEASE.nzb                Verify availability without downloading\n  penne check RELEASE.nzb --fail-fast -q Stop at the first confirmed miss\n  penne download RELEASE.nzb             Download, repair, and extract\n\n\
+Run `penne <command> --help` (or `penne help <command>`) for command options."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -67,11 +69,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    #[command(about = "Inspect an NZB's files, segments, and size")]
     /// Parse a `.nzb` and print file/segment/size counts.
     Info {
         /// Path to the `.nzb` file.
         nzb: PathBuf,
     },
+    #[command(about = "Download, repair, and extract one or more NZBs")]
     /// Download and assemble the contents of one or more `.nzb` files. Exits
     /// 0 if every file ended up complete with no repair needed, 1 if PAR2
     /// repaired something but the end result is complete, 2 if data is still
@@ -157,6 +161,15 @@ enum Command {
         #[arg(long, short)]
         quiet: bool,
     },
+    #[command(
+        about = "Verify that NZB articles are available without downloading",
+        after_help = "EXAMPLES:\n  penne check RELEASE.nzb\n  penne check RELEASE.nzb --method head\n  penne check RELEASE.nzb --method body --fail-fast -q\n  penne check *.nzb --fail-fast --quiet\n\n\
+Use --method stat for the cheapest index check, head for header storage, or \
+body to verify a full article transfer. --fail-fast returns as soon as an \
+article is confirmed missing after failover, so it does not produce a full \
+availability percentage.\n\n\
+EXIT STATUS:\n  0  All checked articles are present\n  1  At least one article is confirmed missing\n  2  Fatal error (configuration, input, or I/O)\n  3  Inconclusive: an article could not be checked"
+    )]
     /// Check article availability across one or more `.nzb` files without
     /// downloading. Exits 0 if all articles are present, 1 if any are
     /// confirmed missing (a server returned a definitive "not present"),
@@ -179,9 +192,11 @@ enum Command {
         /// STAT commands pipelined per connection (default: 128).
         #[arg(long, default_value = "128")]
         pipeline_depth: usize,
-        /// Stop after the first article confirmed missing on every applicable
-        /// server. Already-pipelined requests finish cleanly; the remaining
-        /// articles are reported as skipped rather than missing.
+        /// Stop scheduling after an article is confirmed missing on every
+        /// applicable failover server. Works with stat, head, and body;
+        /// in-flight work finishes cleanly and the remaining articles are
+        /// reported as skipped, not missing. Use when only a pass/fail
+        /// verdict matters, not a complete availability percentage.
         #[arg(long)]
         fail_fast: bool,
         /// Machine-readable JSON output.
@@ -989,22 +1004,22 @@ async fn check(
                     println!("\n[{}/{}] {}", i + 1, queues.len(), nzb_name);
                 }
 
-                let mut incomplete_files = 0u32;
-                for f in &outcome.files {
-                    if f.is_complete() {
-                        println!(
-                            "  complete: {} ({}/{} segments)",
-                            f.name, f.present_segments, f.total_segments
-                        );
-                    } else {
-                        incomplete_files += 1;
-                        println!(
-                            "  INCOMPLETE: {} ({}/{} segments)",
-                            f.name, f.present_segments, f.total_segments
-                        );
-                    }
-                }
+                let incomplete_files =
+                    outcome.files.iter().filter(|f| !f.is_complete()).count() as u32;
                 if !quiet {
+                    for f in &outcome.files {
+                        if f.is_complete() {
+                            println!(
+                                "  complete: {} ({}/{} segments)",
+                                f.name, f.present_segments, f.total_segments
+                            );
+                        } else {
+                            println!(
+                                "  INCOMPLETE: {} ({}/{} segments)",
+                                f.name, f.present_segments, f.total_segments
+                            );
+                        }
+                    }
                     for seg in &outcome.missing {
                         println!("    missing: {} part {}", seg.file_name, seg.part);
                     }
@@ -1044,11 +1059,17 @@ async fn check(
                         unreachable_pct
                     );
                 }
-                if outcome.stopped_early {
-                    println!(
-                        "  stopped early:    {} segment(s) skipped after confirmed missing article",
-                        outcome.skipped
-                    );
+                if fail_fast && !outcome.missing.is_empty() {
+                    println!("  result:           INCOMPLETE — confirmed missing article");
+                    if outcome.stopped_early {
+                        println!(
+                            "  stopped early:    {} segment(s) not checked",
+                            outcome.skipped
+                        );
+                    }
+                    if let Some(seg) = outcome.missing.first() {
+                        println!("  first missing:    {} part {}", seg.file_name, seg.part);
+                    }
                 }
                 println!(
                     "  files complete:   {}/{}",

--- a/crates/penne/tests/cli_check_end_to_end.rs
+++ b/crates/penne/tests/cli_check_end_to_end.rs
@@ -178,4 +178,35 @@ fn quiet_suppresses_the_progress_banner_even_without_json() {
         !stderr.contains("checking"),
         "--quiet must still suppress the banner, got: {stderr}"
     );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("summary"),
+        "expected summary, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("complete: movie.bin"),
+        "--quiet must suppress per-file output, got: {stdout}"
+    );
+}
+
+#[test]
+fn fail_fast_quiet_summary_identifies_the_confirmed_miss() {
+    let addr = spawn_fake_stat_server(HashSet::new());
+    let dir = tempfile::tempdir().unwrap();
+    let nzb_path = write_nzb(dir.path());
+    let config_path = write_config(dir.path(), addr.port());
+
+    let output = run_penne_check(&nzb_path, &config_path, &["--fail-fast", "--quiet"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("INCOMPLETE — confirmed missing article"),
+        "expected explicit fail-fast verdict, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("first missing:    movie.bin part 1"),
+        "expected the first missing article, got: {stdout}"
+    );
 }


### PR DESCRIPTION
## Summary
- add task-oriented quick-start guidance to penne help
- document check methods, fail-fast behavior, and exit codes in command help
- make check --quiet suppress per-file lines and provide a clear fail-fast verdict

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test