### PR TITLE
fix(cli): strip media extensions from --season/--each PESTO_NAME

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pesto-poster"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "bdinfo-rs-core",

--- a/crates/penne/Cargo.toml
+++ b/crates/penne/Cargo.toml
@@ -20,7 +20,7 @@ name = "penne"
 path = "src/bin/penne.rs"
 
 [dependencies]
-pesto = { package = "pesto-poster", path = "../pesto", version = "0.10.3" }
+pesto = { package = "pesto-poster", path = "../pesto", version = "0.10.4" }
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/pesto/CHANGELOG.md
+++ b/crates/pesto/CHANGELOG.md
@@ -12,6 +12,11 @@ changelogs (`crates/penne/CHANGELOG.md`, `crates/parmesan/CHANGELOG.md`).
 
 ## [Unreleased]
 
+## [0.10.4] — 2026-09-12
+
+### Fixed
+- **`--season`/`--each` kept the media extension in `PESTO_NAME`.** Batch entries used the raw filename (`Show.S01E01.mkv`), while a single-file upload already stripped known extensions. Indexer pre-hooks that exact-match a Newznab search then queried `….mkv` and missed the existing release (stored without the extension). `--season`/`--each`/`--watch` now share the same `release_label` helper as the single-file path.
+
 ### Added
 
 - Docker image and Compose example for `pesto --watch` as a long-lived

