### PR TITLE
Fix two-stage interrupt shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/crates/penne/Cargo.toml
+++ b/crates/penne/Cargo.toml
@@ -20,7 +20,7 @@ name = "penne"
 path = "src/bin/penne.rs"
 
 [dependencies]
-pesto = { package = "pesto-poster", path = "../pesto", version = "0.10.0" }
+pesto = { package = "pesto-poster", path = "../pesto", version = "0.10.1" }
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,27 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-09-01
+
+### Added
+
+- JSON progress now emits `aborted` when an interrupt escalates to an immediate
+  I/O abort, before the terminal `finished` event.
+
+### Changed
+
+- Ctrl-C and SIGTERM now use a two-stage shutdown: the first signal drains
+  in-flight articles gracefully, while a second signal or a 10-second deadline
+  drops active NNTP connections and saves resumable progress immediately.
+- Interrupted uploads now retain a partial NZB for confirmed articles alongside
+  their `.pesto-state`, even when `--resume` was not set for that run.
+
+### Fixed
+
+- A second Ctrl-C/SIGTERM is no longer swallowed after graceful shutdown has
+  started, preventing a stalled NNTP command from keeping a process alive until
+  its normal command timeout.
+
 ## [0.10.0] — 2026-09-01
 
 ### Added

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pesto-poster"
 # pesto is versioned, published, and released independently of the rest of
 # the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -624,6 +624,15 @@ their own release or bundled into one.
 
 ## Reliability
 
