### PR TITLE
Improve PAR2 scratch directory observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/README.md
+++ b/README.md
@@ -531,6 +531,21 @@ pesto --par2-only ./MyShow.S01/
 pesto --par2-before-upload movie.mkv
 ```
 
+### PAR2 scratch directory
+
+During a normal posting run, `--par2-temp-dir <DIR>` (or
+`posting.par2_temp_dir` in the configuration file) selects the base directory
+for intermediate PAR2 files. Pesto creates a unique
+`parmesan_<pid>_<run_id>` directory underneath it, writes the PAR2 index and
+recovery volumes there, reads those files back for posting/checks/retries, and
+then removes the per-run directory. The configured base directory is retained.
+
+PAR2 recovery is computed in RAM before these files are materialised, so the
+directory does not exist during most of the PAR2 computation and may be
+short-lived on a fast system. Run with `-v` to see the effective path, written
+file count and byte count, and cleanup result. `--par2-only` does not use this
+scratch directory; it writes PAR2 files next to the sources.
+
 ### SIMD acceleration
 
 pesto selects the fastest available Reed-Solomon path at startup via runtime

--- a/config.example.toml
+++ b/config.example.toml
@@ -119,11 +119,15 @@ groups = ["alt.binaries.test"]
 # Default: 10.
 # par2 = 10
 
-# par2_temp_dir — directory where intermediate PAR2 files are written during
-# posting, before they're read back and posted. Default: the OS temp
-# directory (e.g. /tmp), which may sit on a different filesystem — with less
-# free space or a stricter disk quota — than the destination disk. Ignored
-# with --par2-only, which writes PAR2 files next to the sources instead.
+# par2_temp_dir — base directory where a per-run `parmesan_<pid>_<run_id>`
+# directory is created for intermediate PAR2 files. PAR2 recovery is computed
+# in RAM first; this directory appears only when the index and recovery
+# volumes are materialised for posting, and the per-run directory is removed
+# after posting, checks and retries finish. The configured base itself is
+# preserved. Default: the OS temp directory (e.g. /tmp), which may sit on a
+# different filesystem — with less free space or a stricter disk quota — than
+# the destination disk. Ignored with --par2-only, which writes PAR2 files next
+# to the sources instead. Use -v to see the effective path and lifecycle.
 # par2_temp_dir = "/path/on/destination/disk/tmp"
 
 # par2_before_upload — generate all PAR2 recovery data before posting

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,17 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+## [0.10.3] — 2026-09-05
+
+### Changed
+
+- Verbose output now reports the effective PAR2 scratch directory when it is
+  created, summarizes the files materialised there, and confirms its removal.
+  Scratch creation/write errors include the affected path, while cleanup
+  failures are warned instead of being silently discarded. Documentation now
+  clarifies that recovery is computed in RAM before the short-lived directory
+  appears. Fixes #183.
+
 ## [0.10.2] — 2026-09-02
 
 ### Fixed

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pesto-poster"
 # pesto is versioned, published, and released independently of the rest of
 # the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
-version = "0.10.2"
+version = "0.10.3"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."

--- a/crates/pesto/README.md
+++ b/crates/pesto/README.md
@@ -479,6 +479,21 @@ large release's PAR2 index/volumes can end up posted a while after its data
 files. See `--par2-before-upload` below if that gap matters for how your
 target indexer groups a release's files together.
 
+### PAR2 scratch directory
+
+During a normal posting run, `--par2-temp-dir <DIR>` (or
+`posting.par2_temp_dir` in the configuration file) selects the base directory
+for intermediate PAR2 files. Pesto creates a unique
+`parmesan_<pid>_<run_id>` directory underneath it, writes the PAR2 index and
+recovery volumes there, reads those files back for posting/checks/retries, and
+then removes the per-run directory. The configured base directory is retained.
+
+PAR2 recovery is computed in RAM before these files are materialised, so the
+directory does not exist during most of the PAR2 computation and may be
+short-lived on a fast system. Run with `-v` to see the effective path, written
+file count and byte count, and cleanup result. `--par2-only` does not use this
+scratch directory; it writes PAR2 files next to the sources.
+
 ### Generating PAR2 before posting
 
 By default pesto computes PAR2 recovery data concurrently with the upload —

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -231,12 +231,12 @@ struct Cli {
     #[arg(long)]
     memory_report: bool,
 
-    /// Directory where intermediate PAR2 files are written during posting,
-    /// before they're read back and posted. Defaults to the OS temp
-    /// directory (e.g. /tmp), which may sit on a different filesystem —
-    /// with less free space or a stricter disk quota — than the destination
-    /// disk. Ignored with --par2-only, which writes PAR2 files next to the
-    /// sources instead [config: posting.par2_temp_dir].
+    /// Base for a per-run directory holding intermediate PAR2 files. Recovery
+    /// is computed in RAM first; the directory is created when the PAR2 files
+    /// are materialised and removed after posting/checks/retries. Use -v to
+    /// see its effective path. Defaults to the OS temp directory (e.g. /tmp).
+    /// Ignored with --par2-only, which writes PAR2 files next to the sources
+    /// instead [config: posting.par2_temp_dir].
     #[arg(long, value_name = "DIR")]
     par2_temp_dir: Option<String>,
 
@@ -2012,7 +2012,7 @@ async fn run_single_upload(
     // is it safe to remove the PAR2 temp dir. See `par2_temp_dir`'s doc
     // comment for why this used to happen too early.
     if !config.par2_only {
-        let _ = tokio::fs::remove_dir_all(&outcome.par2_temp_dir).await;
+        outcome.cleanup_par2_temp_dir().await;
     }
 
     // 26g — per-phase timing summary (only when -v is active)

--- a/crates/pesto/src/config/types.rs
+++ b/crates/pesto/src/config/types.rs
@@ -390,13 +390,14 @@ pub struct PostingSection {
     /// `pesto::memory::budget` — bounded together with (not looser than)
     /// `par2_memory_limit` and the RLIMIT_AS-specific pass-sizing model.
     pub memory_limit: Option<String>,
-    /// Base directory for the intermediate PAR2 files written during a
-    /// normal posting run, before they're read back and posted. Default:
-    /// the OS temp directory (`std::env::temp_dir()`, usually `/tmp` or
-    /// `$TMPDIR`), which may sit on a different filesystem — with less free
-    /// space or a stricter quota — than the destination disk. Ignored when
-    /// `--par2-only` is set, since PAR2 files are then written next to the
-    /// sources instead of a scratch directory.
+    /// Base directory for the per-run directory holding intermediate PAR2
+    /// files. Recovery data is computed in RAM first; the directory appears
+    /// only while the index and volumes are materialised, posted, checked and
+    /// retried, then the per-run directory is removed. Default: the OS temp
+    /// directory (`std::env::temp_dir()`, usually `/tmp` or `$TMPDIR`), which
+    /// may sit on a different filesystem — with less free space or a stricter
+    /// quota — than the destination disk. Ignored when `--par2-only` is set,
+    /// since PAR2 files are then written next to the sources.
     pub par2_temp_dir: Option<String>,
     /// Generate all PAR2 recovery data before posting anything, instead of
     /// computing it concurrently with the data upload (the default). Every

--- a/crates/pesto/src/poster/mod.rs
+++ b/crates/pesto/src/poster/mod.rs
@@ -313,6 +313,16 @@ pub struct PostOutcome {
     pub par2_temp_dir: PathBuf,
 }
 
+impl PostOutcome {
+    /// Remove this run's PAR2 scratch directory after every consumer has
+    /// finished reading it. A missing directory is an expected no-op when
+    /// PAR2 generation was disabled or did not reach materialisation.
+    /// Cleanup failures are logged but do not invalidate the upload outcome.
+    pub async fn cleanup_par2_temp_dir(&self) {
+        cleanup_par2_temp_dir(&self.par2_temp_dir).await;
+    }
+}
+
 /// Whether the NZB (and NFO / post-hooks) should be written for this run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NzbWriteDecision {
@@ -1855,6 +1865,30 @@ pub fn par2_temp_dir(base: Option<&Path>, run_id: u64) -> PathBuf {
     base.join(format!("parmesan_{}_{run_id}", std::process::id()))
 }
 
+/// Remove a per-run PAR2 scratch directory once every consumer has finished
+/// reading it. A missing directory is an expected no-op when PAR2 generation
+/// was disabled or did not reach the materialisation phase. Other cleanup
+/// failures do not invalidate an otherwise successful upload, but are logged
+/// so operators can find and remove leaked scratch data.
+async fn cleanup_par2_temp_dir(path: &Path) {
+    let started = Instant::now();
+    match tokio::fs::remove_dir_all(path).await {
+        Ok(()) => info!(
+            path = %path.display(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "PAR2 scratch directory removed"
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            debug!(path = %path.display(), "PAR2 scratch directory was not created")
+        }
+        Err(error) => warn!(
+            path = %path.display(),
+            error = %error,
+            "failed to remove PAR2 scratch directory"
+        ),
+    }
+}
+
 /// Restrict the global Rayon pool to physical cores. The PAR2 encoder is pure
 /// SIMD/ALU work; sibling hyperthreads contend for the same execution ports
 /// and add almost nothing, so one worker per logical CPU only heats the
@@ -2469,6 +2503,9 @@ async fn producer(
     let mut par2_dir = None;
     let mut base_packets = Vec::new();
     let mut rsid = [0u8; 16];
+    let mut par2_materialize_started = None;
+    let mut par2_materialized_files = 0usize;
+    let mut par2_materialized_bytes = 0u64;
 
     for (pass_idx, (exp_start, rec_count)) in passes.iter().copied().enumerate() {
         if rec_count > 0 {
@@ -2785,17 +2822,35 @@ async fn producer(
 
                 if shared.config.par2_only {
                     par2_dir = Some(par2_output_dir(&metas[0]));
+                    info!(
+                        path = %par2_dir.as_ref().unwrap().display(),
+                        configured_scratch_base = shared.config.par2_temp_dir.is_some(),
+                        "PAR2-only output directory selected; PAR2 scratch configuration is not used"
+                    );
                 } else {
                     par2_dir = Some(par2_temp_dir(
                         shared.config.par2_temp_dir.as_deref(),
                         shared.run_id,
                     ));
-                    tokio::fs::create_dir_all(par2_dir.as_ref().unwrap()).await?;
+                    let dir = par2_dir.as_ref().unwrap();
+                    tokio::fs::create_dir_all(dir).await.with_context(|| {
+                        format!("creating PAR2 scratch directory `{}`", dir.display())
+                    })?;
+                    par2_materialize_started = Some(Instant::now());
+                    info!(
+                        path = %dir.display(),
+                        configured_base = shared.config.par2_temp_dir.is_some(),
+                        "PAR2 scratch directory created"
+                    );
                 }
 
                 let index_name = layout::index_name(par2_release_base(&metas[0].real_name));
                 let index_path = par2_dir.as_ref().unwrap().join(&index_name);
-                tokio::fs::write(&index_path, &base_packets).await?;
+                tokio::fs::write(&index_path, &base_packets)
+                    .await
+                    .with_context(|| format!("writing PAR2 index `{}`", index_path.display()))?;
+                par2_materialized_files += 1;
+                par2_materialized_bytes += base_packets.len() as u64;
                 if let Some(tx) = &tx_opt {
                     if shared.config.obfuscate.policy().publish_par2_index {
                         // In discovery modes the standalone index remains the
@@ -2832,10 +2887,17 @@ async fn producer(
                     .create(true)
                     .append(true)
                     .open(&vol_path)
-                    .await?;
+                    .await
+                    .with_context(|| {
+                        format!("opening PAR2 recovery volume `{}`", vol_path.display())
+                    })?;
 
                 if slice.exponent == vol.first {
-                    file.write_all(&base_packets).await?;
+                    file.write_all(&base_packets).await.with_context(|| {
+                        format!("writing PAR2 recovery volume `{}`", vol_path.display())
+                    })?;
+                    par2_materialized_files += 1;
+                    par2_materialized_bytes += base_packets.len() as u64;
                 }
 
                 let pkt = packet::serialize_packet(
@@ -2843,7 +2905,10 @@ async fn producer(
                     &packet::TYPE_RECOVERY,
                     &packet::recovery_body(slice.exponent, &slice.data),
                 );
-                file.write_all(&pkt).await?;
+                file.write_all(&pkt).await.with_context(|| {
+                    format!("writing PAR2 recovery volume `{}`", vol_path.display())
+                })?;
+                par2_materialized_bytes += pkt.len() as u64;
                 shared.emit(crate::progress::ProgressEvent::Par2SliceWritten);
 
                 if slice.exponent == vol.first + vol.count - 1 {
@@ -2864,6 +2929,18 @@ async fn producer(
                 elapsed_ms = t_par2_write.elapsed().as_millis(),
                 phase = "par2_write",
                 "phase done"
+            );
+        }
+    }
+
+    if let (Some(dir), Some(started)) = (&par2_dir, par2_materialize_started) {
+        if !shared.config.par2_only {
+            info!(
+                path = %dir.display(),
+                files = par2_materialized_files,
+                bytes = par2_materialized_bytes,
+                elapsed_ms = started.elapsed().as_millis(),
+                "PAR2 scratch files ready"
             );
         }
     }

--- a/crates/pesto/src/upload.rs
+++ b/crates/pesto/src/upload.rs
@@ -498,7 +498,7 @@ pub async fn run_upload(
     // See `poster::par2_temp_dir`'s doc comment for why this used to happen
     // too early.
     if !config.par2_only {
-        let _ = tokio::fs::remove_dir_all(&outcome.par2_temp_dir).await;
+        outcome.cleanup_par2_temp_dir().await;
     }
 
     Ok(UploadOutcome {

--- a/crates/pesto/tests/par2_temp_dir_survives_post.rs
+++ b/crates/pesto/tests/par2_temp_dir_survives_post.rs
@@ -103,9 +103,10 @@ async fn par2_temp_dir_is_not_deleted_by_post_files() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let input = dir.join("movie.bin");
+    let configured_par2_base = dir.join("configured-par2-base");
     std::fs::write(&input, content(0)).unwrap();
 
-    let config = Config {
+    let mut config = Config {
         host: "127.0.0.1".to_string(),
         port: addr.port(),
         ssl: false,
@@ -129,7 +130,7 @@ async fn par2_temp_dir_is_not_deleted_by_post_files() {
         par2_recovery_count: None,
         par2_memory_limit: Some(1_000_000_000),
         memory_limit: None,
-        par2_temp_dir: None,
+        par2_temp_dir: Some(configured_par2_base.clone()),
         compress_temp_dir: None,
         par2_only: false,
         par2_before_upload: false,
@@ -210,6 +211,11 @@ async fn par2_temp_dir_is_not_deleted_by_post_files() {
     // running --check afterward can still re-read them to repost a segment
     // STAT couldn't find.
     let par2_dir = &outcome.par2_temp_dir;
+    assert_eq!(
+        par2_dir.parent(),
+        Some(configured_par2_base.as_path()),
+        "PAR2 files must be materialised under the configured base"
+    );
     assert!(
         par2_dir.exists(),
         "outcome.par2_temp_dir ({}) must still exist right after post_files() \
@@ -217,6 +223,35 @@ async fn par2_temp_dir_is_not_deleted_by_post_files() {
         par2_dir.display()
     );
 
-    let _ = std::fs::remove_dir_all(par2_dir);
+    outcome.cleanup_par2_temp_dir().await;
+    assert!(
+        !par2_dir.exists(),
+        "per-run PAR2 scratch directory should be removed"
+    );
+    assert!(
+        configured_par2_base.exists(),
+        "cleanup must preserve the configured base directory"
+    );
+
+    // A configured base that cannot contain a directory must fail clearly at
+    // that exact path. It must never fall back to the OS temp directory,
+    // because that could unexpectedly exhaust a different filesystem.
+    let invalid_base = dir.join("not-a-directory");
+    std::fs::write(&invalid_base, b"file blocks create_dir_all").unwrap();
+    config.par2_temp_dir = Some(invalid_base.clone());
+    let failed = post_files(&config, &inputs).await.unwrap();
+    let reason = failed
+        .failure_reason
+        .as_deref()
+        .expect("invalid configured PAR2 base should surface a producer error");
+    assert!(
+        reason.contains("creating PAR2 scratch directory"),
+        "error should identify the failed lifecycle operation: {reason}"
+    );
+    assert!(
+        reason.contains(&invalid_base.display().to_string()),
+        "error should include the configured path: {reason}"
+    );
+
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary

- report the effective PAR2 scratch path, materialized file/byte totals, and cleanup in verbose logs
- add path-aware creation/write errors and warn when scratch cleanup fails
- document the in-memory compute and short-lived materialization lifecycle
- verify configured-base usage, base preservation, cleanup, and no silent fallback
- bump pesto-poster to 0.10.3

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- git diff --check

Closes #183