--- a/crates/pesto/Cargo.toml
+++ b/crates/pesto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pesto-poster"
 # pesto is versioned, published, and released independently of the rest of
 # the workspace (own CHANGELOG.md, own `pesto-v*` tag) — see RELEASING.md.
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 rust-version.workspace = true
 description = "Fast, lean Usenet poster: yEnc, NNTP and .nzb generation. Also provides the core library used by upapasta."

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -3753,7 +3753,7 @@ async fn run(tuning: pesto::memory::ThreadTuning) -> Result<()> {
     let label = cli
         .files
         .first()
-        .map(release_label)
+        .map(|p| release_label(p))
         .unwrap_or_else(|| format!("{}", std::process::id()));
     let result = run_single_upload(
         &params,

--- a/crates/pesto/src/bin/pesto.rs
+++ b/crates/pesto/src/bin/pesto.rs
@@ -2393,6 +2393,64 @@ impl Drop for CompressTempCleanup {
     }
 }
 
+/// Human-readable entry label for hooks (`PESTO_NAME`), banners, and history.
+///
+/// Strips only known media/archive extensions so `Show.S01E01.mkv` becomes
+/// `Show.S01E01`. Dots inside a scene name (`Show.S01E01.720p.BluRay-Group`)
+/// are kept — `file_stem()` would chop them. `--season`/`--each` used to
+/// pass the raw filename, so indexer pre-hooks searched for `….mkv` and
+/// missed an existing release whose name has no extension.
+fn release_label(path: &Path) -> String {
+    const STRIP_EXTS: &[&str] = &[
+        "mkv", "mp4", "avi", "ts", "m2ts", "mov", "wmv", "flv", "webm", "mpg", "mpeg", "vob",
+        "iso", "nzb", "zip", "rar", "7z", "tar", "gz", "bz2", "cbz", "cbr", "pdf", "epub",
+    ];
+    path.file_name()
+        .map(|s| {
+            let name = s.to_string_lossy();
+            let p = Path::new(s);
+            match p.extension().and_then(|e| e.to_str()) {
+                Some(ext) if STRIP_EXTS.contains(&ext.to_ascii_lowercase().as_str()) => {
+                    p.file_stem().unwrap_or(s).to_string_lossy().into_owned()
+                }
+                _ => name.into_owned(),
+            }
+        })
+        .unwrap_or_else(|| "entry".to_string())
+}
+
+#[cfg(test)]
+mod release_label_tests {
+    use super::release_label;
+    use std::path::Path;
+
+    #[test]
+    fn strips_mkv_from_season_episode_file() {
+        assert_eq!(
+            release_label(Path::new("/tv/Show.S01E01.1080p.mkv")),
+            "Show.S01E01.1080p"
+        );
+    }
+
+    #[test]
+    fn keeps_scene_name_without_media_extension() {
+        assert_eq!(
+            release_label(Path::new("/tv/Show.S01E01.720p.BluRay-Group")),
+            "Show.S01E01.720p.BluRay-Group"
+        );
+    }
+
+    #[test]
+    fn strips_extension_case_insensitively() {
+        assert_eq!(release_label(Path::new("Movie.MKV")), "Movie");
+    }
+
+    #[test]
+    fn keeps_directory_like_names() {
+        assert_eq!(release_label(Path::new("/season/Episode01")), "Episode01");
+    }
+}
+
 async fn run_batch(
     params: Arc<UploadParams>,
     dirs: &[PathBuf],
@@ -2485,10 +2543,7 @@ async fn run_batch(
         let task_cancel = cancel.clone();
         let task_password = season_password.clone();
         let task_broker = broker.clone();
-        let label = entry
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "entry".to_string());
+        let label = release_label(&entry);
 
         info!(
             entry = entry_idx + 1,
@@ -3005,10 +3060,7 @@ async fn run_watch(
                     let params = Arc::clone(&params);
                     let watch_done = watch_done.map(PathBuf::from);
                     let tx = result_tx.clone();
-                    let label = entry
-                        .file_name()
-                        .map(|n| n.to_string_lossy().into_owned())
-                        .unwrap_or_else(|| "entry".to_string());
+                    let label = release_label(&entry);
                     let task_cancel = cancel.clone();
                     let explicit_out = explicit_out.clone();
 
@@ -3696,30 +3748,12 @@ async fn run(tuning: pesto::memory::ThreadTuning) -> Result<()> {
     }
 
     // ── Single upload (normal mode) ───────────────────────────────────────────
-    // Derive a human-readable label from the first input path without any
-    // blocking filesystem calls (no is_dir/stat in the async executor).
-    // file_name() returns the last path component; we strip a known extension
-    // Strip the extension only for known media file types. Release names that
-    // contain dots (e.g. "Show.S01E01.720p.BluRay-Group") must not be trimmed
-    // by file_stem(), which would drop everything after the last dot.
-    const STRIP_EXTS: &[&str] = &[
-        "mkv", "mp4", "avi", "ts", "m2ts", "mov", "wmv", "flv", "webm", "mpg", "mpeg", "vob",
-        "iso", "nzb", "zip", "rar", "7z", "tar", "gz", "bz2", "cbz", "cbr", "pdf", "epub",
-    ];
+    // Same label helper as `--season`/`--each` (no is_dir/stat on the
+    // async executor). See `release_label`.
     let label = cli
         .files
         .first()
-        .and_then(|p| p.file_name())
-        .map(|s| {
-            let name = s.to_string_lossy();
-            let p = std::path::Path::new(s);
-            match p.extension().and_then(|e| e.to_str()) {
-                Some(ext) if STRIP_EXTS.contains(&ext.to_ascii_lowercase().as_str()) => {
-                    p.file_stem().unwrap_or(s).to_string_lossy().into_owned()
-                }
-                _ => name.into_owned(),
-            }
-        })
+        .map(release_label)
         .unwrap_or_else(|| format!("{}", std::process::id()));
     let result = run_single_upload(
         &params,

--- a/crates/pesto/tests/batch_order.rs
+++ b/crates/pesto/tests/batch_order.rs
@@ -41,9 +41,9 @@ fn each_processes_entries_in_natural_order() {
     assert_eq!(
         labels,
         vec![
-            "── Show.S01E01.mkv ──",
-            "── Show.S01E02.mkv ──",
-            "── Show.S01E10.mkv ──",
+            "── Show.S01E01 ──",
+            "── Show.S01E02 ──",
+            "── Show.S01E10 ──",
         ],
         "unexpected order in stdout:\n{}",
         stdout


### PR DESCRIPTION
## Summary

- `--season` / `--each` / `--watch` now strip known media extensions from the entry label (`PESTO_NAME`), matching single-file uploads.
- A Newznab pre-hook that exact-matches the search no longer queries `Show.S01E01.mkv` against a release stored as `Show.S01E01`.

## Motivation

Single-file mode already stripped `.mkv`/`.mp4`/… so scene dots stay (`Show.S01E01.720p`). `run_batch` passed `file_name()` raw, so `--season` of a folder of `.mkv` files made indexer duplicate checks miss.

## Test Plan

- [x] Unit tests on `release_label` (strip mkv, keep scene dots, case-insensitive, directory names)
- [ ] `cargo test -p pesto-poster --bin pesto release_label` (needs rustc 1.96; this environment has 1.95)
- [ ] Manual: `--season` a folder of `.mkv` episodes and confirm pre-hook search has no `.mkv`

## Notes for Reviewers

Does not change NZB stem (already `file_stem()` for files). Only the hook/history label.