### PR TITLE
Add Docker image and Compose for pesto --watch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Allowlist. This working tree holds tens of GB of local media and bench
+# corpora; gitignore-style `*.mkv` does **not** recurse in Docker (only
+# the repo root), so a denylist leaked ~1.3GB into the first build.
+# Cargo only needs the workspace; GHCR `--target runtime-prebuilt` also
+# needs the linux-gnu binary named `pesto` at the context root.
+
+*
+!Cargo.toml
+!Cargo.lock
+!crates
+!crates/**
+!pesto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,15 @@ jobs:
         run: cargo clippy -p pesto-poster -p parmesan-par2 --all-targets -- -D warnings
       - name: Test (pesto + parmesan)
         run: cargo test -p pesto-poster -p parmesan-par2 --lib
+
+  # Packaging only: Compose validity + the Debian runtime stage. The full
+  # from-source image is `docker build` locally; GHCR is published from the
+  # linux-gnu release artifact (see release-pesto.yml).
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Compose file
+        run: docker compose -f docker/compose.yaml config --quiet
+      - name: Build runtime base
+        run: docker build --target runtime-base -t pesto:runtime-base .

--- a/.github/workflows/release-pesto.yml
+++ b/.github/workflows/release-pesto.yml
@@ -23,8 +23,11 @@ jobs:
     strategy:
       matrix:
         include:
+          # Ubuntu 22.04 (glibc 2.35) so the gnu artifact runs on Debian 12
+          # (bookworm, glibc 2.36) — the Docker runtime — and on newer hosts.
+          # ubuntu-latest is 24.04 (glibc 2.39), which bookworm cannot load.
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: pesto
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
@@ -143,3 +146,59 @@ jobs:
             pesto-windows-x86_64.exe
             SHA256SUMS
           body_path: /tmp/release-body.md
+
+  # GHCR image uses the linux-gnu artifact from `build`, not a second LTO
+  # compile, so `ghcr.io/franzopl/pesto:<semver>` is the same binary as
+  # `pesto-linux-x86_64` on the GitHub Release (issue #185).
+  docker:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download linux-gnu binary
+        uses: actions/download-artifact@v4
+        with:
+          name: x86_64-unknown-linux-gnu
+          path: .
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/franzopl/pesto
+          tags: |
+            type=match,pattern=pesto-v(\d+\.\d+\.\d+),group=1
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime-prebuilt
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PESTO_BIN=pesto
+
+      - name: Confirm image
+        run: |
+          VERSION="${GITHUB_REF_NAME#pesto-v}"
+          docker pull "ghcr.io/franzopl/pesto:${VERSION}"
+          docker run --rm "ghcr.io/franzopl/pesto:${VERSION}" --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+#
+# pesto CLI image for `pesto --watch` (issue #185).
+#
+# Default target `runtime` builds from source:
+#   docker build -t pesto .
+#   docker run --rm pesto --version
+#
+# Target `runtime-prebuilt` copies a glibc binary from the build context
+# (used by `.github/workflows/release-pesto.yml` so GHCR matches the
+# GitHub Release linux-gnu artifact bit-for-bit). That artifact is built
+# on Ubuntu 22.04 (glibc 2.35) so it loads on this bookworm runtime
+# (glibc 2.36). A binary from Ubuntu 24.04 / glibc 2.39 will not.
+#   docker build --target runtime-prebuilt -t pesto .
+#
+# v1 is linux/amd64 only. Credentials are never baked in.
+
+ARG RUST_VERSION=1.96
+ARG DEBIAN_VERSION=bookworm
+
+FROM debian:${DEBIAN_VERSION}-slim AS runtime-base
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        p7zip-full \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# uid 1000 matches a typical host user so bind-mounted incoming/nzb/archive
+# directories are writable without a root container. Override at run time
+# with `user:` in Compose if the host uid differs.
+RUN groupadd --gid 1000 pesto \
+    && useradd --uid 1000 --gid 1000 --create-home --home-dir /home/pesto \
+        --shell /usr/sbin/nologin pesto \
+    && mkdir -p /config/pesto /data/incoming /data/nzb /data/archive \
+    && chown -R pesto:pesto /config /data /home/pesto
+
+ENV XDG_CONFIG_HOME=/config \
+    TMPDIR=/tmp \
+    PATH="/usr/local/bin:${PATH}"
+
+LABEL org.opencontainers.image.source="https://github.com/franzopl/pesto" \
+      org.opencontainers.image.url="https://github.com/franzopl/pesto" \
+      org.opencontainers.image.title="pesto" \
+      org.opencontainers.image.description="Fast Usenet poster — watch-daemon image" \
+      org.opencontainers.image.licenses="MIT"
+
+# ── Pre-built glibc binary (release workflow) ───────────────────────────────
+
+FROM runtime-base AS runtime-prebuilt
+
+# File name in the build context; the release job downloads the linux-gnu
+# artifact as `pesto`.
+ARG PESTO_BIN=pesto
+COPY ${PESTO_BIN} /usr/local/bin/pesto
+RUN chmod 755 /usr/local/bin/pesto
+
+USER pesto
+ENTRYPOINT ["tini", "--", "pesto"]
+CMD ["--help"]
+
+# ── Build from source (default `docker build`) ──────────────────────────────
+
+FROM rust:${RUST_VERSION}-bookworm AS builder
+
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p pesto-poster --bin pesto \
+    && cp target/release/pesto /pesto
+
+FROM runtime-base AS runtime
+
+COPY --from=builder /pesto /usr/local/bin/pesto
+RUN chmod 755 /usr/local/bin/pesto
+
+USER pesto
+ENTRYPOINT ["tini", "--", "pesto"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ with a deliberately minimal scope: just the essentials, executed extremely fast.
 ## Contents
 
 - [Installing](#installing)
+  - [Docker (watch daemon)](#docker-watch-daemon)
 - [Build from source](#build-from-source)
 - [Quick start](#quick-start)
 - [Configuration](#configuration)
@@ -95,6 +96,59 @@ cargo install pesto-poster
 ```
 
 The installed binary is named `pesto`.
+
+### Docker (watch daemon)
+
+Run `pesto --watch` as a container instead of a host service. The image is
+**pesto CLI only** (not upapasta, penne, or sugo).
+
+```bash
+docker pull ghcr.io/franzopl/pesto:latest
+docker run --rm ghcr.io/franzopl/pesto:latest --version
+```
+
+Each `pesto-v*` GitHub Release also publishes `ghcr.io/franzopl/pesto:<semver>`
+and `:latest` (`linux/amd64`). The image binary is the same glibc artifact as
+`pesto-linux-x86_64`. The first package may be private until a maintainer
+marks it public (`docker login ghcr.io` until then).
+
+Build from source:
+
+```bash
+docker build -t pesto .
+docker run --rm pesto --version
+```
+
+Compose example (config / incoming / nzb / archive bind mounts, non-root,
+`stop_grace_period: 30m`):
+
+```bash
+mkdir -p docker/config/pesto docker/incoming docker/nzb docker/archive
+cp docker/config.toml.example docker/config/pesto/config.toml
+# edit credentials — they are never baked into the image
+
+docker compose -f docker/compose.yaml up -d
+```
+
+The compose file uses `--nzb-dir /data/nzb`, not `--out` (`--out` is a file
+path). `--compress=rar` is not in the image; 7z/zip are (`p7zip-full`).
+
+**Signals.** SIGTERM tells `--watch` to stop polling. After 10 seconds pesto
+aborts in-flight NNTP I/O and persists resume state — it does not keep
+uploading a large release to completion. `stop_grace_period: 30m` only
+prevents Docker's default 10s SIGKILL from racing that shutdown.
+
+**Existing files.** `--watch` ignores entries already in the directory at
+startup. After a restart, drain leftovers with:
+
+```bash
+docker compose -f docker/compose.yaml --profile drain run --rm pesto-drain
+```
+
+or `pesto --each /data/incoming --cleanup-to /data/archive` (plus `--nzb-dir`).
+
+Full volume layout, uid notes, and hook caveats:
+[`docker/README.md`](docker/README.md).
 
 ### Build from source
 
@@ -637,6 +691,7 @@ pesto --watch ./incoming/ --jobs 3 --watch-interval 60
 
 Entries already present in the watched directory when `pesto` starts are ignored;
 only new arrivals are posted. By default, completed entries are left in place.
+To run `--watch` as a container, see [Docker (watch daemon)](#docker-watch-daemon).
 
 ### `--cleanup` and `--cleanup-to` — source cleanup after upload
 

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,19 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+### Added
+
+- Docker image and Compose example for `pesto --watch` as a long-lived
+  daemon (`Dockerfile`, `docker/compose.yaml`). Each `pesto-v*` tag also
+  publishes `ghcr.io/franzopl/pesto:<semver>` from the linux-gnu release
+  artifact. See #185.
+
+### Changed
+
+- The `pesto-linux-x86_64` GitHub Release artifact is built on Ubuntu 22.04
+  (glibc 2.35) so it runs on Debian 12 and inside the Docker image. Musl
+  and Windows artifacts are unchanged.
+
 ## [0.10.3] — 2026-09-05
 
 ### Changed

--- a/crates/pesto/RELEASING.md
+++ b/crates/pesto/RELEASING.md
@@ -105,13 +105,20 @@ git push origin pesto-v<version>
 ```
 
 Pushing a `pesto-v*` tag triggers `.github/workflows/release-pesto.yml`,
-which builds the `pesto` binary for `x86_64-unknown-linux-gnu`,
+which builds the `pesto` binary for `x86_64-unknown-linux-gnu` (Ubuntu
+22.04 / glibc 2.35, so it loads on Debian 12 and in the Docker image),
 `x86_64-unknown-linux-musl`, and `x86_64-pc-windows-msvc`, then creates a
-GitHub Release at that tag with all three attached. It does **not** use
+GitHub Release at that tag with all three attached. The same workflow
+publishes `ghcr.io/franzopl/pesto:<semver>` and `:latest` from the
+linux-gnu artifact (not a second compile), so the image binary matches
+`pesto-linux-x86_64`. v1 is `linux/amd64` only. It does **not** use
 GitHub's auto-generated release notes — those pick the "previous tag" by
 creation time across the *whole repo*, which would pull in unrelated
 `parmesan-v*`/`penne-v*` tags interleaved with `pesto-v*` ones. The release
 body just links to `CHANGELOG.md`, crates.io, and docs.rs instead.
+
+The first GHCR package may be private; set it **public** in the GitHub
+package settings (or consumers must `docker login ghcr.io`).
 
 Watch it with:
 
@@ -128,6 +135,12 @@ gh release view pesto-v<version> --json url,assets -q '{url, assets: [.assets[].
 
 Should list all three binaries and a working URL.
 
+```bash
+docker pull ghcr.io/franzopl/pesto:<version>
+docker run --rm ghcr.io/franzopl/pesto:<version> --version
+# expect: pesto <version>
+```
+
 ## Checklist summary
 
 - [ ] Decide version bump (semver 0.x rules)
@@ -140,3 +153,4 @@ Should list all three binaries and a working URL.
 - [ ] Confirm docs.rs built (`status.json`)
 - [ ] `git tag pesto-v<version>` + push
 - [ ] Confirm the GitHub Actions run succeeded and the release has all three binaries
+- [ ] Confirm `ghcr.io/franzopl/pesto:<version>` and `:latest` were published (`docker run --rm ... --version`)

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,5 @@
+# Host bind mounts created next to compose.yaml.
+config/
+incoming/
+nzb/
+archive/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,119 @@
+# Docker — `pesto --watch` daemon
+
+Container image for the pesto CLI running as a long-lived `--watch` daemon.
+Scope is the **pesto CLI only** (not upapasta, penne, or sugo). See issue
+[#185](https://github.com/franzopl/pesto/issues/185).
+
+## Pull vs build
+
+```bash
+# Pre-built (published on each pesto-v* tag)
+docker pull ghcr.io/franzopl/pesto:latest
+# or a specific version, e.g. ghcr.io/franzopl/pesto:0.10.3
+
+docker run --rm ghcr.io/franzopl/pesto:latest --version
+```
+
+The first GHCR package for this repo may be private until a maintainer sets
+the package visibility to **public**. Until then:
+
+```bash
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u USER --password-stdin
+```
+
+The runtime is **Debian 12 (bookworm, glibc 2.36)**. GHCR and
+`pesto-linux-x86_64` are the same glibc binary, built on Ubuntu 22.04
+(glibc 2.35) so they load here. A host binary from Ubuntu 24.04
+(glibc 2.39) will not (`GLIBC_2.39 not found`).
+
+Build from source (linux/amd64, default Dockerfile target):
+
+```bash
+docker build -t pesto .
+docker run --rm pesto --version
+```
+
+`--compress=rar` is **not** in the image (`rar` is not redistributable).
+`--compress` / `--compress=7z` / `--compress=zip` use `p7zip-full`.
+`mediainfo` is also absent; `--nfo` falls back without it.
+
+## Compose
+
+From the repository root:
+
+```bash
+mkdir -p docker/config/pesto docker/incoming docker/nzb docker/archive
+cp docker/config.toml.example docker/config/pesto/config.toml
+# edit credentials in docker/config/pesto/config.toml — never commit it
+
+docker compose -f docker/compose.yaml up -d
+```
+
+| Volume | Container path | Use |
+|---|---|---|
+| `docker/config` | `/config` | `config.toml` at `/config/pesto/config.toml`, history, hooks |
+| `docker/incoming` | `/data/incoming` | `--watch` |
+| `docker/nzb` | `/data/nzb` | `--nzb-dir` (directory, **not** `--out`) |
+| `docker/archive` | `/data/archive` | `--cleanup-to` after a successful upload |
+| tmpfs | `/tmp` | PAR2 / compress scratch (`TMPDIR`) |
+
+The service runs as uid/gid **1000**. If the host user is not 1000, set
+`user: "${UID}:${GID}"` in `compose.yaml` (and chmod the bind mounts).
+
+Optional `mem_limit` is commented in the compose file; pesto's PAR2 planner
+already reads cgroup `memory.max` when a limit is present.
+
+## Signals
+
+`docker compose stop` / `restart` send SIGTERM.
+
+- **First SIGTERM:** `--watch` stops polling and waits for in-progress
+  uploads to unwind (the CLI help text's "finish in-progress upload").
+- **10 seconds later:** pesto aborts in-flight NNTP I/O
+  (`GRACEFUL_SHUTDOWN_DEADLINE` in `crates/pesto/src/cancel.rs`) and
+  persists resume state. It does **not** keep posting a multi-gigabyte
+  release to completion after that deadline.
+- **`stop_grace_period: 30m`:** stops Docker's default 10s SIGKILL from
+  racing that abort/persist path. It is not a promise that the current
+  file will finish uploading.
+
+A second SIGTERM/SIGINT aborts immediately, same as on the host.
+
+## Existing files on startup
+
+`--watch` ignores entries already in the watched directory when the
+process starts (`run_watch` pre-populates `done` from `top_level_entries`).
+A container restart therefore skips files that arrived while it was down.
+`--cleanup-to` keeps *completed* work out of `incoming` but does not close
+that gap.
+
+Drain leftovers with the compose `drain` profile (one-shot `--each`):
+
+```bash
+docker compose -f docker/compose.yaml --profile drain run --rm pesto-drain
+```
+
+Or:
+
+```bash
+docker run --rm \
+  -v "$PWD/docker/config:/config" \
+  -v "$PWD/docker/incoming:/data/incoming" \
+  -v "$PWD/docker/nzb:/data/nzb" \
+  -v "$PWD/docker/archive:/data/archive" \
+  ghcr.io/franzopl/pesto:latest \
+  --each /data/incoming --nzb-dir /data/nzb --cleanup-to /data/archive
+```
+
+There is no `--watch-include-existing` flag yet; that is a follow-up.
+
+## Hooks
+
+The image is Linux. Shell hooks work if the script lives on the config
+volume (`/config/pesto/hooks/`) and is executable. PowerShell hooks do not.
+The runtime has `/bin/sh`.
+
+## Credentials
+
+Username/password stay in the mounted TOML. pesto does not read
+`PESTO_PASSWORD` or other credential environment variables.

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,71 @@
+# pesto --watch daemon (issue #185).
+#
+# From the repository root:
+#   docker compose -f docker/compose.yaml up -d
+#
+# Bind-mount paths are relative to this file (`docker/`). Create them first:
+#   mkdir -p docker/config/pesto docker/incoming docker/nzb docker/archive
+#   cp docker/config.toml.example docker/config/pesto/config.toml
+#
+# `--nzb-dir` is a directory. Do not point `--out` at the nzb folder
+# (`--out` is a file path; that yields EISDIR / Access denied).
+
+name: pesto
+
+x-pesto-common: &pesto-common
+  image: ghcr.io/franzopl/pesto:latest
+  build:
+    context: ..
+    dockerfile: Dockerfile
+  user: "1000:1000"
+  init: true
+  cap_drop:
+    - ALL
+  security_opt:
+    - no-new-privileges:true
+  environment:
+    XDG_CONFIG_HOME: /config
+    TMPDIR: /tmp
+  tmpfs:
+    - /tmp:uid=1000,gid=1000,mode=1777
+  volumes:
+    - ./config:/config
+    - ./incoming:/data/incoming
+    - ./nzb:/data/nzb
+    - ./archive:/data/archive
+  # Optional: expose a cgroup memory.max so pesto's PAR2 planner sees a cap.
+  # mem_limit: 8g
+
+services:
+  pesto:
+    <<: *pesto-common
+    restart: unless-stopped
+    # Docker's default 10s SIGKILL races pesto's own 10s I/O-abort deadline
+    # (GRACEFUL_SHUTDOWN_DEADLINE) and can skip resume-state persistence.
+    # SIGTERM still cancels in-flight NNTP I/O after 10s; this grace only
+    # keeps Docker from killing the process while watch drains tasks.
+    stop_grace_period: 30m
+    command:
+      - --watch
+      - /data/incoming
+      - --nzb-dir
+      - /data/nzb
+      - --cleanup-to
+      - /data/archive
+      - --watch-interval
+      - "30"
+
+  # One-shot drain of leftovers in incoming. `--watch` ignores entries
+  # already present at startup, so after a restart run:
+  #   docker compose -f docker/compose.yaml --profile drain run --rm pesto-drain
+  pesto-drain:
+    <<: *pesto-common
+    profiles: ["drain"]
+    restart: "no"
+    command:
+      - --each
+      - /data/incoming
+      - --nzb-dir
+      - /data/nzb
+      - --cleanup-to
+      - /data/archive

--- a/docker/config.toml.example
+++ b/docker/config.toml.example
@@ -1,0 +1,26 @@
+# Bind-mount this file as `/config/pesto/config.toml`.
+#
+#   mkdir -p docker/config/pesto
+#   cp docker/config.toml.example docker/config/pesto/config.toml
+#
+# Do not bake credentials into the image. Paths below match docker/compose.yaml.
+# Full option list: ../config.example.toml
+
+[server]
+host = "news.example.com"
+# port = 563
+# ssl = true
+# connections = 4
+
+[auth]
+username = "your_username"
+password = "your_password"
+
+[posting]
+groups = ["alt.binaries.test"]
+# par2 = 10
+# obfuscate = "none"
+
+[output]
+# Compose already passes --nzb-dir /data/nzb; this is the config equivalent.
+nzb_dir = "/data/nzb"


### PR DESCRIPTION
Closes #185.

Official Docker packaging for the pesto CLI as a long-lived `--watch` daemon:

- Root `Dockerfile` (source build) and `runtime-prebuilt` target for GHCR
- `docker/compose.yaml` with config / incoming / nzb / archive volumes, `--nzb-dir` (not `--out`), `stop_grace_period: 30m`, non-root uid 1000
- Drain profile for leftovers `--watch` ignores on startup
- `pesto-v*` release workflow publishes `ghcr.io/franzopl/pesto:<semver>` and `:latest` from the linux-gnu artifact
- linux-gnu GitHub Release binary is now built on Ubuntu 22.04 (glibc 2.35) so it loads on Debian 12 / the image

No Rust changes. Image is pesto CLI only (not upapasta, penne, or sugo).