+### Interrupting an upload
+
+Press Ctrl-C (or send SIGTERM) once to stop queueing new articles and finish
+the articles already in flight. Press it again to abort immediately: pesto
+drops active NNTP connections, writes the partial NZB and `.pesto-state`, and
+exits 130. If graceful shutdown is still waiting after about 10 seconds, it
+escalates automatically. In both cases, run again with `--resume` to skip
+confirmed segments.
+
 ### Upload resume
 
 If a posting run is interrupted (Ctrl-C, network failure, articles still
@@ -1171,10 +1180,20 @@ A segment failed permanently after exhausting all retries.
 #### `interrupted`
 
 Emitted when Ctrl-C is received. The run is winding down; a `finished` event
-follows once in-flight segments complete.
+follows once in-flight segments complete. A second signal (or the ten-second
+graceful-shutdown deadline) emits `aborted` before `finished`.
 
 ```json
 {"type":"interrupted"}
+```
+
+#### `aborted`
+
+Emitted when pesto drops in-flight NNTP I/O during an escalated interrupt. The
+partial resume state is saved before the following `finished` event.
+
+```json
+{"type":"aborted"}
 ```
 
 #### `compress_started`

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -49,7 +49,10 @@ given, pesto loads it from the OS-standard location: $XDG_CONFIG_HOME/pesto/conf
 build never checks. Create that file interactively with `pesto --config`,
 which prints the exact path it wrote to.
 
-Any config value can be overridden by the matching flag below.";
+Any config value can be overridden by the matching flag below.
+
+Ctrl-C or SIGTERM once stops gracefully; press it again to abort immediately.
+Progress is saved for --resume in either case.";
 
 /// Examples printed after the option list.
 const AFTER_HELP: &str = "\
@@ -1709,27 +1712,14 @@ async fn run_single_upload(
     // If the user specified a destination (--out or nzb_dir), a hardlink (or
     // copy when cross-device) is placed there so re-uploads never collide.
     let out: Option<PathBuf> = if let Some(stem) = nzb_out_path {
-        if !cancelled || config.resume {
-            Some(nzb_archive_path(&stem).await)
-        } else {
-            if outcome.failure_reason.is_some() {
-                eprintln!("upload failed — skipping nzb output");
-            } else {
-                eprintln!("interrupted — skipping nzb output");
-            }
-            None
-        }
+        Some(nzb_archive_path(&stem).await)
     } else {
         None
     };
 
     // nzb_reported_path: the path shown to the user and passed to hooks/history.
     // It is the user-dest (hardlink) when set, otherwise the archive copy.
-    let mut nzb_reported_path: Option<PathBuf> = if cancelled && !config.resume {
-        None
-    } else {
-        nzb_user_dest.clone().or_else(|| out.clone())
-    };
+    let mut nzb_reported_path: Option<PathBuf> = nzb_user_dest.clone().or_else(|| out.clone());
 
     let _nzb_xml: Option<String> = if let Some(out) = &out {
         if !config.par2_only {

--- a/crates/pesto/src/cancel.rs
+++ b/crates/pesto/src/cancel.rs
@@ -1,37 +1,101 @@
 //! Unified cancellation support for pesto.
 //!
 //! Provides a single signal listener that flips a shared [`AtomicBool`] on
-//! Ctrl-C or SIGTERM.  Library code should **never** install its own signal
-//! handler; instead it accepts an `Arc<AtomicBool>` and polls it at safe
-//! boundaries.
+//! Ctrl-C or SIGTERM. The first signal is graceful; a second signal (or the
+//! graceful-shutdown deadline) requests an immediate I/O abort. Library code
+//! should **never** install its own signal handler; instead it accepts an
+//! `Arc<AtomicBool>` and polls it at safe boundaries.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::OnceLock;
+use tokio::sync::Notify;
+
+/// How long a graceful signal may wait for in-flight network I/O before the
+/// listener escalates to an abort. Kept deliberately short: NNTP commands may
+/// otherwise be waiting on the configured (normally 120 second) timeout.
+pub const GRACEFUL_SHUTDOWN_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+
+struct AbortState {
+    requested: AtomicBool,
+    notify: Notify,
+}
+
+static ABORT_STATE: OnceLock<Arc<AbortState>> = OnceLock::new();
+
+fn abort_state() -> Arc<AbortState> {
+    ABORT_STATE
+        .get_or_init(|| {
+            Arc::new(AbortState {
+                requested: AtomicBool::new(false),
+                notify: Notify::new(),
+            })
+        })
+        .clone()
+}
+
+fn request_abort(state: &AbortState) {
+    state.requested.store(true, Ordering::Release);
+    state.notify.notify_waiters();
+}
+
+/// Returns whether a signal listener has escalated graceful cancellation to
+/// an immediate abort for this process.
+pub fn abort_requested() -> bool {
+    abort_state().requested.load(Ordering::Acquire)
+}
+
+/// Wait until a second signal, or the graceful-shutdown deadline, requests an
+/// immediate abort. This is cancellation-safe and also handles an abort that
+/// happened before the caller started waiting.
+pub async fn aborted() {
+    let state = abort_state();
+    while !state.requested.load(Ordering::Acquire) {
+        state.notify.notified().await;
+    }
+}
 
 /// Spawn a background task that listens for Ctrl-C (and SIGTERM on Unix) and
-/// sets `flag` to `true` when either fires.
+/// sets `flag` to `true` when either fires. A second signal, or a timeout
+/// after the first, wakes [`aborted`] so callers can drop in-flight sockets.
 ///
 /// Call this **once** per binary invocation / per run, then pass `flag` to
 /// every long-running phase (posting, check, repost, etc.).
 pub fn spawn_listener(flag: Arc<AtomicBool>) {
     tokio::spawn(async move {
-        let ctrl_c = async {
+        #[cfg(unix)]
+        let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+            .expect("SIGINT handler");
+        #[cfg(not(unix))]
+        let sigint = async {
             tokio::signal::ctrl_c().await.ok();
         };
-        #[cfg(unix)]
-        let sigterm = async {
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .expect("SIGTERM handler")
-                .recv()
-                .await;
-        };
-        #[cfg(not(unix))]
-        let sigterm = std::future::pending::<()>();
 
+        #[cfg(unix)]
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("SIGTERM handler");
+
+        #[cfg(unix)]
         tokio::select! {
-            _ = ctrl_c => {},
-            _ = sigterm => {},
+            _ = sigint.recv() => {},
+            _ = sigterm.recv() => {},
         }
-        flag.store(true, Ordering::Relaxed);
+        #[cfg(not(unix))]
+        sigint.await;
+
+        flag.store(true, Ordering::Release);
+
+        let state = abort_state();
+        #[cfg(unix)]
+        tokio::select! {
+            _ = sigint.recv() => request_abort(&state),
+            _ = sigterm.recv() => request_abort(&state),
+            _ = tokio::time::sleep(GRACEFUL_SHUTDOWN_DEADLINE) => request_abort(&state),
+        }
+        #[cfg(not(unix))]
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => request_abort(&state),
+            _ = tokio::time::sleep(GRACEFUL_SHUTDOWN_DEADLINE) => request_abort(&state),
+        }
     });
 }

--- a/crates/pesto/src/poster/check.rs
+++ b/crates/pesto/src/poster/check.rs
@@ -234,8 +234,23 @@ impl Inner {
 pub struct CheckCoordinatorHandle {
     tx: Option<mpsc::UnboundedSender<PostedSegment>>,
     inner: Arc<Inner>,
-    feeder: tokio::task::JoinHandle<()>,
+    feeder: Option<tokio::task::JoinHandle<()>>,
     workers: Vec<tokio::task::JoinHandle<ConnectionSlot>>,
+}
+
+impl Drop for CheckCoordinatorHandle {
+    fn drop(&mut self) {
+        // A force-abort drops the coordinator from its owner task. Abort all
+        // children explicitly: dropping a JoinHandle alone detaches it, which
+        // would leave a silent STAT/repost waiting on its NNTP timeout.
+        self.tx.take();
+        if let Some(feeder) = &self.feeder {
+            feeder.abort();
+        }
+        for worker in &self.workers {
+            worker.abort();
+        }
+    }
 }
 
 impl CheckCoordinatorHandle {
@@ -277,9 +292,11 @@ impl CheckCoordinatorHandle {
     /// checked out for recovery and are returned to the caller as one set.
     pub async fn finish_and_drain(mut self) -> CheckDrain {
         drop(self.tx.take());
-        let _ = self.feeder.await;
+        if let Some(feeder) = self.feeder.take() {
+            let _ = feeder.await;
+        }
         let mut slots = Vec::with_capacity(self.workers.len());
-        for w in self.workers {
+        for w in std::mem::take(&mut self.workers) {
             if let Ok(slot) = w.await {
                 slots.push(slot);
             }
@@ -382,7 +399,7 @@ pub fn spawn_check_coordinator(
     CheckCoordinatorHandle {
         tx: Some(tx),
         inner,
-        feeder,
+        feeder: Some(feeder),
         workers,
     }
 }

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -1286,7 +1286,7 @@ pub async fn post_files_inner(
     // Streaming check: every segment that gets a clean `240` is queued here
     // and STAT-checked a few seconds later, concurrently with the rest of
     // the upload, instead of waiting for the whole run to finish.
-    let check_coordinator = if !check_slots.is_empty() {
+    let mut check_coordinator = if !check_slots.is_empty() {
         Some(spawn_check_coordinator(
             config.clone(),
             shared.post_group.clone(),
@@ -1350,29 +1350,55 @@ pub async fn post_files_inner(
         None
     };
 
+    // The second signal (or the first signal's deadline) is deliberately
+    // handled here rather than inside every NNTP read/write: aborting these
+    // tasks drops their `TcpStream`s immediately, while preserving the
+    // single final resume-state persistence path below.
+    let mut force_abort = crate::cancel::abort_requested();
+    if force_abort {
+        shared.cancelled.store(true, Ordering::Release);
+        shared.emit(ProgressEvent::Aborted);
+    }
+
     // Producer (or, when PAR2 was already generated above, the
     // already-generated-files poster) runs in this thread. Skipped entirely
     // if the generation phase above already failed — nothing valid to post.
-    if failure_reason.is_none() {
-        let result = if will_defer {
-            let result = match tx_opt.as_ref() {
-                Some(tx) => {
-                    post_pregenerated_release(&metas, &par2_dir, recovery_count, tx, &shared).await
+    if failure_reason.is_none() && !force_abort {
+        let producer_shared = shared.clone();
+        let producer_result: std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<()>> + Send>,
+        > = if will_defer {
+            Box::pin(async move {
+                match tx_opt.as_ref() {
+                    Some(tx) => {
+                        post_pregenerated_release(
+                            &metas,
+                            &par2_dir,
+                            recovery_count,
+                            tx,
+                            &producer_shared,
+                        )
+                        .await
+                    }
+                    None => Ok(()),
                 }
-                None => Ok(()),
-            };
-            // Unlike `producer`, which owns (and so drops) `tx_opt` itself,
-            // `post_pregenerated_release` only borrows `tx` — drop the real
-            // owner explicitly now that posting is done. Without this the
-            // channel never closes, `rx.recv()` in each worker never sees
-            // the end of the stream, and the join loop below hangs forever
-            // waiting for workers that are just idling.
-            drop(tx_opt);
-            result
+                // `tx_opt` is owned by this future, so it closes here
+                // even when a force-abort cancels the future.
+            })
         } else {
-            producer(metas, tx_opt, shared.clone(), total_conns).await
+            Box::pin(producer(metas, tx_opt, producer_shared, total_conns))
         };
-        if let Err(e) = result {
+        let result = tokio::select! {
+            result = producer_result => Some(result),
+            _ = crate::cancel::aborted() => {
+                force_abort = true;
+                None
+            }
+        };
+        if force_abort {
+            shared.cancelled.store(true, Ordering::Release);
+            shared.emit(ProgressEvent::Aborted);
+        } else if let Some(Err(e)) = result {
             let description = format!("producer error: {e:#}");
             // `Failed` alone only reaches `--output-format json` consumers; log
             // it too so the reason survives in the session log file even when
@@ -1387,12 +1413,49 @@ pub async fn post_files_inner(
         }
     }
 
-    for handle in encode_handles {
-        let _ = handle.await;
+    if !force_abort {
+        while let Some(mut handle) = encode_handles.pop() {
+            tokio::select! {
+                _ = &mut handle => {},
+                _ = crate::cancel::aborted() => {
+                    handle.abort();
+                    force_abort = true;
+                    shared.cancelled.store(true, Ordering::Release);
+                    shared.emit(ProgressEvent::Aborted);
+                    break;
+                }
+            }
+        }
     }
-    for handle in handles {
-        if let Ok(slot) = handle.await {
-            post_slots.push(slot);
+    if force_abort {
+        for handle in encode_handles {
+            handle.abort();
+        }
+        for handle in handles {
+            handle.abort();
+        }
+        shared.cancelled.store(true, Ordering::Release);
+    } else {
+        while let Some(mut handle) = handles.pop() {
+            tokio::select! {
+                result = &mut handle => {
+                    if let Ok(slot) = result {
+                        post_slots.push(slot);
+                    }
+                }
+                _ = crate::cancel::aborted() => {
+                    handle.abort();
+                    force_abort = true;
+                    break;
+                }
+            }
+        }
+        if force_abort {
+            for handle in handles {
+                handle.abort();
+            }
+            shared.cancelled.store(true, Ordering::Release);
+            shared.emit(ProgressEvent::Aborted);
         }
     }
 
@@ -1469,10 +1532,26 @@ pub async fn post_files_inner(
     // leaving this sender alive would hang `finish_and_drain` forever.
     let _ = shared.check_tx.lock().unwrap().take();
     crate::memory::set_phase(crate::memory::Phase::Check);
-    let drain = if let Some(mut coordinator) = check_coordinator {
+    let drain = if force_abort {
+        // Dropping the coordinator aborts all STAT/repost tasks (its Drop
+        // implementation must not merely detach them), so no NNTP timeout
+        // can delay resume persistence.
+        drop(check_coordinator.take());
+        check::CheckDrain::default()
+    } else if let Some(mut coordinator) = check_coordinator.take() {
         // Ownership transfer: no checkin in between post-join and scale_up.
         coordinator.scale_up(std::mem::take(&mut post_slots));
-        coordinator.finish_and_drain().await
+        let mut drain_handle = tokio::spawn(async move { coordinator.finish_and_drain().await });
+        tokio::select! {
+            result = &mut drain_handle => result.unwrap_or_default(),
+            _ = crate::cancel::aborted() => {
+                drain_handle.abort();
+                let _ = drain_handle.await;
+                shared.cancelled.store(true, Ordering::Release);
+                shared.emit(ProgressEvent::Aborted);
+                check::CheckDrain::default()
+            }
+        }
     } else {
         check::CheckDrain {
             slots: std::mem::take(&mut post_slots),

--- a/crates/pesto/src/progress.rs
+++ b/crates/pesto/src/progress.rs
@@ -110,6 +110,9 @@ pub enum ProgressEvent {
     PostRetryRecovered { count: u64, previously_failed: bool },
     /// Ctrl-C was received; the run is winding down.
     Interrupted,
+    /// A second Ctrl-C/SIGTERM, or the graceful-shutdown deadline, dropped
+    /// in-flight I/O. Resume state is still persisted before `Finished`.
+    Aborted,
     /// An external pause flag was set: every posting worker is suspended at
     /// the next segment-batch boundary, connections kept alive rather than
     /// torn down. See `poster::post_files_inner`'s `external_pause`.
@@ -395,6 +398,9 @@ async fn json_emit_loop(mut rx: ProgressReceiver) {
                     }
                     ProgressEvent::Interrupted => {
                         let _ = writeln!(out, r#"{{"type":"interrupted"}}"#);
+                    }
+                    ProgressEvent::Aborted => {
+                        let _ = writeln!(out, r#"{{"type":"aborted"}}"#);
                     }
                     ProgressEvent::Paused => {
                         let _ = writeln!(out, r#"{{"type":"paused"}}"#);

--- a/crates/pesto/src/ui/terminal.rs
+++ b/crates/pesto/src/ui/terminal.rs
@@ -172,6 +172,7 @@ struct RenderState {
     /// Number of typed retry-queue signals awaiting their detailed `Failed` event.
     post_retry_queued_events: u64,
     interrupted: bool,
+    aborted: bool,
     /// Set by `ProgressEvent::Failed` (e.g. a producer error such as the
     /// `--memory-limit` address-space check bailing). Printed alongside the
     /// "interrupted" note so a run that dies before posting anything doesn't
@@ -350,6 +351,7 @@ impl RenderState {
             recovered_check_retries: 0,
             post_retry_queued_events: 0,
             interrupted: false,
+            aborted: false,
             failed_description: None,
             status: String::new(),
             proxy_status: None,
@@ -561,6 +563,10 @@ impl RenderState {
                 }
             }
             ProgressEvent::Interrupted => self.interrupted = true,
+            ProgressEvent::Aborted => {
+                self.interrupted = true;
+                self.aborted = true;
+            }
             // No CLI flag drives external_pause yet (embedder-only, see
             // ROADMAP.new.md Phase 2) — reuse the existing status line so a
             // future embedder-triggered pause still renders sensibly here.
@@ -1902,8 +1908,12 @@ impl RenderState {
         // of file names) still can't make the panel grow without limit.
         if let Some(desc) = &self.failed_description {
             lines.extend(wrapped_note("⚠ ", desc, width));
+        } else if self.aborted {
+            lines.push("⚠ abort — dropping connections, saving resume state".to_string());
         } else if self.interrupted {
-            lines.push("⚠ interrupt received — finishing in-flight segments".to_string());
+            lines.push(
+                "⚠ interrupt — finishing in-flight articles · Ctrl+C again to abort".to_string(),
+            );
         } else if !self.status.is_empty() {
             let elapsed_str = if let Some(since) = self.status_since {
                 format!(" · {}", format_duration(since.elapsed().as_secs_f64()))
@@ -3155,6 +3165,19 @@ mod tests {
             summary.iter().any(|l| l.contains("too many input slices")),
             "the actual failure reason should be visible in the final summary: {summary:?}"
         );
+    }
+
+    #[test]
+    fn abort_note_replaces_the_graceful_interrupt_hint() {
+        let mut state = started_state(false);
+        state.apply(ProgressEvent::Interrupted);
+        let graceful = state.panel_lines(false, 120).join("\n");
+        assert!(graceful.contains("Ctrl+C again to abort"));
+
+        state.apply(ProgressEvent::Aborted);
+        let aborted = state.panel_lines(false, 120).join("\n");
+        assert!(aborted.contains("dropping connections, saving resume state"));
+        assert!(!aborted.contains("Ctrl+C again to abort"));
     }
 
     #[test]

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -280,94 +280,90 @@ pub async fn run_upload(
     ) == crate::poster::NzbWriteDecision::Refuse;
 
     // ── Write NZB ────────────────────────────────────────────────────────────
-    let nzb_path: Option<PathBuf> = if (cancelled && !config.resume)
-        || outcome.segments.is_empty()
-        || config.dry_run
-        || config.par2_only
-        || write_blocked
-    {
-        None
-    } else if let Some(base) = nzb_base {
-        let out = versioned_nzb_path(&base).await;
-        let nzb_meta = crate::nzb::NzbMeta {
-            name: config.nzb_title.clone().or_else(|| {
-                entry_paths
-                    .first()
-                    .and_then(|p| p.file_name())
-                    .map(|n| n.to_string_lossy().into_owned())
-            }),
-            password: config
-                .nzb_password
-                .clone()
-                .or_else(|| effective_password.clone()),
-            category: config.nzb_category.clone(),
-            tmdb_id: config.tmdb_id.clone(),
-            imdb_id: config.imdb_id.clone(),
-            tvdb_id: config.tvdb_id.clone(),
-            mal_id: config.mal_id.clone(),
-            tags: config.nzb_tags.clone(),
-        };
-        crate::memory::set_phase(crate::memory::Phase::Nzb);
-        let xml = crate::nzb::generate(
-            &outcome.groups,
-            &outcome.segments,
-            &nzb_meta,
-            config.obfuscate,
-        );
-        match tokio::fs::write(&out, &xml).await {
-            Ok(()) => {
-                emit_status(&progress_tx, format!("wrote nzb: {}", out.display()));
+    let nzb_path: Option<PathBuf> =
+        if outcome.segments.is_empty() || config.dry_run || config.par2_only || write_blocked {
+            None
+        } else if let Some(base) = nzb_base {
+            let out = versioned_nzb_path(&base).await;
+            let nzb_meta = crate::nzb::NzbMeta {
+                name: config.nzb_title.clone().or_else(|| {
+                    entry_paths
+                        .first()
+                        .and_then(|p| p.file_name())
+                        .map(|n| n.to_string_lossy().into_owned())
+                }),
+                password: config
+                    .nzb_password
+                    .clone()
+                    .or_else(|| effective_password.clone()),
+                category: config.nzb_category.clone(),
+                tmdb_id: config.tmdb_id.clone(),
+                imdb_id: config.imdb_id.clone(),
+                tvdb_id: config.tvdb_id.clone(),
+                mal_id: config.mal_id.clone(),
+                tags: config.nzb_tags.clone(),
+            };
+            crate::memory::set_phase(crate::memory::Phase::Nzb);
+            let xml = crate::nzb::generate(
+                &outcome.groups,
+                &outcome.segments,
+                &nzb_meta,
+                config.obfuscate,
+            );
+            match tokio::fs::write(&out, &xml).await {
+                Ok(()) => {
+                    emit_status(&progress_tx, format!("wrote nzb: {}", out.display()));
 
-                if write_history && !config.dry_run {
-                    let par2_str;
-                    let par2_pct = if config.par2 > 0 {
-                        par2_str = format!("{}%", config.par2);
-                        Some(par2_str.as_str())
-                    } else {
-                        None
-                    };
-                    // The server(s) that actually accepted an article
-                    // (`outcome.servers`), not just the statically
-                    // configured primary — see the analogous comment on
-                    // `group` below.
-                    let history_servers_str = outcome.servers.join(", ");
-                    let wire_subjects_vec = crate::nzb::wire_subjects(&outcome.segments);
-                    crate::history::record_upload(
-                        &crate::history::UploadRecord {
-                            name: entry_label,
-                            obfuscated_name: if config.obfuscate != ObfuscateMode::None {
-                                Some(entry_label)
-                            } else {
-                                None
+                    if write_history && !config.dry_run {
+                        let par2_str;
+                        let par2_pct = if config.par2 > 0 {
+                            par2_str = format!("{}%", config.par2);
+                            Some(par2_str.as_str())
+                        } else {
+                            None
+                        };
+                        // The server(s) that actually accepted an article
+                        // (`outcome.servers`), not just the statically
+                        // configured primary — see the analogous comment on
+                        // `group` below.
+                        let history_servers_str = outcome.servers.join(", ");
+                        let wire_subjects_vec = crate::nzb::wire_subjects(&outcome.segments);
+                        crate::history::record_upload(
+                            &crate::history::UploadRecord {
+                                name: entry_label,
+                                obfuscated_name: if config.obfuscate != ObfuscateMode::None {
+                                    Some(entry_label)
+                                } else {
+                                    None
+                                },
+                                password: effective_password.as_deref(),
+                                total_bytes,
+                                // The group actually posted to (`pick_post_group`
+                                // chose one at random from `config.groups`), not
+                                // the configured list's static first entry.
+                                group: outcome.groups.first().map(String::as_str),
+                                server: (!history_servers_str.is_empty())
+                                    .then_some(history_servers_str.as_str()),
+                                par2_redundancy: par2_pct,
+                                duration_secs: upload_start.elapsed().as_secs_f64(),
+                                nzb_path: Some(&out.display().to_string()),
+                                subject: config.nzb_title.as_deref().or(Some(entry_label)),
+                                wire_subjects: &wire_subjects_vec,
                             },
-                            password: effective_password.as_deref(),
-                            total_bytes,
-                            // The group actually posted to (`pick_post_group`
-                            // chose one at random from `config.groups`), not
-                            // the configured list's static first entry.
-                            group: outcome.groups.first().map(String::as_str),
-                            server: (!history_servers_str.is_empty())
-                                .then_some(history_servers_str.as_str()),
-                            par2_redundancy: par2_pct,
-                            duration_secs: upload_start.elapsed().as_secs_f64(),
-                            nzb_path: Some(&out.display().to_string()),
-                            subject: config.nzb_title.as_deref().or(Some(entry_label)),
-                            wire_subjects: &wire_subjects_vec,
-                        },
-                        config.history_dir.as_deref(),
-                    );
-                }
+                            config.history_dir.as_deref(),
+                        );
+                    }
 
-                Some(out)
+                    Some(out)
+                }
+                Err(e) => {
+                    emit_status(&progress_tx, format!("failed to write nzb: {e}"));
+                    None
+                }
             }
-            Err(e) => {
-                emit_status(&progress_tx, format!("failed to write nzb: {e}"));
-                None
-            }
-        }
-    } else {
-        None
-    };
+        } else {
+            None
+        };
     // ─────────────────────────────────────────────────────────────────────────
 
     // ── Notifications ────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #179.\n\n## Summary\n- Keep Ctrl-C/SIGTERM listener alive after the first signal; a second signal or 10-second deadline aborts active I/O.\n- Persist confirmed progress and write a partial NZB on cancellation.\n- Add aborted JSON/TTY progress, documentation, and release bump to pesto-poster 0.10.1.\n\n## Validation\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace\n- cargo doc --no-deps -p pesto-poster\n\nNo version tag or package publication is included.